### PR TITLE
Fix compling the wgpu-example-runner on wasm32-unknown-unknown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2877,8 +2897,12 @@ dependencies = [
 name = "wgpu-example-runner"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
+ "console_log",
  "futures",
  "spirv-builder",
+ "wasm-bindgen-futures",
+ "web-sys",
  "wgpu",
  "wgpu-subscriber",
  "winit 0.22.2",

--- a/examples/wgpu-example-runner/Cargo.toml
+++ b/examples/wgpu-example-runner/Cargo.toml
@@ -7,9 +7,17 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 wgpu = "0.6.0"
-wgpu-subscriber = "0.1.0"
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 winit = { version = "0.22.1", features = ["web-sys"] }
 
 [build-dependencies]
 spirv-builder = { path = "../../spirv-builder" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+wgpu-subscriber = "0.1.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = "=0.3.39"
+console_error_panic_hook = "0.1.6"
+console_log = "0.2.0"
+wasm-bindgen-futures = "0.4.18"


### PR DESCRIPTION
#92 was missing some dependencies needed for wasm compilation, so I've added them here. You can compile it with `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --bin wgpu-example-runner --target wasm32-unknown-unknown`. It won't actually render on firefox nightly unless you downgrade to the [`gecko`](https://github.com/gfx-rs/wgpu-rs/tree/gecko) branch, which is lagging behind significantly. Haven't tested on chrome canary yet.