### PR TITLE
Use rustc_codegen_llvm's get_dylib_metadata to unblock proc macros.

### DIFF
--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -231,8 +231,16 @@ impl MetadataLoader for SpirvMetadataLoader {
         link::read_metadata(path)
     }
 
-    fn get_dylib_metadata(&self, _: &Target, _: &Path) -> Result<MetadataRef, String> {
-        Err("TODO: implement get_dylib_metadata".to_string())
+    fn get_dylib_metadata(&self, target: &Target, path: &Path) -> Result<MetadataRef, String> {
+        // HACK(eddyb) this is needed to allow metadata loading for proc macros
+        // (compiled as host dylibs); perhaps it'd be better to use the `object`
+        // crate, like `rustc_codegen_cranelift` does.
+        // NOTE(eddyb) while both `::new()` and `.metadata_loader()` call `Box::new`,
+        // they only do so with ZST values, and so we don't pointlessly allocate.
+        extern crate rustc_codegen_llvm;
+        rustc_codegen_llvm::LlvmCodegenBackend::new()
+            .metadata_loader()
+            .get_dylib_metadata(target, path)
     }
 }
 


### PR DESCRIPTION
Given what I found in https://github.com/EmbarkStudios/rust-gpu/issues/192#issuecomment-731261378, proc macros should've been working already, but their loading was silently failing. After getting `RUSTC_LOG` to work (needs https://github.com/rust-lang/rust/pull/79238 and/or #267), I could see this:
```rust
   WARN rustc_metadata::locator no metadata found: TODO: implement get_dylib_metadata
```

That's a `warn!` in `rustc_metadata`, so ideally it would be visible by default, but it's not, due to https://github.com/rust-lang/rust/issues/76824.
(It should also be reported as an error, but I'm not sure if the LLVM backend has non-fatal metadata loading errors)

<hr>

The main problem is that `rustc_metadata` is relying on `rustc_codegen_spirv` to load proc macro metadata.

This PR works around that by grabbing `rustc_codegen_llvm`'s, but we should probably copy what `rustc_codegen_cranelift` does, instead, or fix `rustc` to not rely on the codegen backend for proc macro metadata.

Fixes #192.