### PR TITLE
Make SpirvValue contain an enum for its value

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/ext_inst.rs
+++ b/crates/rustc_codegen_spirv/src/builder/ext_inst.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 None,
                 glsl,
                 op as u32,
-                args.iter().map(|a| Operand::IdRef(a.def)),
+                args.iter().map(|a| Operand::IdRef(a.def(self))),
             )
             .unwrap()
             .with_type(args[0].ty)
@@ -77,7 +77,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 None,
                 opencl,
                 op as u32,
-                args.iter().map(|a| Operand::IdRef(a.def)),
+                args.iter().map(|a| Operand::IdRef(a.def(self))),
             )
             .unwrap()
             .with_type(args[0].ty)

--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -99,7 +99,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
                     )),
                 };
                 // TODO: Implement this
-                self.zombie(result.def, "saturating_add is not implemented yet");
+                self.zombie(result.def(self), "saturating_add is not implemented yet");
                 result
             }
             sym::saturating_sub => {
@@ -115,7 +115,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
                     )),
                 };
                 // TODO: Implement this
-                self.zombie(result.def, "saturating_sub is not implemented yet");
+                self.zombie(result.def(self), "saturating_sub is not implemented yet");
                 result
             }
 
@@ -326,7 +326,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
                         .u_count_leading_zeros_intel(
                             args[0].immediate().ty,
                             None,
-                            args[0].immediate().def,
+                            args[0].immediate().def(self),
                         )
                         .unwrap()
                         .with_type(args[0].immediate().ty)
@@ -340,7 +340,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
                         .u_count_trailing_zeros_intel(
                             args[0].immediate().ty,
                             None,
-                            args[0].immediate().def,
+                            args[0].immediate().def(self),
                         )
                         .unwrap()
                         .with_type(args[0].immediate().ty)
@@ -349,12 +349,12 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
 
             sym::ctpop => self
                 .emit()
-                .bit_count(args[0].immediate().ty, None, args[0].immediate().def)
+                .bit_count(args[0].immediate().ty, None, args[0].immediate().def(self))
                 .unwrap()
                 .with_type(args[0].immediate().ty),
             sym::bitreverse => self
                 .emit()
-                .bit_reverse(args[0].immediate().ty, None, args[0].immediate().def)
+                .bit_reverse(args[0].immediate().ty, None, args[0].immediate().def(self))
                 .unwrap()
                 .with_type(args[0].immediate().ty),
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -107,7 +107,7 @@ impl<'tcx> CodegenCx<'tcx> {
         emit.function_call(
             entry_func_return,
             None,
-            entry_func.def,
+            entry_func.def_cx(self),
             arguments.iter().map(|&(a, _)| a),
         )
         .unwrap();
@@ -234,7 +234,7 @@ impl<'tcx> CodegenCx<'tcx> {
             .collect::<Vec<_>>();
         emit.begin_block(None).unwrap();
         let call_result = emit
-            .function_call(entry_func_return, None, entry_func.def, arguments)
+            .function_call(entry_func_return, None, entry_func.def_cx(self), arguments)
             .unwrap();
         if self.lookup_type(entry_func_return) == SpirvType::Void {
             emit.ret().unwrap();

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -4,11 +4,10 @@ mod entry;
 mod type_;
 
 use crate::builder::ExtInst;
-use crate::builder_spirv::{BuilderCursor, BuilderSpirv, SpirvValue, SpirvValueExt};
+use crate::builder_spirv::{BuilderCursor, BuilderSpirv, SpirvValue, SpirvValueKind};
 use crate::finalizing_passes::export_zombies;
 use crate::spirv_type::{SpirvType, SpirvTypePrinter, TypeCache};
 use crate::symbols::Symbols;
-use bimap::BiHashMap;
 use rspirv::dr::{Module, Operand};
 use rspirv::spirv::{Decoration, LinkageType, MemoryModel, StorageClass, Word};
 use rustc_codegen_ssa::mir::debuginfo::{FunctionDebugContext, VariableKind};
@@ -52,9 +51,7 @@ pub struct CodegenCx<'tcx> {
     /// Cache of all the builtin symbols we need
     pub sym: Box<Symbols>,
     pub really_unsafe_ignore_bitcasts: RefCell<HashSet<SpirvValue>>,
-    /// Functions created in `get_fn_addr`, and values created in `static_addr_of`.
-    /// left: the OpUndef pseudo-pointer. right: the concrete value.
-    constant_pointers: RefCell<BiHashMap<SpirvValue, SpirvValue>>,
+    pub zombie_undefs_for_system_constant_pointers: RefCell<HashMap<Word, Word>>,
     /// Some runtimes (e.g. intel-compute-runtime) disallow atomics on i8 and i16, even though it's allowed by the spec.
     /// This enables/disables them.
     pub i8_i16_atomics_allowed: bool,
@@ -104,7 +101,7 @@ impl<'tcx> CodegenCx<'tcx> {
             kernel_mode,
             sym,
             really_unsafe_ignore_bitcasts: Default::default(),
-            constant_pointers: Default::default(),
+            zombie_undefs_for_system_constant_pointers: Default::default(),
             i8_i16_atomics_allowed: false,
         }
     }
@@ -185,47 +182,28 @@ impl<'tcx> CodegenCx<'tcx> {
         )
     }
 
-    /// Function pointer registration:
-    /// LLVM, and therefore `codegen_ssa`, is very murky with function values vs. function
-    /// pointers. So, `codegen_ssa` has a pattern where *even for direct function calls*, it uses
-    /// `get_fn_*addr*`, and then uses that function *pointer* when calling
-    /// `BuilderMethods::call()`. However, spir-v doesn't support function pointers! So, instead,
-    /// when `get_fn_addr` is called, we register a "token" (via `OpUndef`), storing it in a
-    /// dictionary. Then, when `BuilderMethods::call()` is called, and it's calling a function
-    /// pointer, we check the dictionary, and if it is, invoke the function directly. It's kind of
-    /// conceptually similar to a constexpr deref, except specialized to just functions. We also
-    /// use the same system with `static_addr_of`: we don't support creating addresses of arbitrary
-    /// constant values, so instead, we register the constant, and whenever we load something, we
-    /// check if the pointer we're loading is a special `OpUndef` token: if so, we directly
-    /// reference the registered value.
-    pub fn register_constant_pointer(&self, value: SpirvValue) -> SpirvValue {
-        // If we've already registered this value, return it.
-        if let Some(undef) = self.constant_pointers.borrow().get_by_right(&value) {
-            return *undef;
-        }
+    /// See note on `SpirvValueKind::ConstantPointer`
+    pub fn make_constant_pointer(&self, value: SpirvValue) -> SpirvValue {
         let ty = SpirvType::Pointer {
             storage_class: StorageClass::Function,
             pointee: value.ty,
         }
         .def(self);
-        // We want a unique ID for these undefs, so don't use the caching system.
-        let result = self.emit_global().undef(ty, None).with_type(ty);
-        // It's obviously invalid, so zombie it. Zombie it in user code as well, because it's valid there too.
-        // It'd be realllly nice to give this a Span, the UX of this is horrible...
-        self.zombie_even_in_user_code(result.def, "dynamic use of address of constant");
-        self.constant_pointers
-            .borrow_mut()
-            .insert_no_overwrite(result, value)
-            .unwrap();
-        result
-    }
-
-    /// See comment on `register_constant_pointer`
-    pub fn lookup_constant_pointer(&self, pointer: SpirvValue) -> Option<SpirvValue> {
-        self.constant_pointers
-            .borrow()
-            .get_by_left(&pointer)
-            .cloned()
+        if self.is_system_crate() {
+            // Create these undefs up front instead of on demand in SpirvValue::def because
+            // SpirvValue::def can't use cx.emit()
+            self.zombie_undefs_for_system_constant_pointers
+                .borrow_mut()
+                .entry(ty)
+                .or_insert_with(|| {
+                    // We want a unique ID for these undefs, so don't use the caching system.
+                    self.emit_global().undef(ty, None)
+                });
+        }
+        SpirvValue {
+            kind: SpirvValueKind::ConstantPointer(value.def_cx(self)),
+            ty,
+        }
     }
 }
 
@@ -286,7 +264,7 @@ impl<'tcx> MiscMethods<'tcx> for CodegenCx<'tcx> {
 
     fn get_fn_addr(&self, instance: Instance<'tcx>) -> Self::Value {
         let function = self.get_fn_ext(instance);
-        self.register_constant_pointer(function)
+        self.make_constant_pointer(function)
     }
 
     fn eh_personality(&self) -> Self::Value {

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -148,7 +148,7 @@ impl SpirvType {
                     .sizeof(cx)
                     .expect("Element of sized array must be sized")
                     .bytes();
-                let result = cx.emit_global().type_array(element, count.def);
+                let result = cx.emit_global().type_array(element, count.def_cx(cx));
                 if !cx.kernel_mode {
                     // TODO: kernel mode can't do this??
                     cx.emit_global().decorate(


### PR DESCRIPTION
This is a prerequisite for all sorts of work (panics, printf extension, builtin functions, nested constants, all sorts of fun stuff) - `SpirvValueKind` is eventually going to have a decent number of cases. However, just for a proof-of-concept, I've added one "extra" case: `ConstantPointer`. Not only does this work towards my goal of removing the horrible `zombie_even_in_user_code` hack, it significantly improves error messages, since we're able to report violations of using the constant pointer directly in the compiler, not the linker, and so we have span information.

Before:

```rust
  error: dynamic use of address of constant
    |
    = note: Stack:
            main_fs
            Unnamed function ID %343
```

After:

```rust
  error: Cannot use this pointer directly, it must be dereferenced first
     --> examples/shaders/sky-shader/src/lib.rs:184:5
      |
  184 |     f(&2);
      |     ^^^^^
```