### PR TITLE
Add git submodule setup to setup scripts

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,3 +1,6 @@
 setlocal
 
 rustup toolchain install nightly-2020-10-25 --component rust-src rustc-dev llvm-tools-preview
+
+git submodule init
+git submodule update

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
 rustup toolchain install nightly-2020-10-25 --component rust-src rustc-dev llvm-tools-preview
+
+git submodule init
+git submodule update


### PR DESCRIPTION
Necessary for spirv-tools-sys crate to work (unless cloned with `--recurse-submodules`)