### PR TITLE
Use our new badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,19 +91,17 @@ There are a few different components to this repo:
 - [spirv-std](spirv-std) for GPU intrinsics, types, and other library items used by GPU crates.
 - [spirv-builder](spirv-builder) for a convenient way of building a GPU crate in a CPU build.rs file.
 
-## Getting started
-
-We welcome community contributions to this project. If you would like to get started, be sure to checkout the [`rust-gpu` dev guide][gpu-guide] and our [Contributor Guide](CONTRIBUTING.md) for more information on how to get started.
-
-[gpu-guide]: https://embarkstudios.github.io/rust-gpu/book/
-
 ## Contributing
 
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](../CODE_OF_CONDUCT.md)
 
 We welcome community contributions to this project.
 
-Please read our [Contributor Guide](CONTRIBUTING.md) for more information on how to get started.
+If you would like to get started, be sure to checkout the [`rust-gpu` dev
+guide][gpu-guide] and our [Contributor Guide](CONTRIBUTING.md) for more
+information on how to get started.
+
+[gpu-guide]: https://embarkstudios.github.io/rust-gpu/
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
-[![Crates.io](https://img.shields.io/crates/v/rust-gpu.svg)](https://crates.io/crates/rust-gpu)
-[![Docs](https://docs.rs/rust-gpu/badge.svg)](https://docs.rs/rust-gpu)
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu)
 [![Build status](https://github.com/EmbarkStudios/rust-gpu/workflows/Continuous%20integration/badge.svg?branch=main)](https://github.com/EmbarkStudios/rust-gpu/actions)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # 🐉 Rust GPU
 
-[![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
-[![API Documentation](https://img.shields.io/badge/docs-main-blue)](https://embarkstudios.github.io/rust-gpu/api/rustc_codegen_spirv)
-[![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu)
-[![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.dev)
+[![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
+[![Crates.io](https://img.shields.io/crates/v/rust-gpu.svg)](https://crates.io/crates/rust-gpu)
+[![Docs](https://docs.rs/rust-gpu/badge.svg)](https://docs.rs/rust-gpu)
+[![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu)
+[![Build status](https://github.com/EmbarkStudios/rust-gpu/workflows/Continuous%20integration/badge.svg?branch=main)](https://github.com/EmbarkStudios/rust-gpu/actions)
 
 This is a very early stage project to make Rust a first-class language and ecosystem for building GPU code 🚀🚧
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ We welcome community contributions to this project. If you would like to get sta
 
 [gpu-guide]: https://embarkstudios.github.io/rust-gpu/book/
 
+## Contributing
+
+[![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](../CODE_OF_CONDUCT.md)
+
+We welcome community contributions to this project.
+
+Please read our [Contributor Guide](CONTRIBUTING.md) for more information on how to get started.
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐉 Rust GPU
 
-[![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
+[![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://embark.dev)
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu)
 [![Build status](https://github.com/EmbarkStudios/rust-gpu/workflows/Continuous%20integration/badge.svg?branch=main)](https://github.com/EmbarkStudios/rust-gpu/actions)
@@ -91,13 +91,11 @@ There are a few different components to this repo:
 
 ## Contributing
 
-[![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](../CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 We welcome community contributions to this project.
 
-If you would like to get started, be sure to checkout the [`rust-gpu` dev
-guide][gpu-guide] and our [Contributor Guide](CONTRIBUTING.md) for more
-information on how to get started.
+If you would like to get started, be sure to checkout the [`rust-gpu` dev guide][gpu-guide] and our [Contributor Guide](CONTRIBUTING.md) for more information on how to get started.
 
 [gpu-guide]: https://embarkstudios.github.io/rust-gpu/
 


### PR DESCRIPTION
The CI badge is a little large here. We could shorten the name of the GitHub Actions workflow to make the badge smaller.

Part of https://github.com/EmbarkStudios/opensource-template/issues/20