### PR TITLE
Implement copysign intrinsic

### DIFF
--- a/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -240,7 +240,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
                 if self.kernel_mode {
                     self.cl_op(CLOp::copysign, [args[0].immediate(), args[1].immediate()])
                 } else {
-                    self.fatal("TODO: Shader copysign not supported yet")
+                    self.gl_op(GLOp::FSign, [args[0].immediate(), args[1].immediate()])
                 }
             }
             sym::floorf32 | sym::floorf64 => {


### PR DESCRIPTION
Took a quick look in https://www.khronos.org/registry/spir-v/specs/unified1/GLSL.std.450.pdf and `FSign` from looks like the equivalent GLCompute instruction to the `copysign` CLCompute instruction.
