### PR TITLE
Enable clippy on spirv-std

### DIFF
--- a/rustc_codegen_spirv/src/lib.rs
+++ b/rustc_codegen_spirv/src/lib.rs
@@ -1,12 +1,16 @@
 #![feature(rustc_private)]
 #![feature(once_cell)]
 #![deny(clippy::unimplemented, clippy::ok_expect, clippy::mem_forget)]
+// Our standard Clippy lints that we use in Embark projects, we opt out of a few that are not appropriate for the specific crate (yet)
 #![warn(
     clippy::all,
     clippy::doc_markdown,
     clippy::dbg_macro,
+    //clippy::todo,
     clippy::empty_enum,
+    //clippy::enum_glob_use,
     clippy::pub_enum_variant_names,
+    clippy::mem_forget,
     clippy::use_self,
     clippy::filter_map_next,
     clippy::needless_continue,
@@ -15,6 +19,7 @@
     clippy::if_let_mutex,
     clippy::mismatched_target_os,
     clippy::await_holding_lock,
+    //clippy::match_on_vec_items,
     clippy::imprecise_flops,
     clippy::suboptimal_flops,
     clippy::lossy_float_literal,

--- a/spirv-std/src/lib.rs
+++ b/spirv-std/src/lib.rs
@@ -1,6 +1,41 @@
 #![no_std]
 #![feature(register_attr, repr_simd, core_intrinsics)]
 #![register_attr(spirv)]
+// Our standard Clippy lints that we use in Embark projects, we opt out of a few that are not appropriate for the specific crate (yet)
+#![warn(
+    clippy::all,
+    clippy::doc_markdown,
+    clippy::dbg_macro,
+    clippy::todo,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::pub_enum_variant_names,
+    clippy::mem_forget,
+    //clippy::use_self,
+    clippy::filter_map_next,
+    clippy::needless_continue,
+    clippy::needless_borrow,
+    clippy::match_wildcard_for_single_variants,
+    clippy::if_let_mutex,
+    clippy::mismatched_target_os,
+    clippy::await_holding_lock,
+    clippy::match_on_vec_items,
+    clippy::imprecise_flops,
+    //clippy::suboptimal_flops,
+    clippy::lossy_float_literal,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::fn_params_excessive_bools,
+    clippy::exit,
+    clippy::inefficient_to_string,
+    clippy::linkedlist,
+    clippy::macro_use_imports,
+    clippy::option_option,
+    clippy::verbose_file_reads,
+    clippy::unnested_or_patterns,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style
+)]
 
 pub mod math;
 pub use crate::math::MathExt;
@@ -68,11 +103,11 @@ pointer_addrspace!("physical_storage_buffer", PhysicalStorageBuffer, true);
 pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
 /// libcore requires a few external symbols to be defined:
-/// https://github.com/rust-lang/rust/blob/c2bc344eb23d8c1d18e803b3f1e631cf99926fbb/library/core/src/lib.rs#L23-L27
-/// TODO: This is copied from compiler_builtins/mem.rs. Can we use that one instead? The note in the above link says
-/// "[the symbols] can also be provided by the compiler-builtins crate". The memcpy in compiler_builtins is behind a
+/// <https://github.com/rust-lang/rust/blob/c2bc344eb23d8c1d18e803b3f1e631cf99926fbb/library/core/src/lib.rs#L23-L27>
+/// TODO: This is copied from `compiler_builtins/mem.rs`. Can we use that one instead? The note in the above link says
+/// "[the symbols] can also be provided by the compiler-builtins crate". The memcpy in `compiler_builtins` is behind a
 /// "mem" feature flag - can we enable that somehow?
-/// https://github.com/rust-lang/compiler-builtins/blob/eff506cd49b637f1ab5931625a33cef7e91fbbf6/src/mem.rs#L12-L13
+/// <https://github.com/rust-lang/compiler-builtins/blob/eff506cd49b637f1ab5931625a33cef7e91fbbf6/src/mem.rs#L12-L13>
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {

--- a/spirv-std/src/math/mod.rs
+++ b/spirv-std/src/math/mod.rs
@@ -1,4 +1,4 @@
-//! This math library is heavily borrowed from https://github.com/bitshifter/glam-rs
+//! This math library is heavily borrowed from [glam](https://github.com/bitshifter/glam-rs)
 //! In the future we hope to be able to use it directly!
 
 pub mod mat2;


### PR DESCRIPTION
And some smaller rustdoc markdown fixes for clippy.

Fun to run clippy on GPU code :)