### PR TITLE
Fixed nested if statements

### DIFF
--- a/rustc_codegen_spirv/src/linker/structurizer.rs
+++ b/rustc_codegen_spirv/src/linker/structurizer.rs
@@ -88,7 +88,7 @@ pub fn insert_selection_merge_on_conditional_branch(
             }
         }
     }
-    
+
     // Find convergence point.
     for (bi, ii) in branch_conditional_ops {
         let out = outgoing_edges(&blocks[bi]);


### PR DESCRIPTION
The "loop detection" I used was wrong in the case of nested if statements.
With this fix you can write nested if statements in rust-gpu.