### PR TITLE
Use the --component option in setup scripts

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,4 +1,3 @@
 setlocal
 
-rustup install nightly
-rustup component add rust-src rustc-dev llvm-tools-preview
+rustup toolchain install nightly --component rust-src rustc-dev llvm-tools-preview

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-rustup install nightly
-rustup component add rust-src rustc-dev llvm-tools-preview
+rustup toolchain install nightly --component rust-src rustc-dev llvm-tools-preview


### PR DESCRIPTION
This should mean that if one of the required components is broken on a given nightly, rustup will try going backwards until it finds one which works.

This also makes it clear that the components are being installed for the nightly toolchain, such as if someone blindly copies the setup script, it will work even if they don't have nightly as their current toolchain (such as if they are not in the

I have tested this works both when no nightly toolchain is installed and when a nightly toolchain is already installed (the components appear in `rustup component list --toolchain nightly`. Additionally, rustc, cargo and rustfmt etc. installed as normal.