### PR TITLE
Force use latest tar crate to avoid insecure warning on deps.rs

### DIFF
--- a/rustc_codegen_spirv/Cargo.toml
+++ b/rustc_codegen_spirv/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["dylib"]
 [dependencies]
 bimap = "0.5"
 rspirv = "0.7.0"
-tar = "0.4"
+tar = "0.4.30"
 thiserror = "1.0.20"
 topological-sort = "0.1"
 


### PR DESCRIPTION
Current https://deps.rs/repo/github/EmbarkStudios/rust-gpu is showing that this repo has an insecure dependencies with the tar crate.

I believe this is because a previous tar v0.4.16 and earlier had a security advisory on it ([link](https://rustsec.org/advisories/RUSTSEC-2018-0002.html)) and that the deps.rs  service does not yet support Cargo.lock where we had specified that we use a latest version. Tracked in https://github.com/deps-rs/deps.rs/issues/26

So simply force require latest tar crate version (that we were already using) in Cargo.toml here with the hope that https://deps.rs won't flag the repo as having insecure dependencies