### PR TITLE
Add generated to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 docs/* linguist-documentation
 spirv-tools-sys/spirv-headers/* linguist-vendored
 spirv-tools-sys/spirv-tools/* linguist-vendored
+spirv-tools-sys/generated/* linguist-generated


### PR DESCRIPTION
This should remove the C++ & PHP stats in the language bar.