### PR TITLE
Improve error message for pointer casts

### DIFF
--- a/rustc_codegen_spirv/src/builder/mod.rs
+++ b/rustc_codegen_spirv/src/builder/mod.rs
@@ -17,6 +17,7 @@ use rustc_codegen_ssa::traits::{
     CoverageInfoBuilderMethods, DebugInfoBuilderMethods, HasCodegen, InlineAsmOperandRef,
     StaticBuilderMethods,
 };
+use rustc_errors::DiagnosticBuilder;
 use rustc_hir::LlvmInlineAsmInner;
 use rustc_middle::mir::coverage::{
     CodeRegion, CounterValueReference, ExpressionOperandId, InjectedExpressionIndex, Op,
@@ -63,7 +64,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    /*
     pub fn struct_err(&self, msg: &str) -> DiagnosticBuilder<'_> {
         if let Some(current_span) = self.current_span {
             self.tcx.sess.struct_span_err(current_span, msg)
@@ -71,7 +71,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.tcx.sess.struct_err(msg)
         }
     }
-    */
 
     pub fn err(&self, msg: &str) {
         if let Some(current_span) = self.current_span {

--- a/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -136,7 +136,7 @@ impl<'tcx> CodegenCx<'tcx> {
         self.zombie_values.borrow_mut().insert(word, reason);
     }
 
-    fn is_system_crate(&self) -> bool {
+    pub fn is_system_crate(&self) -> bool {
         self.tcx
             .sess
             .contains_name(self.tcx.hir().krate_attrs(), sym::compiler_builtins)


### PR DESCRIPTION
when running on <https://github.com/EmbarkStudios/rust-gpu/pull/149>:

```
  error: Cannot cast between pointer types
     --> /home/khyperia/.cargo/git/checkouts/glam-rs-c6c9bb5297445777/0c13d3a/src/f32/vec3a.rs:867:20
      |
  867 |         unsafe { &*(self as *const Vec3A as *const [f32; 3]) }
      |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: from: *{Function} struct f32::vec3a::Vec3A { 0: struct f32::vec3::Vec3 { 0: f32, 1: f32, 2: f32 } }
      = note: to: *{Function} [f32; 3]
```