### PR TITLE
Move lang_items into spirv-std

### DIFF
--- a/crates/spirv-builder/src/test/mod.rs
+++ b/crates/spirv-builder/src/test/mod.rs
@@ -49,15 +49,10 @@ spirv-std = { path = "../../crates/spirv-std" }
 "#;
 
 static SRC_PREFIX: &str = r#"#![no_std]
-#![feature(lang_items, register_attr, asm)]
+#![feature(register_attr, asm)]
 #![register_attr(spirv)]
-use core::panic::PanicInfo;
 #[allow(unused_imports)]
 use spirv_std::*;
-#[panic_handler]
-fn panic(_: &PanicInfo) -> ! {
-    loop {}
-}
 "#;
 
 fn setup(src: &str) -> Result<PathBuf, Box<dyn Error>> {

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(register_attr, repr_simd, core_intrinsics)]
+#![feature(register_attr, repr_simd, core_intrinsics, lang_items)]
 #![cfg_attr(target_arch = "spirv", feature(asm))]
 #![register_attr(spirv)]
 // Our standard Clippy lints that we use in Embark projects, we opt out of a few that are not appropriate for the specific crate (yet)
@@ -39,6 +39,16 @@
 
 pub use glam;
 pub use num_traits;
+
+#[cfg(all(not(test), target_arch = "spirv"))]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[cfg(all(not(test), target_arch = "spirv"))]
+#[lang = "eh_personality"]
+extern "C" fn rust_eh_personality() {}
 
 macro_rules! pointer_addrspace_write {
     (false) => {};

--- a/examples/shaders/compute-shader/src/lib.rs
+++ b/examples/shaders/compute-shader/src/lib.rs
@@ -1,15 +1,8 @@
 #![cfg_attr(target_arch = "spirv", no_std)]
-#![feature(lang_items)]
 #![feature(register_attr)]
 #![register_attr(spirv)]
 
 extern crate spirv_std;
-
-#[cfg(all(not(test), target_arch = "spirv"))]
-#[panic_handler]
-fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
 
 #[allow(unused_attributes)]
 #[spirv(gl_compute)]

--- a/examples/shaders/simplest-shader/src/lib.rs
+++ b/examples/shaders/simplest-shader/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(target_arch = "spirv", no_std)]
-#![feature(lang_items)]
 #![feature(register_attr)]
 #![register_attr(spirv)]
 
@@ -26,13 +25,3 @@ pub fn main_vs(
         1.0,
     ));
 }
-
-#[cfg(all(not(test), target_arch = "spirv"))]
-#[panic_handler]
-fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
-
-#[cfg(all(not(test), target_arch = "spirv"))]
-#[lang = "eh_personality"]
-extern "C" fn rust_eh_personality() {}

--- a/examples/shaders/sky-shader/src/lib.rs
+++ b/examples/shaders/sky-shader/src/lib.rs
@@ -179,13 +179,3 @@ pub fn main_vs(
 
     builtin_pos.store(pos.extend(0.0).extend(1.0));
 }
-
-#[cfg(all(not(test), target_arch = "spirv"))]
-#[panic_handler]
-fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
-
-#[cfg(all(not(test), target_arch = "spirv"))]
-#[lang = "eh_personality"]
-extern "C" fn rust_eh_personality() {}


### PR DESCRIPTION
This PR moves the lang_items that shader crates need to define into `spirv-std` itself, so `spirv-std` behaves a little more like `std`, and reduces the amount of code you need to get started. It's included under a default feature so if for some reason you still need to define your own `lang_items` you still can.