### PR TITLE
Put shader modules at the top of the example runners

### DIFF
--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -17,6 +17,10 @@ use std::io::Cursor;
 use std::ops::Drop;
 use structopt::StructOpt;
 
+fn shader_module() -> &'static [u8] {
+    &include_bytes!(env!("sky_shader.spv"))[..]
+}
+
 // Simple offset_of macro akin to C++ offsetof
 #[macro_export]
 macro_rules! offset_of {
@@ -619,7 +623,7 @@ fn main() {
             })
             .collect();
 
-        let mut spv_file = Cursor::new(&include_bytes!(env!("sky_shader.spv"))[..]);
+        let mut spv_file = Cursor::new(shader_module());
         let code = read_spv(&mut spv_file).expect("Failed to read spv file");
         let shader_info = vk::ShaderModuleCreateInfo::builder().code(&code);
 

--- a/examples/runners/cpu/src/main.rs
+++ b/examples/runners/cpu/src/main.rs
@@ -3,6 +3,8 @@ use rayon::prelude::*;
 use spirv_std::glam::{vec2, Vec4};
 use std::time::Instant;
 
+use sky_shader as shader_module;
+
 // apply the srgb OETF (i.e. do "linear to sRGB")
 fn srgb_oetf(x: f32) -> f32 {
     if x <= 0.0031308 {
@@ -47,7 +49,7 @@ fn main() {
             );
 
             // evaluate the fragment shader for the specific pixel
-            let color = sky_shader::fs(screen_pos);
+            let color = shader_module::fs(screen_pos);
 
             color_u32_from_vec4(color)
         })

--- a/examples/runners/wgpu-compute/src/main.rs
+++ b/examples/runners/wgpu-compute/src/main.rs
@@ -1,3 +1,7 @@
+fn shader_module() -> wgpu::ShaderModuleSource<'static> {
+    wgpu::include_spirv!(env!("compute_shader.spv"))
+}
+
 fn create_device_queue() -> (wgpu::Device, wgpu::Queue) {
     async fn create_device_queue_async() -> (wgpu::Device, wgpu::Queue) {
         let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
@@ -35,7 +39,7 @@ fn main() {
     let (device, queue) = create_device_queue();
 
     // Load the shaders from disk
-    let module = device.create_shader_module(wgpu::include_spirv!(env!("compute_shader.spv")));
+    let module = device.create_shader_module(shader_module());
 
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: None,

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -4,6 +4,10 @@ use winit::{
     window::Window,
 };
 
+fn shader_module() -> wgpu::ShaderModuleSource<'static> {
+    wgpu::include_spirv!(env!("sky_shader.spv"))
+}
+
 async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::TextureFormat) {
     let size = window.inner_size();
     let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
@@ -39,7 +43,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
         .expect("Failed to create device");
 
     // Load the shaders from disk
-    let module = device.create_shader_module(wgpu::include_spirv!(env!("sky_shader.spv")));
+    let module = device.create_shader_module(shader_module());
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: None,


### PR DESCRIPTION
This moves the shader module that the runners use to the top of the file to make it easier to quickly change between different shaders.