### PR TITLE
Re-enable CI on pushes to all branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,4 @@
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: [push, pull_request]
 
 name: Continuous integration
 


### PR DESCRIPTION
I think @XAMPPRocky disabled this recently, but generally we want CI to be enabled on all branches (we have in all of our other repos) so one can iterate on branches without having PRs for them and get CI coverage.

Does cause some redundant building, but that is fine.