### PR TITLE
repository 'https://github.com/EmbarkStudios.com/rust-gpu/' not found

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -8,7 +8,7 @@ how to use and develop on Rust-GPU.
 1. Clone the repository.
 
     ```shell
-    git clone --recurse-submodules https://github.com/EmbarkStudios.com/rust-gpu
+    git clone --recurse-submodules https://github.com/EmbarkStudios/rust-gpu
     ```
 
 1. Install the prerequisites using the provided setup script. From the root of the project, run:


### PR DESCRIPTION
```
git clone --recurse-submodules https://github.com/EmbarkStudios.com/rust-gpu
Cloning into 'rust-gpu'...
remote: Repository not found.
fatal: repository 'https://github.com/EmbarkStudios.com/rust-gpu/' not found
```

Removing the `.com` from EmbarkStudios solves it.