### PR TITLE
Download spirv-tools directly on ubuntu CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
-      - run: brew install spirv-tools
+      - run: |
+          mkdir "${HOME}/spirv-tools"
+          curl -fL https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/linux-clang-release/continuous/1305/20201026-063148/install.tgz | tar -xz -C "${HOME}/spirv-tools"
+          echo "${HOME}/spirv-tools/install/bin" >> $GITHUB_PATH
       - run: rustup component add rustfmt clippy rust-src rustc-dev llvm-tools-preview
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,15 @@ jobs:
       spirv_tools_version: "20200928"
     steps:
       - uses: actions/checkout@v2
+      # Ubuntu does have `brew install spirv-tools`, but it installs from
+      # source and so takes >8 minutes.
       - if: ${{ runner.os == 'Linux' }}
-        run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
-      - if: ${{ runner.os != 'Windows' }}
+        run: |
+          sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
+          mkdir "${HOME}/spirv-tools"
+          curl -fL https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/linux-clang-release/continuous/1305/20201026-063148/install.tgz | tar -xz -C "${HOME}/spirv-tools"
+          echo "${HOME}/spirv-tools/install/bin" >> $GITHUB_PATH
+      - if: ${{ runner.os == 'macOS' }}
         run: brew install spirv-tools
       # Currently SPIR-V tools aren't available in any package manager
       # on Windows that put the tools in the path.


### PR DESCRIPTION
I just pulled the latest download link, since I don't actually know how to get the proper download link for specific versions. Not sure if that's okay or not. 