### PR TITLE
Make all example windows 720p by default

### DIFF
--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -564,7 +564,7 @@ fn main() {
     let options = Options::from_args();
 
     unsafe {
-        let (base, events_loop) = ExampleBase::new(1920, 1080, &options);
+        let (base, events_loop) = ExampleBase::new(1280, 720, &options);
         let renderpass_attachments = [vk::AttachmentDescription {
             format: base.surface_format.format,
             samples: vk::SampleCountFlags::TYPE_1,


### PR DESCRIPTION
Resolves #178.

Regarding using a scaled resolution for 4K monitors: as far as I can tell, using `winit`'s `LogicalSize` respects monitor scaling, so it should be fine even for larger resolutions.