### PR TITLE
Update ash-molten to use version 0.7

### DIFF
--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -20,7 +20,7 @@ structopt = "0.3.20"
 winit = "0.23.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-ash-molten = { git = "https://github.com/EmbarkStudios/ash-molten", branch = "moltenvk-1.1.0" }
+ash-molten = "0.7"
 
 [build-dependencies]
 spirv-builder = { path = "../../../crates/spirv-builder", default-features = false }


### PR DESCRIPTION
The moltenvk-1.1.0 branch no longer exists

See also https://github.com/EmbarkStudios/ash-molten/pull/25 and https://github.com/EmbarkStudios/ash-molten/commit/c32356a0222ba8f6b417fa0702e2b063f0c84bc6