### PR TITLE
Enable Clippy use_self lint in spirv-std

### DIFF
--- a/spirv-std/src/lib.rs
+++ b/spirv-std/src/lib.rs
@@ -11,7 +11,7 @@
     clippy::enum_glob_use,
     clippy::pub_enum_variant_names,
     clippy::mem_forget,
-    //clippy::use_self,
+    clippy::use_self,
     clippy::filter_map_next,
     clippy::needless_continue,
     clippy::needless_borrow,

--- a/spirv-std/src/math/mat2.rs
+++ b/spirv-std/src/math/mat2.rs
@@ -42,7 +42,7 @@ impl Mat2 {
     /// returned matrix.
     #[inline]
     pub fn from_cols_array(m: &[f32; 4]) -> Self {
-        Mat2(Vec4::new(m[0], m[1], m[2], m[3]))
+        Self(Vec4::new(m[0], m[1], m[2], m[3]))
     }
 
     /// Creates a `[f32; 4]` storing data in column major order.
@@ -57,7 +57,7 @@ impl Mat2 {
     /// the returned matrix.
     #[inline]
     pub fn from_cols_array_2d(m: &[[f32; 2]; 2]) -> Self {
-        Mat2(Vec4::new(m[0][0], m[0][1], m[1][0], m[1][1]))
+        Self(Vec4::new(m[0][0], m[0][1], m[1][0], m[1][1]))
     }
 
     /// Creates a `[[f32; 2]; 2]` storing data in column major order.
@@ -167,7 +167,7 @@ impl Mat2 {
     pub fn mul_mat2(&self, other: &Self) -> Self {
         // TODO: SSE2
         let (x0, y0, x1, y1) = other.0.into();
-        Mat2::from_cols(
+        Self::from_cols(
             self.mul_vec2(Vec2::new(x0, y0)),
             self.mul_vec2(Vec2::new(x1, y1)),
         )
@@ -176,20 +176,20 @@ impl Mat2 {
     /// Adds two 2x2 matrices.
     #[inline]
     pub fn add_mat2(&self, other: &Self) -> Self {
-        Mat2(self.0 + other.0)
+        Self(self.0 + other.0)
     }
 
     /// Subtracts two 2x2 matrices.
     #[inline]
     pub fn sub_mat2(&self, other: &Self) -> Self {
-        Mat2(self.0 - other.0)
+        Self(self.0 - other.0)
     }
 
     /// Multiplies a 2x2 matrix by a scalar.
     #[inline]
     pub fn mul_scalar(&self, other: f32) -> Self {
         let s = Vec4::splat(other);
-        Mat2(self.0 * s)
+        Self(self.0 * s)
     }
 }
 

--- a/spirv-std/src/math/mat3.rs
+++ b/spirv-std/src/math/mat3.rs
@@ -62,7 +62,7 @@ impl Mat3 {
     /// returned matrix.
     #[inline]
     pub fn from_cols_array(m: &[f32; 9]) -> Self {
-        Mat3 {
+        Self {
             x_axis: Vec3::new(m[0], m[1], m[2]),
             y_axis: Vec3::new(m[3], m[4], m[5]),
             z_axis: Vec3::new(m[6], m[7], m[8]),
@@ -84,7 +84,7 @@ impl Mat3 {
     /// returned matrix.
     #[inline]
     pub fn from_cols_array_2d(m: &[[f32; 3]; 3]) -> Self {
-        Mat3 {
+        Self {
             x_axis: m[0].into(),
             y_axis: m[1].into(),
             z_axis: m[2].into(),
@@ -217,7 +217,7 @@ impl Mat3 {
         let det = self.z_axis.dot_as_vec3(tmp2);
         let inv_det = det.recip();
         // TODO: Work out if it's possible to get rid of the transpose
-        Mat3::from_cols(tmp0 * inv_det, tmp1 * inv_det, tmp2 * inv_det).transpose()
+        Self::from_cols(tmp0 * inv_det, tmp1 * inv_det, tmp2 * inv_det).transpose()
     }
 
     /// Multiplies two 3x3 matrices.

--- a/spirv-std/src/math/mat4.rs
+++ b/spirv-std/src/math/mat4.rs
@@ -34,7 +34,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix with all elements set to `0.0`.
     #[inline]
     pub const fn zero() -> Self {
-        Mat4 {
+        Self {
             x_axis: Vec4::zero(),
             y_axis: Vec4::zero(),
             z_axis: Vec4::zero(),
@@ -45,7 +45,7 @@ impl Mat4 {
     /// Creates a 4x4 identity matrix.
     #[inline]
     pub const fn identity() -> Self {
-        Mat4 {
+        Self {
             x_axis: Vec4::new(1.0, 0.0, 0.0, 0.0),
             y_axis: Vec4::new(0.0, 1.0, 0.0, 0.0),
             z_axis: Vec4::new(0.0, 0.0, 1.0, 0.0),
@@ -69,7 +69,7 @@ impl Mat4 {
     /// returned matrix.
     #[inline]
     pub fn from_cols_array(m: &[f32; 16]) -> Self {
-        Mat4 {
+        Self {
             x_axis: Vec4::new(m[0], m[1], m[2], m[3]),
             y_axis: Vec4::new(m[4], m[5], m[6], m[7]),
             z_axis: Vec4::new(m[8], m[9], m[10], m[11]),
@@ -89,7 +89,7 @@ impl Mat4 {
     /// the returned matrix.
     #[inline]
     pub fn from_cols_array_2d(m: &[[f32; 4]; 4]) -> Self {
-        Mat4 {
+        Self {
             x_axis: m[0].into(),
             y_axis: m[1].into(),
             z_axis: m[2].into(),

--- a/spirv-std/src/math/mod.rs
+++ b/spirv-std/src/math/mod.rs
@@ -27,44 +27,45 @@ pub trait MathExt {
     fn saturate(self) -> Self;
 }
 
+#[allow(clippy::use_self)]
 impl MathExt for f32 {
-    fn pow(self, factor: f32) -> f32 {
+    fn pow(self, factor: Self) -> Self {
         unsafe { core::intrinsics::powf32(self, factor) }
     }
 
-    fn sqrt(self) -> f32 {
+    fn sqrt(self) -> Self {
         unsafe { core::intrinsics::sqrtf32(self) }
     }
 
-    fn log2(self) -> f32 {
+    fn log2(self) -> Self {
         unsafe { core::intrinsics::log2f32(self) }
     }
 
-    fn abs(self) -> f32 {
+    fn abs(self) -> Self {
         unsafe { core::intrinsics::fabsf32(self) }
     }
 
-    fn cos(self) -> f32 {
+    fn cos(self) -> Self {
         unsafe { core::intrinsics::cosf32(self) }
     }
 
-    fn round(self) -> f32 {
+    fn round(self) -> Self {
         unsafe { core::intrinsics::roundf32(self) }
     }
 
-    fn floor(self) -> f32 {
+    fn floor(self) -> Self {
         unsafe { core::intrinsics::floorf32(self) }
     }
 
-    fn ceil(self) -> f32 {
+    fn ceil(self) -> Self {
         unsafe { core::intrinsics::ceilf32(self) }
     }
 
-    fn exp(self) -> f32 {
+    fn exp(self) -> Self {
         unsafe { core::intrinsics::expf32(self) }
     }
 
-    fn saturate(self) -> f32 {
+    fn saturate(self) -> Self {
         self.max(0.0).min(1.0)
     }
 }

--- a/spirv-std/src/math/vec2.rs
+++ b/spirv-std/src/math/vec2.rs
@@ -38,38 +38,38 @@ impl Vec2 {
 
     /// Creates a new `Vec2`.
     #[inline]
-    pub fn new(x: f32, y: f32) -> Vec2 {
-        Vec2(x, y)
+    pub fn new(x: f32, y: f32) -> Self {
+        Self(x, y)
     }
 
     /// Creates a `Vec2` with all elements set to `0.0`.
     #[inline]
-    pub fn zero() -> Vec2 {
+    pub fn zero() -> Self {
         Self::splat(0.0)
     }
 
     /// Creates a `Vec2` with all elements set to `1.0`.
     #[inline]
-    pub fn one() -> Vec2 {
+    pub fn one() -> Self {
         Self::splat(1.0)
     }
 
     /// Creates a `Vec2` with values `[x: 1.0, y: 0.0]`.
     #[inline]
-    pub fn unit_x() -> Vec2 {
+    pub fn unit_x() -> Self {
         Self::new(1.0, 0.0)
     }
 
     /// Creates a `Vec2` with values `[x: 0.0, y: 1.0]`.
     #[inline]
-    pub fn unit_y() -> Vec2 {
+    pub fn unit_y() -> Self {
         Self::new(0.0, 1.0)
     }
 
     /// Creates a `Vec2` with all elements set to `v`.
     #[inline]
-    pub fn splat(v: f32) -> Vec2 {
-        Vec2(v, v)
+    pub fn splat(v: f32) -> Self {
+        Self(v, v)
     }
 
     /// Creates a `Vec3` from `self` and the given `z` value.
@@ -116,7 +116,7 @@ impl Vec2 {
 
     /// Computes the dot product of `self` and `other`.
     #[inline]
-    pub fn dot(self, other: Vec2) -> f32 {
+    pub fn dot(self, other: Self) -> f32 {
         (self.0 * other.0) + (self.1 * other.1)
     }
 
@@ -153,7 +153,7 @@ impl Vec2 {
     ///
     /// For valid results, `self` must _not_ be of length zero.
     #[inline]
-    pub fn normalize(self) -> Vec2 {
+    pub fn normalize(self) -> Self {
         self * self.length_recip()
     }
 
@@ -163,8 +163,8 @@ impl Vec2 {
     /// `[x: min(x1, x2), y: min(y1, y2)]`,
     /// taking the minimum of each element individually.
     #[inline]
-    pub fn min(self, other: Vec2) -> Vec2 {
-        Vec2(self.0.min(other.0), self.1.min(other.1))
+    pub fn min(self, other: Self) -> Self {
+        Self(self.0.min(other.0), self.1.min(other.1))
     }
 
     /// Returns the vertical maximum of `self` and `other`.
@@ -173,8 +173,8 @@ impl Vec2 {
     /// `[x: max(x1, x2), y: max(y1, y2)]`,
     /// taking the maximum of each element individually.
     #[inline]
-    pub fn max(self, other: Vec2) -> Vec2 {
-        Vec2(self.0.max(other.0), self.1.max(other.1))
+    pub fn max(self, other: Self) -> Self {
+        Self(self.0.max(other.0), self.1.max(other.1))
     }
 
     /// Returns the horizontal minimum of `self`'s elements.
@@ -255,7 +255,7 @@ impl Vec2 {
 
     /// The perpendicular dot product of the vector and `other`.
     #[inline]
-    pub fn perp_dot(self, other: Vec2) -> f32 {
+    pub fn perp_dot(self, other: Self) -> f32 {
         (self.0 * other.1) - (self.1 * other.0)
     }
 }
@@ -263,14 +263,14 @@ impl Vec2 {
 impl Div<Vec2> for Vec2 {
     type Output = Self;
     #[inline]
-    fn div(self, other: Vec2) -> Self {
+    fn div(self, other: Self) -> Self {
         Self(self.0 / other.0, self.1 / other.1)
     }
 }
 
 impl DivAssign<Vec2> for Vec2 {
     #[inline]
-    fn div_assign(&mut self, other: Vec2) {
+    fn div_assign(&mut self, other: Self) {
         self.0 /= other.0;
         self.1 /= other.1;
     }
@@ -303,14 +303,14 @@ impl Div<Vec2> for f32 {
 impl Mul<Vec2> for Vec2 {
     type Output = Self;
     #[inline]
-    fn mul(self, other: Vec2) -> Self {
+    fn mul(self, other: Self) -> Self {
         Self(self.0 * other.0, self.1 * other.1)
     }
 }
 
 impl MulAssign<Vec2> for Vec2 {
     #[inline]
-    fn mul_assign(&mut self, other: Vec2) {
+    fn mul_assign(&mut self, other: Self) {
         self.0 *= other.0;
         self.1 *= other.1;
     }
@@ -359,14 +359,14 @@ impl AddAssign for Vec2 {
 impl Sub for Vec2 {
     type Output = Self;
     #[inline]
-    fn sub(self, other: Vec2) -> Self {
+    fn sub(self, other: Self) -> Self {
         Self(self.0 - other.0, self.1 - other.1)
     }
 }
 
 impl SubAssign for Vec2 {
     #[inline]
-    fn sub_assign(&mut self, other: Vec2) {
+    fn sub_assign(&mut self, other: Self) {
         self.0 -= other.0;
         self.1 -= other.1;
     }

--- a/spirv-std/src/math/vec3.rs
+++ b/spirv-std/src/math/vec3.rs
@@ -155,7 +155,7 @@ impl Vec3 {
     #[allow(dead_code)]
     pub(crate) fn dot_as_vec3(self, other: Self) -> Self {
         let dot = self.dot(other);
-        Vec3::new(dot, dot, dot)
+        Self::new(dot, dot, dot)
     }
 
     /// Computes the cross product of `self` and `other`.

--- a/spirv-std/src/math/vec4.rs
+++ b/spirv-std/src/math/vec4.rs
@@ -27,37 +27,37 @@ impl Vec4 {
     /// Creates a `Vec4` with all elements set to `0.0`.
     #[inline]
     pub const fn zero() -> Self {
-        Vec4::splat(0.0)
+        Self::splat(0.0)
     }
 
     /// Creates a `Vec4` with all elements set to `1.0`.
     #[inline]
     pub const fn one() -> Self {
-        Vec4::splat(1.0)
+        Self::splat(1.0)
     }
 
     /// Creates a `Vec4` with values `[x: 1.0, y: 0.0, z: 0.0, w: 0.0]`.
     #[inline]
     pub const fn unit_x() -> Self {
-        Vec4::new(1.0, 0.0, 0.0, 0.0)
+        Self::new(1.0, 0.0, 0.0, 0.0)
     }
 
     /// Creates a `Vec4` with values `[x: 0.0, y: 1.0, z: 0.0, w: 0.0]`.
     #[inline]
     pub const fn unit_y() -> Self {
-        Vec4::new(0.0, 1.0, 0.0, 0.0)
+        Self::new(0.0, 1.0, 0.0, 0.0)
     }
 
     /// Creates a `Vec4` with values `[x: 0.0, y: 0.0, z: 1.0, w: 0.0]`.
     #[inline]
     pub const fn unit_z() -> Self {
-        Vec4::new(0.0, 0.0, 1.0, 0.0)
+        Self::new(0.0, 0.0, 1.0, 0.0)
     }
 
     /// Creates a `Vec4` with values `[x: 0.0, y: 0.0, z: 0.0, w: 1.0]`.
     #[inline]
     pub const fn unit_w() -> Self {
-        Vec4::new(0.0, 0.0, 0.0, 1.0)
+        Self::new(0.0, 0.0, 0.0, 1.0)
     }
 
     /// Creates a `Vec4` with all elements set to `v`.


### PR DESCRIPTION
As mentioned in #34, the use_self lint is currently disabled in spirv-std.

There is one exception to this. I had to introduce an exception in mod.rs because there is bug that confuses core::intrinsics with f32. I have opened a bug report for it over on the Clippy repo [here](https://github.com/rust-lang/rust-clippy/issues/6221). It seems there a few related errors where this also happens.

```rust
#[allow(clippy::use_self)]
impl MathExt for f32 {
    fn pow(self, factor: f32) -> f32 {
    ...
}
```

I'm not sure whether enabling the use_self lint is a good idea or not. The feature doesn't seem to be bug-free.
