### PR TITLE
Use a demangled symbol name for OpName.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,6 +1964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+
+[[package]]
 name = "rustc_codegen_spirv"
 version = "0.1.0"
 dependencies = [
@@ -1971,6 +1977,7 @@ dependencies = [
  "pipe",
  "pretty_assertions",
  "rspirv",
+ "rustc-demangle",
  "spirv-tools",
  "tar",
  "tempfile",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -29,6 +29,7 @@ use-compiled-tools = ["spirv-tools/use-compiled-tools"]
 [dependencies]
 bimap = "0.5"
 rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "01ca0d2e5b667a0e4ff1bc1804511e38f9a08759" }
+rustc-demangle = "0.1.18"
 spirv-tools = { version = "0.1.0", default-features = false }
 tar = "0.4.30"
 topological-sort = "0.1"

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -143,7 +143,7 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         format!(" -C target-feature={}", target_features.join(","))
     };
     let rustflags = format!(
-        "-Z codegen-backend={}{}",
+        "-Z codegen-backend={} -Z symbol-mangling-version=v0{}",
         rustc_codegen_spirv.display(),
         feature_flag,
     );

--- a/crates/spirv-builder/src/test/mod.rs
+++ b/crates/spirv-builder/src/test/mod.rs
@@ -113,12 +113,13 @@ fn assert_str_eq(expected: &str, result: &str) {
 fn dis_fn(src: &str, func: &str, expect: &str) {
     let _lock = global_lock();
     let module = read_module(&build(src)).unwrap();
+    let abs_func_path = format!("test_project::{}", func);
     let id = module
         .debugs
         .iter()
         .find(|inst| {
             inst.class.opcode == rspirv::spirv::Op::Name
-                && inst.operands[1].unwrap_literal_string() == func
+                && inst.operands[1].unwrap_literal_string() == abs_func_path
         })
         .expect("No function with that name found")
         .operands[0]

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -39,8 +39,7 @@ pub fn acos_approx(v: f32) -> f32 {
     }
 }
 
-/// renamed because of cross-compilation issues with spirv-cross/ moltenvk
-pub fn my_smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+pub fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
     // Scale, bias and saturate x to 0..1 range
     let x = ((x - edge0) / (edge1 - edge0)).saturate();
     // Evaluate polynomial

--- a/examples/shaders/sky-shader/src/lib.rs
+++ b/examples/shaders/sky-shader/src/lib.rs
@@ -97,7 +97,7 @@ fn sky(dir: Vec3, sun_position: Vec3) -> Vec3 {
 
     // Composition + solar disc
     let sun_angular_diameter_cos = SUN_ANGULAR_DIAMETER_DEGREES.cos();
-    let sundisk = my_smoothstep(
+    let sundisk = smoothstep(
         sun_angular_diameter_cos,
         sun_angular_diameter_cos + 0.00002,
         cos_theta,


### PR DESCRIPTION
Fixes #102, using @khyperia's suggestion of demangling `v0` symbols to get an absolute path (with all of the generic parameters). This required #265 so that `-Z symbol-mangling-version=v0` works at all.

If we want to avoid `spirv-builder` passing `-Z symbol-mangling-version=v0` explicitly, I could make a small change to `rustc` that would allow overriding the symbol mangling version from within the codegen backend (e.g. via overriding queries).

Also undid https://github.com/EmbarkStudios/rust-gpu/pull/86#issuecomment-714378730, but will require testing on macOS to confirm the plain `smoothstep` works now.