### PR TITLE
Shader hot-reloading in WGPU example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anymap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,12 +393,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -403,7 +419,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -414,10 +430,21 @@ checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg 1.0.1",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -576,6 +603,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "futures",
+ "notify",
  "spirv-builder",
  "wasm-bindgen-futures",
  "web-sys",
@@ -616,6 +644,25 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fsevent"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f347202c95c98805c216f9e1df210e8ebaec9fdb2365700a43c10797a35e63"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a29c77f1ca394c3e73a9a5d24cfcabb734682d9634fc398f2204a63c994120"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -944,6 +991,26 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "inotify"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dd0a94b393c730779ccfd2a872b67b1eb67be3fc33082e733bdb38b5fde4d4"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "inplace_it"
@@ -1299,6 +1366,26 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b946889dfdad884379cd56367d93b6d0ce8889cc027d26a69a3a31c0a03bb5"
+dependencies = [
+ "anymap",
+ "bitflags",
+ "crossbeam-channel 0.4.4",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1794,9 +1881,9 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.5.0",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
  "num_cpus",
 ]

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -8,14 +8,16 @@ publish = false
 
 # See rustc_codegen_spirv/Cargo.toml for details on these features
 [features]
-default = ["use-compiled-tools"]
+default = ["use-compiled-tools", "hot-reload"]
 use-installed-tools = ["spirv-builder/use-installed-tools"]
 use-compiled-tools = ["spirv-builder/use-compiled-tools"]
+hot-reload = ["notify"]
 
 [dependencies]
 wgpu = "0.6.0"
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 winit = { version = "0.23", features = ["web-sys"] }
+notify = { version = "5.0.0-pre.4", optional = true }
 
 [build-dependencies]
 spirv-builder = { path = "../../../spirv-builder", default-features = false }

--- a/shaders-build.sh
+++ b/shaders-build.sh
@@ -1,0 +1,1 @@
+RUSTFLAGS="-Zcodegen-backend=rustc_codegen_spirv.dll" cargo build -Z build-std=core --target spirv-unknown-unknown --release -p sky-shader

--- a/shaders-watch.sh
+++ b/shaders-watch.sh
@@ -1,0 +1,1 @@
+RUSTFLAGS="-Zcodegen-backend=rustc_codegen_spirv.dll" cargo watch -x 'build -Z build-std=core --target spirv-unknown-unknown --release -p sky-shader'

--- a/shaders-watch.sh
+++ b/shaders-watch.sh
@@ -1,1 +1,1 @@
-RUSTFLAGS="-Zcodegen-backend=rustc_codegen_spirv.dll" cargo watch -x 'build -Z build-std=core --target spirv-unknown-unknown --release -p sky-shader'
+RUSTFLAGS="-Zcodegen-backend=rustc_codegen_spirv.dll" cargo watch -x 'build -Z build-std=core --target spirv-unknown-unknown --release -p sky-shader' -q -d 0.1


### PR DESCRIPTION
This is the the test a did 1-2 weeks ago on hot-reloading of shaders, haven't had time to continue on it but do think we should clean it up and get it in to the all the example runners

It does have a problem with spirv-builder where that somehow causes every iteration in cargo-watch to rebuild `core` and everything, it seems like.  I did test before to not have the spriv-builder build path at all and just load .spv directly from the target folder and that worked flawlessly when iterating, could potentially disable the spriv-builder path when one has the `hot-reload` feature enabled as it is not needed then