### PR TITLE
wgpu-runner: Added clap to switch between shaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,41 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.12.1",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -603,11 +635,13 @@ name = "example-runner-wgpu"
 version = "0.1.0"
 dependencies = [
  "cfg-if 1.0.0",
+ "clap 3.0.0-beta.2",
  "console_error_panic_hook",
  "console_log",
  "futures",
  "ndk-glue",
  "spirv-builder",
+ "strum",
  "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
@@ -964,6 +998,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1026,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+dependencies = [
+ "autocfg 1.0.1",
+ "hashbrown",
+]
 
 [[package]]
 name = "inplace_it"
@@ -1450,6 +1500,12 @@ dependencies = [
  "redox_syscall",
  "sdl2",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "output_vt100"
@@ -2205,12 +2261,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "lazy_static",
  "structopt-derive",
 ]
@@ -2223,6 +2285,27 @@ checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
 dependencies = [
  "heck",
  "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "strum"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89a286a7e3b5720b9a477b23253bc50debac207c8d21505f8e70b36792f11b5"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
+dependencies = [
+ "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.48",
@@ -2277,10 +2360,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -20,6 +20,8 @@ cfg-if = "1.0.0"
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 wgpu = "0.6.0"
 winit = { version = "0.23", features = ["web-sys"] }
+clap = "3.0.0-beta.2"
+strum = { version = "0.19", default_features = false, features = ["derive"] }
 
 [build-dependencies]
 spirv-builder = { path = "../../../crates/spirv-builder", default-features = false }

--- a/examples/runners/wgpu/build.rs
+++ b/examples/runners/wgpu/build.rs
@@ -1,10 +1,15 @@
 use spirv_builder::SpirvBuilder;
 use std::error::Error;
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // This will set the env var `sky-shader.spv` to a spir-v file that can be include!()'d
-    SpirvBuilder::new("../../shaders/sky-shader")
+fn build_shader(path_to_create: &str) -> Result<(), Box<dyn Error>> {
+    SpirvBuilder::new(path_to_create)
         .spirv_version(1, 0)
         .build()?;
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    build_shader("../../shaders/sky-shader")?;
+    build_shader("../../shaders/simplest-shader")?;
     Ok(())
 }


### PR DESCRIPTION
Added `clap` so you can choose what shader to run with. i.e: `cargo run --bin wgpu-example-runner -- --shader=Simplest`.
Should make adding examples easier and removes the need (in most cases) for adding a new runner.