### PR TITLE
spirv-builder: pass through non-JSON stdout lines even after an error.

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -162,9 +162,14 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         .env("RUSTFLAGS", rustflags)
         .output()
         .expect("failed to execute cargo build");
+
+    // `get_last_artifact` has the side-effect of printing invalid lines, so
+    // we do that even in case of an error, to let through any useful messages
+    // that ended up on stdout instead of stderr.
+    let stdout = String::from_utf8(build.stdout).unwrap();
+    let artifact = get_last_artifact(&stdout);
+
     if build.status.success() {
-        let stdout = String::from_utf8(build.stdout).unwrap();
-        let artifact = get_last_artifact(&stdout);
         if builder.print_metadata {
             print_deps_of(&artifact);
         }


### PR DESCRIPTION
While investigating #192, I couldn't get `RUSTC_LOG` to work for the nested build, and it turns out that it was a combination of it outputting on stdout (which https://github.com/rust-lang/rust/pull/79238 fixes) and `spirv-builder` not showing any of the stdout on failure.

This addresses the latter, in case a similar problem to the former, arises in the future.