### PR TITLE
Make it easier to build & run examples on NixOS.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,20 @@
+let
+  pkgs = import <nixpkgs> {};
+in with pkgs; stdenv.mkDerivation rec {
+  name = "rust-gpu";
+
+  # Workaround for https://github.com/NixOS/nixpkgs/issues/60919.
+  hardeningDisable = [ "fortify" ];
+
+  # Allow cargo to download crates.
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  buildInputs = [
+    pkgconfig rustup x11 libxkbcommon
+  ];
+
+  # Runtime dependencies.
+  LD_LIBRARY_PATH = with xlibs; stdenv.lib.makeLibraryPath [
+    libX11 libXcursor libXi libXrandr vulkan-loader
+  ];
+}


### PR DESCRIPTION
With this `default.nix` file you can enter `nix-shell`, and don't have to worry about installing the dependencies system/user-wide (which probably runs into a different set of problems, etc.)

I've tested that all these 3 work (the `--pure` flag is usually unnecessary, but it validates that no other deps are needed):

```sh
nix-shell --pure --run 'cargo run --bin example-runner-cpu'
nix-shell --pure --run 'cargo run --bin example-runner-ash'
nix-shell --pure --run 'cargo run --bin example-runner-wgpu'
```

Normally I would use https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector to automatically enter the `nix-shell` environment for all aspects of VSCode (including any LSP servers like RLS or RA), but I can't get it to work anymore.

Still, I can e.g. have this `.vscode/tasks.json` file (and/or set the VSCode terminal shell to `nix-shell` etc.):
```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "run wgpu",
            "type": "shell",
            "command": "nix-shell --run 'cargo run --bin example-runner-wgpu'",
            "problemMatcher": [
                "$rustc"
            ],
            "group": {
                "kind": "build",
                "isDefault": true
            }
        }
    ]
}
```