### PR TITLE
Add changes to compile rust-gpu on the latest nightly

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -245,19 +245,16 @@ impl<'a, 'tcx> DebugInfoBuilderMethods for Builder<'a, 'tcx> {
     fn dbg_var_addr(
         &mut self,
         _dbg_var: Self::DIVariable,
-        _scope_metadata: Self::DIScope,
+        _scope_metadata: Self::DILocation,
         _variable_alloca: Self::Value,
         _direct_offset: Size,
         // NB: each offset implies a deref (i.e. they're steps in a pointer chain).
         _indirect_offsets: &[Size],
-        _span: Span,
     ) {
         todo!()
     }
 
-    fn set_source_location(&mut self, _scope: Self::DIScope, _span: Span) {
-        todo!()
-    }
+    fn set_dbg_loc(&mut self, _: Self::DILocation) { todo!() }
 
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self) {
         todo!()
@@ -375,6 +372,7 @@ impl<'a, 'tcx> BackendTypes for Builder<'a, 'tcx> {
 
     type DIScope = <CodegenCx<'tcx> as BackendTypes>::DIScope;
     type DIVariable = <CodegenCx<'tcx> as BackendTypes>::DIVariable;
+    type DILocation = <CodegenCx<'tcx> as BackendTypes>::DILocation;
 }
 
 impl<'a, 'tcx> HasCodegen<'tcx> for Builder<'a, 'tcx> {

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -20,7 +20,7 @@ use rustc_codegen_ssa::traits::{
 use rustc_errors::DiagnosticBuilder;
 use rustc_hir::LlvmInlineAsmInner;
 use rustc_middle::mir::coverage::{
-    CodeRegion, CounterValueReference, ExpressionOperandId, InjectedExpressionIndex, Op,
+    CodeRegion, CounterValueReference, ExpressionOperandId, InjectedExpressionId, Op,
 };
 use rustc_middle::ty::layout::{HasParamEnv, HasTyCtxt, TyAndLayout};
 use rustc_middle::ty::{Instance, ParamEnv, Ty, TyCtxt};
@@ -214,29 +214,29 @@ impl<'a, 'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'a, 'tcx> {
         todo!()
     }
 
-    fn add_counter_region(
+    fn set_function_source_hash(&mut self, _: rustc_middle::ty::Instance<'tcx>, _: u64) -> bool {
+        todo!()
+    }
+    fn add_coverage_counter(
         &mut self,
-        _instance: Instance<'tcx>,
-        _function_source_hash: u64,
-        _id: CounterValueReference,
-        _region: CodeRegion,
+        _: Instance<'tcx>,
+        _: CounterValueReference,
+        _: CodeRegion,
     ) -> bool {
         todo!()
     }
-
-    fn add_counter_expression_region(
+    fn add_coverage_counter_expression(
         &mut self,
-        _instance: Instance<'tcx>,
-        _id: InjectedExpressionIndex,
-        _lhs: ExpressionOperandId,
-        _op: Op,
-        _rhs: ExpressionOperandId,
-        _region: CodeRegion,
+        _: Instance<'tcx>,
+        _: InjectedExpressionId,
+        _: ExpressionOperandId,
+        _: Op,
+        _: ExpressionOperandId,
+        _: Option<CodeRegion>,
     ) -> bool {
         todo!()
     }
-
-    fn add_unreachable_region(&mut self, _instance: Instance<'tcx>, _region: CodeRegion) -> bool {
+    fn add_coverage_unreachable(&mut self, _: Instance<'tcx>, _: CodeRegion) -> bool {
         todo!()
     }
 }

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -254,7 +254,9 @@ impl<'a, 'tcx> DebugInfoBuilderMethods for Builder<'a, 'tcx> {
         todo!()
     }
 
-    fn set_dbg_loc(&mut self, _: Self::DILocation) { todo!() }
+    fn set_dbg_loc(&mut self, _: Self::DILocation) {
+        todo!()
+    }
 
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self) {
         todo!()

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -20,7 +20,7 @@ use rustc_hir::GlobalAsm;
 use rustc_middle::mir::mono::CodegenUnit;
 use rustc_middle::mir::Body;
 use rustc_middle::ty::layout::{HasParamEnv, HasTyCtxt};
-use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt};
+use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyS, TyCtxt};
 use rustc_session::Session;
 use rustc_span::def_id::{CrateNum, LOCAL_CRATE};
 use rustc_span::source_map::Span;
@@ -240,6 +240,7 @@ impl<'tcx> BackendTypes for CodegenCx<'tcx> {
     type Funclet = ();
 
     type DIScope = ();
+    type DILocation = ();
     type DIVariable = ();
 }
 
@@ -326,13 +327,17 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
         // Ignore.
     }
 
+    fn dbg_scope_fn(&self, _: rustc_middle::ty::Instance<'tcx>, _: &FnAbi<'tcx, &'tcx TyS<'tcx>>, _: Option<Self::Function>) -> Self::DIScope { todo!() }
+
+    fn dbg_loc(&self, _: Self::DIScope, _: Option<Self::DILocation>, _: Span) -> Self::DILocation { todo!() }
+
     fn create_function_debug_context(
         &self,
         _instance: Instance<'tcx>,
         _fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
         _llfn: Self::Function,
         _mir: &Body<'_>,
-    ) -> Option<FunctionDebugContext<Self::DIScope>> {
+    ) -> Option<FunctionDebugContext<Self::DIScope, Self::DILocation>> {
         // TODO: This is ignored. Do we want to implement this at some point?
         None
     }
@@ -341,7 +346,6 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
         &self,
         _scope_metadata: Self::DIScope,
         _file: &SourceFile,
-        _defining_crate: CrateNum,
     ) -> Self::DIScope {
         todo!()
     }
@@ -352,7 +356,6 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
 
     fn create_dbg_var(
         &self,
-        _dbg_context: &FunctionDebugContext<Self::DIScope>,
         _variable_name: Symbol,
         _variable_type: Ty<'tcx>,
         _scope_metadata: Self::DIScope,

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -20,7 +20,7 @@ use rustc_hir::GlobalAsm;
 use rustc_middle::mir::mono::CodegenUnit;
 use rustc_middle::mir::Body;
 use rustc_middle::ty::layout::{HasParamEnv, HasTyCtxt};
-use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyS, TyCtxt};
+use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt, TyS};
 use rustc_session::Session;
 use rustc_span::def_id::{CrateNum, LOCAL_CRATE};
 use rustc_span::source_map::Span;
@@ -327,9 +327,18 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
         // Ignore.
     }
 
-    fn dbg_scope_fn(&self, _: rustc_middle::ty::Instance<'tcx>, _: &FnAbi<'tcx, &'tcx TyS<'tcx>>, _: Option<Self::Function>) -> Self::DIScope { todo!() }
+    fn dbg_scope_fn(
+        &self,
+        _: rustc_middle::ty::Instance<'tcx>,
+        _: &FnAbi<'tcx, &'tcx TyS<'tcx>>,
+        _: Option<Self::Function>,
+    ) -> Self::DIScope {
+        todo!()
+    }
 
-    fn dbg_loc(&self, _: Self::DIScope, _: Option<Self::DILocation>, _: Span) -> Self::DILocation { todo!() }
+    fn dbg_loc(&self, _: Self::DIScope, _: Option<Self::DILocation>, _: Span) -> Self::DILocation {
+        todo!()
+    }
 
     fn create_function_debug_context(
         &self,

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -22,7 +22,7 @@ use rustc_middle::mir::Body;
 use rustc_middle::ty::layout::{HasParamEnv, HasTyCtxt};
 use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt, TyS};
 use rustc_session::Session;
-use rustc_span::def_id::{CrateNum, LOCAL_CRATE};
+use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::source_map::Span;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_span::SourceFile;

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -151,23 +151,19 @@ fn is_blocklisted_fn(symbol_name: &str) -> bool {
 fn target_options() -> Target {
     Target {
         llvm_target: "no-llvm".to_string(),
-        target_endian: "little".to_string(),
         pointer_width: 32,
-        target_c_int_width: "32".to_string(),
-        target_os: "unknown".to_string(),
-        target_env: String::new(),
-        target_vendor: "unknown".to_string(),
         data_layout: "e-m:e-p:32:32:32-i64:64-n8:16:32:64".to_string(),
         arch: "spirv".to_string(),
-        linker_flavor: LinkerFlavor::Ld,
         options: TargetOptions {
+            allows_weak_linkage: false,
+            crt_static_allows_dylibs: true,
             dll_prefix: "".to_string(),
             dll_suffix: ".spv".to_string(),
-            panic_strategy: PanicStrategy::Abort,
-            emit_debug_gdb_scripts: false,
-            allows_weak_linkage: false,
             dynamic_linking: true,
-            crt_static_allows_dylibs: true,
+            emit_debug_gdb_scripts: false,
+            linker_flavor: LinkerFlavor::Ld,
+            panic_strategy: PanicStrategy::Abort,
+            target_os: "unknown".to_string(),
             // TODO: Investigate if main_needs_argc_argv is useful (for building exes)
             main_needs_argc_argv: false,
             ..Default::default()

--- a/crates/spirv-builder/src/test/mod.rs
+++ b/crates/spirv-builder/src/test/mod.rs
@@ -52,6 +52,7 @@ static SRC_PREFIX: &str = r#"#![no_std]
 #![feature(lang_items, register_attr)]
 #![register_attr(spirv)]
 use core::panic::PanicInfo;
+#[allow(unused_imports)]
 use spirv_std::*;
 #[panic_handler]
 fn panic(_: &PanicInfo) -> ! {

--- a/crates/spirv-tools/src/opt/compiled.rs
+++ b/crates/spirv-tools/src/opt/compiled.rs
@@ -80,7 +80,7 @@ impl Optimizer for CompiledOptimizer {
                 ctx: *mut std::ffi::c_void,
             ) {
                 unsafe {
-                    let ctx: &mut Ctx<'_> = &mut *(ctx as *mut Ctx);
+                    let ctx: &mut Ctx<'_> = &mut *(ctx as *mut Ctx<'_>);
 
                     let msg = error::Message::from_parts(level, source, source_pos, msg);
 

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -9,7 +9,7 @@ use ash::extensions::ext::DebugUtils;
 use ash::extensions::khr::{Surface, Swapchain};
 use ash::util::*;
 use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};
-use ash::{vk, Device, Entry, Instance};
+use ash::{vk, Device, Instance};
 use std::borrow::Cow;
 use std::default::Default;
 use std::ffi::{CStr, CString};
@@ -159,7 +159,7 @@ pub struct ExampleBase {
     #[cfg(target_os = "macos")]
     pub entry: ash_molten::MoltenEntry,
     #[cfg(not(target_os = "macos"))]
-    pub entry: Entry,
+    pub entry: ash::Entry,
     pub instance: Instance,
     pub device: Device,
     pub surface_loader: Surface,
@@ -240,7 +240,7 @@ impl ExampleBase {
                 if #[cfg(target_os = "macos")] {
                     let entry = ash_molten::MoltenEntry::load().unwrap();
                 } else {
-                    let entry = Entry::new().unwrap();
+                    let entry = ash::Entry::new().unwrap();
                 }
             }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2020-11-09

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2020-10-25
+nightly


### PR DESCRIPTION
This PR along with allows rustc to be able to pull in and compile rust-gpu as a codegen backend. There's also some changes that are needed on rustc side, for which I'll create a follow up PR that contains a way to checkout and patch rust-lang/rust.