### PR TITLE
Textures!

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -185,6 +185,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             SpirvType::Pointer { .. } => self.fatal("memset on pointers not implemented yet"),
             SpirvType::Function { .. } => self.fatal("memset on functions not implemented yet"),
+            SpirvType::Image { .. } => self.fatal("cannot memset image"),
+            SpirvType::Sampler => self.fatal("cannot memset sampler"),
         }
     }
 
@@ -238,6 +240,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             SpirvType::Pointer { .. } => self.fatal("memset on pointers not implemented yet"),
             SpirvType::Function { .. } => self.fatal("memset on functions not implemented yet"),
+            SpirvType::Image { .. } => self.fatal("cannot memset image"),
+            SpirvType::Sampler => self.fatal("cannot memset sampler"),
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -482,6 +482,11 @@ impl<'tcx> CodegenCx<'tcx> {
                 .tcx
                 .sess
                 .fatal("TODO: SpirvType::Function not supported yet in create_const_alloc"),
+            SpirvType::Image { .. } => self.tcx.sess.fatal("Cannot create a constant image value"),
+            SpirvType::Sampler => self
+                .tcx
+                .sess
+                .fatal("Cannot create a constant sampler value"),
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -174,6 +174,8 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             SpirvType::RuntimeArray { .. } => TypeKind::Array,
             SpirvType::Pointer { .. } => TypeKind::Pointer,
             SpirvType::Function { .. } => TypeKind::Function,
+            SpirvType::Image { .. } => TypeKind::Integer,
+            SpirvType::Sampler => TypeKind::Integer,
         }
     }
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type {

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -1,6 +1,8 @@
 use crate::builder::libm_intrinsics;
 use crate::codegen_cx::CodegenCx;
-use rspirv::spirv::{BuiltIn, ExecutionMode, ExecutionModel, StorageClass};
+use rspirv::spirv::{
+    AccessQualifier, BuiltIn, Dim, ExecutionMode, ExecutionModel, ImageFormat, StorageClass,
+};
 use rustc_ast::ast::{AttrKind, Attribute, Lit, LitIntType, LitKind, NestedMetaItem};
 use rustc_span::symbol::{Ident, Symbol};
 use std::collections::HashMap;
@@ -30,7 +32,14 @@ pub struct Symbols {
     pub spirv15: Symbol,
     descriptor_set: Symbol,
     binding: Symbol,
-    really_unsafe_ignore_bitcasts: Symbol,
+    image: Symbol,
+    dim: Symbol,
+    depth: Symbol,
+    arrayed: Symbol,
+    multisampled: Symbol,
+    sampled: Symbol,
+    image_format: Symbol,
+    access_qualifier: Symbol,
     attributes: HashMap<Symbol, SpirvAttribute>,
     execution_modes: HashMap<Symbol, (ExecutionMode, ExecutionModeExtraDim)>,
     pub libm_intrinsics: HashMap<Symbol, libm_intrinsics::LibmIntrinsic>,
@@ -321,9 +330,19 @@ impl Symbols {
         let execution_models = EXECUTION_MODELS
             .iter()
             .map(|&(a, b)| (a, SpirvAttribute::Entry(b.into())));
+        let custom_attributes = [
+            (
+                "really_unsafe_ignore_bitcasts",
+                SpirvAttribute::ReallyUnsafeIgnoreBitcasts,
+            ),
+            ("sampler", SpirvAttribute::Sampler),
+        ]
+        .iter()
+        .cloned();
         let attributes_iter = builtins
             .chain(storage_classes)
             .chain(execution_models)
+            .chain(custom_attributes)
             .map(|(a, b)| (Symbol::intern(a), b));
         let mut attributes = HashMap::new();
         for (a, b) in attributes_iter {
@@ -362,7 +381,14 @@ impl Symbols {
             spirv15: Symbol::intern("spirv1.5"),
             descriptor_set: Symbol::intern("descriptor_set"),
             binding: Symbol::intern("binding"),
-            really_unsafe_ignore_bitcasts: Symbol::intern("really_unsafe_ignore_bitcasts"),
+            image: Symbol::intern("image"),
+            dim: Symbol::intern("dim"),
+            depth: Symbol::intern("depth"),
+            arrayed: Symbol::intern("arrayed"),
+            multisampled: Symbol::intern("multisampled"),
+            sampled: Symbol::intern("sampled"),
+            image_format: Symbol::intern("image_format"),
+            access_qualifier: Symbol::intern("access_qualifier"),
             attributes,
             execution_modes,
             libm_intrinsics,
@@ -415,6 +441,16 @@ pub enum SpirvAttribute {
     DescriptorSet(u32),
     Binding(u32),
     ReallyUnsafeIgnoreBitcasts,
+    Image {
+        dim: Dim,
+        depth: u32,
+        arrayed: u32,
+        multisampled: u32,
+        sampled: u32,
+        image_format: ImageFormat,
+        access_qualifier: Option<AccessQualifier>,
+    },
+    Sampler,
 }
 
 // Note that we could mark the attr as used via cx.tcx.sess.mark_attr_used(attr), but unused
@@ -448,8 +484,8 @@ pub fn parse_attrs(
                 Vec::new()
             };
             args.into_iter().filter_map(move |ref arg| {
-                if arg.has_name(cx.sym.really_unsafe_ignore_bitcasts) {
-                    Some(SpirvAttribute::ReallyUnsafeIgnoreBitcasts)
+                if arg.has_name(cx.sym.image) {
+                    parse_image(cx, arg)
                 } else if arg.has_name(cx.sym.descriptor_set) {
                     match parse_attr_int_value(cx, arg) {
                         Some(x) => Some(SpirvAttribute::DescriptorSet(x)),
@@ -491,6 +527,136 @@ pub fn parse_attrs(
         });
     // lifetimes are hard :(
     result.collect::<Vec<_>>().into_iter()
+}
+
+fn parse_image(cx: &CodegenCx<'_>, attr: &NestedMetaItem) -> Option<SpirvAttribute> {
+    let args = match attr.meta_item_list() {
+        Some(args) => args,
+        None => {
+            cx.tcx
+                .sess
+                .span_err(attr.span(), "image attribute must have arguments");
+            return None;
+        }
+    };
+    if args.len() != 6 && args.len() != 7 {
+        cx.tcx
+            .sess
+            .span_err(attr.span(), "image attribute must have 6 or 7 arguments");
+        return None;
+    }
+    let check = |idx: usize, sym: Symbol| -> bool {
+        if args[idx].has_name(sym) {
+            false
+        } else {
+            cx.tcx.sess.span_err(
+                args[idx].span(),
+                &format!("image attribute argument {} must be {}=...", idx + 1, sym),
+            );
+            true
+        }
+    };
+    if check(0, cx.sym.dim)
+        | check(1, cx.sym.depth)
+        | check(2, cx.sym.arrayed)
+        | check(3, cx.sym.multisampled)
+        | check(4, cx.sym.sampled)
+        | check(5, cx.sym.image_format)
+        | (args.len() == 7 && check(6, cx.sym.access_qualifier))
+    {
+        return None;
+    }
+    let arg_values = args
+        .iter()
+        .map(
+            |arg| match arg.meta_item().and_then(|arg| arg.name_value_literal()) {
+                Some(arg) => Some(arg),
+                None => {
+                    cx.tcx
+                        .sess
+                        .span_err(arg.span(), "image attribute must be name=value");
+                    None
+                }
+            },
+        )
+        .collect::<Option<Vec<_>>>()?;
+    let dim = match arg_values[0].kind {
+        LitKind::Str(dim, _) => match dim.with(|s| s.parse()) {
+            Ok(dim) => dim,
+            Err(()) => {
+                cx.tcx.sess.span_err(args[0].span(), "invalid dim value");
+                return None;
+            }
+        },
+        _ => {
+            cx.tcx
+                .sess
+                .span_err(args[0].span(), "dim value must be str");
+            return None;
+        }
+    };
+    let parse_lit = |idx: usize, name: &str| -> Option<u32> {
+        match arg_values[idx].kind {
+            LitKind::Int(v, _) => Some(v as u32),
+            _ => {
+                cx.tcx
+                    .sess
+                    .span_err(args[idx].span(), &format!("{} value must be int", name));
+                None
+            }
+        }
+    };
+    let depth = parse_lit(1, "depth")?;
+    let arrayed = parse_lit(2, "arrayed")?;
+    let multisampled = parse_lit(3, "multisampled")?;
+    let sampled = parse_lit(4, "sampled")?;
+    let image_format = match arg_values[5].kind {
+        LitKind::Str(dim, _) => match dim.with(|s| s.parse()) {
+            Ok(dim) => dim,
+            Err(()) => {
+                cx.tcx
+                    .sess
+                    .span_err(args[5].span(), "invalid image_format value");
+                return None;
+            }
+        },
+        _ => {
+            cx.tcx
+                .sess
+                .span_err(args[5].span(), "image_format value must be str");
+            return None;
+        }
+    };
+    let access_qualifier = if args.len() == 7 {
+        Some(match arg_values[6].kind {
+            LitKind::Str(dim, _) => match dim.with(|s| s.parse()) {
+                Ok(dim) => dim,
+                Err(()) => {
+                    cx.tcx
+                        .sess
+                        .span_err(args[6].span(), "invalid access_qualifier value");
+                    return None;
+                }
+            },
+            _ => {
+                cx.tcx
+                    .sess
+                    .span_err(args[6].span(), "access_qualifier value must be str");
+                return None;
+            }
+        })
+    } else {
+        None
+    };
+    Some(SpirvAttribute::Image {
+        dim,
+        depth,
+        arrayed,
+        multisampled,
+        sampled,
+        image_format,
+        access_qualifier,
+    })
 }
 
 fn parse_attr_int_value(cx: &CodegenCx<'_>, arg: &NestedMetaItem) -> Option<u32> {

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -37,8 +37,11 @@
     nonstandard_style
 )]
 
+mod textures;
+
 pub use glam;
 pub use num_traits;
+pub use textures::*;
 
 macro_rules! pointer_addrspace_write {
     (false) => {};

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -1,0 +1,52 @@
+use glam::{Vec2, Vec4};
+
+#[allow(unused_attributes)]
+#[spirv(sampler)]
+#[derive(Copy, Clone)]
+pub struct Sampler {
+    _x: u32,
+}
+
+#[allow(unused_attributes)]
+#[spirv(image(
+    // sampled_type is hardcoded to f32 for now
+    dim = "Dim2D",
+    depth = 0,
+    arrayed = 0,
+    multisampled = 0,
+    sampled = 1,
+    image_format = "Unknown"
+))]
+#[derive(Copy, Clone)]
+pub struct Image2d {
+    _x: u32,
+}
+
+impl Image2d {
+    pub fn sample(&self, sampler: Sampler, coord: Vec2) -> Vec4 {
+        #[cfg(not(target_arch = "spirv"))]
+        {
+            let _ = sampler;
+            let _ = coord;
+            panic!("Image sampling not supported on CPU");
+        }
+        #[cfg(target_arch = "spirv")]
+        unsafe {
+            let mut result = Default::default();
+            asm!(
+                "%typeSampledImage = OpTypeSampledImage typeof*{1}",
+                "%image = OpLoad typeof*{1} {1}",
+                "%sampler = OpLoad typeof*{2} {2}",
+                "%coord = OpLoad typeof*{3} {3}",
+                "%sampledImage = OpSampledImage %typeSampledImage %image %sampler",
+                "%result = OpImageSampleImplicitLod typeof*{0} %sampledImage %coord",
+                "OpStore {0} %result",
+                in(reg) &mut result,
+                in(reg) self,
+                in(reg) &sampler,
+                in(reg) &coord
+            );
+            result
+        }
+    }
+}


### PR DESCRIPTION
Partially does https://github.com/EmbarkStudios/rust-gpu/issues/204 (just the compiler parts and the minimal library part to make sure the compiler bits work - library bits can be done in a follow-up)

I have a local change to wgpu runner based off https://github.com/gfx-rs/wgpu-rs/blob/e59ea495a66ce9606c3a2bbfc2efe8c0c05d413c/examples/cube/main.rs that makes sure textures work, but, considering it changes the shader significantly (adds a texture/sampler parameter and hardcode-replaces the sky shader), I'm not sure what I should do with it.