### PR TITLE
Add custom panic hook

### DIFF
--- a/rustc_codegen_spirv/src/lib.rs
+++ b/rustc_codegen_spirv/src/lib.rs
@@ -543,6 +543,16 @@ impl Drop for DumpModuleOnPanic<'_, '_, '_> {
 /// This is the entrypoint for a hot plugged rustc_codegen_spirv
 #[no_mangle]
 pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
+    // Override rustc's panic hook with our own to override the ICE error
+    // message, and direct people to `rust-gpu`.
+    std::panic::set_hook(Box::new(|panic_info| {
+        rustc_driver::report_ice(
+            panic_info,
+            "https://github.com/EmbarkStudios/rust-gpu/issues/new",
+        );
+        eprintln!("note: `rust-gpu` version {}\n", env!("CARGO_PKG_VERSION"));
+    }));
+
     Box::new(SpirvCodegenBackend)
 }
 


### PR DESCRIPTION
This PR overrides the default panic hook, with our own that will catch when `SPIR-V` tools are not available and give you a specific error message about that, and in all other cases we use the normal ICE message with the URL redirected to this repo, and we print out `rust-gpu`'s version.

fixes #51

### SPIR-V Error Message
```
error: failed to run custom build command for `example-runner v0.1.0 (/Users/src/rust-gpu/examples/example-runner)`

Caused by:
  process didn't exit successfully: `/Users/src/rust-gpu/target/debug/build/example-runner-062276209715c6a1/build-script-build` (exit code: 1)
  --- stderr
     Compiling spirv-std v0.1.0 (/Users/src/rust-gpu/spirv-std)
     Compiling example-shader v0.1.0 (/Users/src/rust-gpu/examples/example-shader)

  error: Couldn't find `spriv-val` tool in PATH.

  error: Please ensure that you have `spirv-tools` installed on your system and available in your PATH.

  note: `rust-gpu` version 0.1.0

  error: could not compile `example-shader`

  To learn more, run the command again with --verbose.
  Error: BuildFailed
```

### Normal ICE
```
error: failed to run custom build command for `example-runner v0.1.0 (/Users/src/rust-gpu/examples/example-runner)`

Caused by:
  process didn't exit successfully: `/Users/src/rust-gpu/target/debug/build/example-runner-062276209715c6a1/build-script-build` (exit code: 1)
  --- stderr
     Compiling spirv-std v0.1.0 (/Users/src/rust-gpu/spirv-std)
  thread 'rustc' panicked at 'explicit panic', rustc_codegen_spirv/src/lib.rs:563:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

  error: internal compiler error: unexpected panic

  note: the compiler unexpectedly panicked. this is a bug.

  note: we would appreciate a bug report: https://github.com/EmbarkStudios/rust-gpu/issues/new

  note: rustc 1.49.0-nightly (8dae8cdcc 2020-10-12) running on x86_64-apple-darwin

  note: compiler flags: -Z unstable-options -Z codegen-backend=librustc_codegen_spirv.dylib -C opt-level=3 -C embed-bitcode=no --crate-type lib

  note: some of the compiler flags provided by cargo are hidden

  note: `rust-gpu` version 0.1.0
  error: could not compile `spirv-std`

  To learn more, run the command again with --verbose.
  Error: BuildFailed
```