### PR TITLE
Move rspirv override to be directly in the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ members = [
     "spirv-builder",
     "spirv-std",
 ]
-
-[patch.crates-io]
-rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "f11f8797bd4df2d1d22cf10767b39a5119c57551" }

--- a/rustc_codegen_spirv/Cargo.toml
+++ b/rustc_codegen_spirv/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["dylib"]
 
 [dependencies]
 bimap = "0.5"
-rspirv = "0.7.0"
+rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "f11f8797bd4df2d1d22cf10767b39a5119c57551" }
 tar = "0.4.30"
 thiserror = "1.0.20"
 topological-sort = "0.1"


### PR DESCRIPTION
This fixes git references to rust-gpu, which don't pick up the workspace override and cause obscure build failures.

See, for example, https://discord.com/channels/750717012564770887/750717499737243679/770415420829597726