### PR TITLE
Add badge for deps.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🐉 Rust GPU
 
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.dev)
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 


### PR DESCRIPTION
Rendered: [![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu) ([new README](https://github.com/DJMcNab/rust-gpu/blob/6168652acad0a39a47d58dc2896913f79432dc2d/README.md))

Note that github caches this badge when it is first requested, so the version above should be seen by everyone.