### PR TITLE
Fix DebugInfoMethods and BackendTypes to match latest source

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -245,19 +245,16 @@ impl<'a, 'tcx> DebugInfoBuilderMethods for Builder<'a, 'tcx> {
     fn dbg_var_addr(
         &mut self,
         _dbg_var: Self::DIVariable,
-        _scope_metadata: Self::DIScope,
+        _scope_metadata: Self::DILocation,
         _variable_alloca: Self::Value,
         _direct_offset: Size,
         // NB: each offset implies a deref (i.e. they're steps in a pointer chain).
         _indirect_offsets: &[Size],
-        _span: Span,
     ) {
         todo!()
     }
 
-    fn set_source_location(&mut self, _scope: Self::DIScope, _span: Span) {
-        todo!()
-    }
+    fn set_dbg_loc(&mut self, _: Self::DILocation) { todo!() }
 
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self) {
         todo!()
@@ -375,6 +372,7 @@ impl<'a, 'tcx> BackendTypes for Builder<'a, 'tcx> {
 
     type DIScope = <CodegenCx<'tcx> as BackendTypes>::DIScope;
     type DIVariable = <CodegenCx<'tcx> as BackendTypes>::DIVariable;
+    type DILocation = <CodegenCx<'tcx> as BackendTypes>::DILocation;
 }
 
 impl<'a, 'tcx> HasCodegen<'tcx> for Builder<'a, 'tcx> {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -20,7 +20,7 @@ use rustc_hir::GlobalAsm;
 use rustc_middle::mir::mono::CodegenUnit;
 use rustc_middle::mir::Body;
 use rustc_middle::ty::layout::{HasParamEnv, HasTyCtxt};
-use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt};
+use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyS, TyCtxt};
 use rustc_session::Session;
 use rustc_span::def_id::{CrateNum, LOCAL_CRATE};
 use rustc_span::source_map::Span;
@@ -240,6 +240,7 @@ impl<'tcx> BackendTypes for CodegenCx<'tcx> {
     type Funclet = ();
 
     type DIScope = ();
+    type DILocation = ();
     type DIVariable = ();
 }
 
@@ -326,13 +327,17 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
         // Ignore.
     }
 
+    fn dbg_scope_fn(&self, _: rustc_middle::ty::Instance<'tcx>, _: &FnAbi<'tcx, &'tcx TyS<'tcx>>, _: Option<Self::Function>) -> Self::DIScope { todo!() }
+
+    fn dbg_loc(&self, _: Self::DIScope, _: Option<Self::DILocation>, _: Span) -> Self::DILocation { todo!() }
+
     fn create_function_debug_context(
         &self,
         _instance: Instance<'tcx>,
         _fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
         _llfn: Self::Function,
         _mir: &Body<'_>,
-    ) -> Option<FunctionDebugContext<Self::DIScope>> {
+    ) -> Option<FunctionDebugContext<Self::DIScope, Self::DILocation>> {
         // TODO: This is ignored. Do we want to implement this at some point?
         None
     }
@@ -341,7 +346,6 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
         &self,
         _scope_metadata: Self::DIScope,
         _file: &SourceFile,
-        _defining_crate: CrateNum,
     ) -> Self::DIScope {
         todo!()
     }
@@ -352,7 +356,6 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
 
     fn create_dbg_var(
         &self,
-        _dbg_context: &FunctionDebugContext<Self::DIScope>,
         _variable_name: Symbol,
         _variable_type: Ty<'tcx>,
         _scope_metadata: Self::DIScope,


### PR DESCRIPTION
This shouldn't be merged yet as the changes aren't released to nightly yet, but I needed this fix to test building with the latest source