### PR TITLE
Pass in span to type translator, remove zombie_even_in_user_code

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -8,6 +8,7 @@ use rspirv::spirv::{StorageClass, Word};
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{FnAbiExt, TyAndLayout};
 use rustc_middle::ty::{GeneratorSubsts, PolyFnSig, Ty, TyKind, TypeAndMut};
+use rustc_span::Span;
 use rustc_target::abi::call::{CastTarget, FnAbi, PassMode, Reg, RegKind};
 use rustc_target::abi::{
     Abi, Align, FieldsShape, LayoutOf, Primitive, Scalar, Size, TagEncoding, Variants,
@@ -64,6 +65,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
     fn end(
         &self,
         cx: &CodegenCx<'tcx>,
+        span: Span,
         pointee: PointeeTy<'tcx>,
         storage_class: StorageClass,
         pointee_spv: Word,
@@ -80,7 +82,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
                         storage_class,
                         pointee: pointee_spv,
                     }
-                    .def(cx);
+                    .def(span, cx);
                     entry.insert(PointeeDefState::Defined(id));
                     id
                 }
@@ -92,7 +94,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
                         storage_class,
                         pointee: pointee_spv,
                     }
-                    .def_with_id(cx, id)
+                    .def_with_id(cx, span, id)
                 }
                 PointeeDefState::Defined(_) => {
                     bug!("RecursivePointeeCache::end defined pointer twice")
@@ -126,48 +128,48 @@ enum PointeeDefState {
 /// Various type-like things can be converted to a spirv type - normal types, function types, etc. - and this trait
 /// provides a uniform way of translating them.
 pub trait ConvSpirvType<'tcx> {
-    fn spirv_type(&self, cx: &CodegenCx<'tcx>) -> Word;
+    fn spirv_type(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word;
     /// spirv (and llvm) do not allow storing booleans in memory, they are abstract unsized values.
     /// So, if we're dealing with a "memory type", convert bool to u8. The opposite is an
     /// "immediate type", which keeps bools as bools. See also the functions `from_immediate` and
     /// `to_immediate`, which convert between the two.
-    fn spirv_type_immediate(&self, cx: &CodegenCx<'tcx>) -> Word {
-        self.spirv_type(cx)
+    fn spirv_type_immediate(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
+        self.spirv_type(span, cx)
     }
 }
 
 impl<'tcx> ConvSpirvType<'tcx> for PointeeTy<'tcx> {
-    fn spirv_type(&self, cx: &CodegenCx<'tcx>) -> Word {
+    fn spirv_type(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
         match *self {
-            PointeeTy::Ty(ty) => ty.spirv_type(cx),
-            PointeeTy::Fn(ty) => FnAbi::of_fn_ptr(cx, ty, &[]).spirv_type(cx),
+            PointeeTy::Ty(ty) => ty.spirv_type(span, cx),
+            PointeeTy::Fn(ty) => FnAbi::of_fn_ptr(cx, ty, &[]).spirv_type(span, cx),
         }
     }
-    fn spirv_type_immediate(&self, cx: &CodegenCx<'tcx>) -> Word {
+    fn spirv_type_immediate(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
         match *self {
-            PointeeTy::Ty(ty) => ty.spirv_type_immediate(cx),
-            PointeeTy::Fn(ty) => FnAbi::of_fn_ptr(cx, ty, &[]).spirv_type_immediate(cx),
+            PointeeTy::Ty(ty) => ty.spirv_type_immediate(span, cx),
+            PointeeTy::Fn(ty) => FnAbi::of_fn_ptr(cx, ty, &[]).spirv_type_immediate(span, cx),
         }
     }
 }
 
 impl<'tcx> ConvSpirvType<'tcx> for Reg {
-    fn spirv_type(&self, cx: &CodegenCx<'tcx>) -> Word {
+    fn spirv_type(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
         match self.kind {
-            RegKind::Integer => SpirvType::Integer(self.size.bits() as u32, false).def(cx),
-            RegKind::Float => SpirvType::Float(self.size.bits() as u32).def(cx),
+            RegKind::Integer => SpirvType::Integer(self.size.bits() as u32, false).def(span, cx),
+            RegKind::Float => SpirvType::Float(self.size.bits() as u32).def(span, cx),
             RegKind::Vector => SpirvType::Vector {
-                element: SpirvType::Integer(8, false).def(cx),
+                element: SpirvType::Integer(8, false).def(span, cx),
                 count: self.size.bytes() as u32,
             }
-            .def(cx),
+            .def(span, cx),
         }
     }
 }
 
 impl<'tcx> ConvSpirvType<'tcx> for CastTarget {
-    fn spirv_type(&self, cx: &CodegenCx<'tcx>) -> Word {
-        let rest_ll_unit = self.rest.unit.spirv_type(cx);
+    fn spirv_type(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
+        let rest_ll_unit = self.rest.unit.spirv_type(span, cx);
         let (rest_count, rem_bytes) = if self.rest.unit.size.bytes() == 0 {
             (0, 0)
         } else {
@@ -187,9 +189,9 @@ impl<'tcx> ConvSpirvType<'tcx> for CastTarget {
             if rem_bytes == 0 {
                 return SpirvType::Array {
                     element: rest_ll_unit,
-                    count: cx.constant_u32(rest_count as u32),
+                    count: cx.constant_u32(span, rest_count as u32),
                 }
-                .def(cx);
+                .def(span, cx);
             }
         }
 
@@ -203,7 +205,7 @@ impl<'tcx> ConvSpirvType<'tcx> for CastTarget {
                     kind,
                     size: self.prefix_chunk_size,
                 }
-                .spirv_type(cx)
+                .spirv_type(span, cx)
             })
             .chain((0..rest_count).map(|_| rest_ll_unit))
             .collect();
@@ -212,7 +214,7 @@ impl<'tcx> ConvSpirvType<'tcx> for CastTarget {
         if rem_bytes != 0 {
             // Only integers can be really split further.
             assert_eq!(self.rest.unit.kind, RegKind::Integer);
-            args.push(SpirvType::Integer(rem_bytes as u32 * 8, false).def(cx));
+            args.push(SpirvType::Integer(rem_bytes as u32 * 8, false).def(span, cx));
         }
 
         let size = Some(self.size(cx));
@@ -228,60 +230,70 @@ impl<'tcx> ConvSpirvType<'tcx> for CastTarget {
             field_offsets,
             field_names: None,
         }
-        .def(cx)
+        .def(span, cx)
     }
 }
 
 impl<'tcx> ConvSpirvType<'tcx> for FnAbi<'tcx, Ty<'tcx>> {
-    fn spirv_type(&self, cx: &CodegenCx<'tcx>) -> Word {
+    fn spirv_type(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
         let mut argument_types = Vec::new();
 
         let return_type = match self.ret.mode {
-            PassMode::Ignore => SpirvType::Void.def(cx),
-            PassMode::Direct(_) | PassMode::Pair(..) => self.ret.layout.spirv_type_immediate(cx),
-            PassMode::Cast(cast_target) => cast_target.spirv_type(cx),
+            PassMode::Ignore => SpirvType::Void.def(span, cx),
+            PassMode::Direct(_) | PassMode::Pair(..) => {
+                self.ret.layout.spirv_type_immediate(span, cx)
+            }
+            PassMode::Cast(cast_target) => cast_target.spirv_type(span, cx),
             PassMode::Indirect { .. } => {
-                let pointee = self.ret.layout.spirv_type(cx);
+                let pointee = self.ret.layout.spirv_type(span, cx);
                 let pointer = SpirvType::Pointer {
                     storage_class: StorageClass::Function,
                     pointee,
                 }
-                .def(cx);
+                .def(span, cx);
                 // Important: the return pointer comes *first*, not last.
                 argument_types.push(pointer);
-                SpirvType::Void.def(cx)
+                SpirvType::Void.def(span, cx)
             }
         };
 
         for arg in &self.args {
             let arg_type = match arg.mode {
                 PassMode::Ignore => continue,
-                PassMode::Direct(_) => arg.layout.spirv_type_immediate(cx),
+                PassMode::Direct(_) => arg.layout.spirv_type_immediate(span, cx),
                 PassMode::Pair(_, _) => {
-                    argument_types.push(scalar_pair_element_backend_type(cx, arg.layout, 0, true));
-                    argument_types.push(scalar_pair_element_backend_type(cx, arg.layout, 1, true));
+                    argument_types.push(scalar_pair_element_backend_type(
+                        cx, span, arg.layout, 0, true,
+                    ));
+                    argument_types.push(scalar_pair_element_backend_type(
+                        cx, span, arg.layout, 1, true,
+                    ));
                     continue;
                 }
-                PassMode::Cast(cast_target) => cast_target.spirv_type(cx),
+                PassMode::Cast(cast_target) => cast_target.spirv_type(span, cx),
                 PassMode::Indirect {
                     extra_attrs: Some(_),
                     ..
                 } => {
                     let ptr_ty = cx.tcx.mk_mut_ptr(arg.layout.ty);
                     let ptr_layout = cx.layout_of(ptr_ty);
-                    argument_types.push(scalar_pair_element_backend_type(cx, ptr_layout, 0, true));
-                    argument_types.push(scalar_pair_element_backend_type(cx, ptr_layout, 1, true));
+                    argument_types.push(scalar_pair_element_backend_type(
+                        cx, span, ptr_layout, 0, true,
+                    ));
+                    argument_types.push(scalar_pair_element_backend_type(
+                        cx, span, ptr_layout, 1, true,
+                    ));
                     continue;
                 }
                 PassMode::Indirect {
                     extra_attrs: None, ..
                 } => {
-                    let pointee = arg.layout.spirv_type(cx);
+                    let pointee = arg.layout.spirv_type(span, cx);
                     SpirvType::Pointer {
                         storage_class: StorageClass::Function,
                         pointee,
                     }
-                    .def(cx)
+                    .def(span, cx)
                 }
             };
             argument_types.push(arg_type);
@@ -291,23 +303,28 @@ impl<'tcx> ConvSpirvType<'tcx> for FnAbi<'tcx, Ty<'tcx>> {
             return_type,
             arguments: argument_types,
         }
-        .def(cx)
+        .def(span, cx)
     }
 }
 
 impl<'tcx> ConvSpirvType<'tcx> for TyAndLayout<'tcx> {
-    fn spirv_type(&self, cx: &CodegenCx<'tcx>) -> Word {
-        trans_type_impl(cx, *self, false)
+    fn spirv_type(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
+        trans_type_impl(cx, span, *self, false)
     }
-    fn spirv_type_immediate(&self, cx: &CodegenCx<'tcx>) -> Word {
-        trans_type_impl(cx, *self, true)
+    fn spirv_type_immediate(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
+        trans_type_impl(cx, span, *self, true)
     }
 }
 
-fn trans_type_impl<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>, is_immediate: bool) -> Word {
+fn trans_type_impl<'tcx>(
+    cx: &CodegenCx<'tcx>,
+    span: Span,
+    ty: TyAndLayout<'tcx>,
+    is_immediate: bool,
+) -> Word {
     if let TyKind::Adt(adt, _) = *ty.ty.kind() {
         for attr in parse_attrs(cx, cx.tcx.get_attrs(adt.did)) {
-            if let Some(image) = trans_image(cx, ty, attr) {
+            if let Some(image) = trans_image(cx, span, ty, attr) {
                 return image;
             }
         }
@@ -324,12 +341,12 @@ fn trans_type_impl<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>, is_immedia
             field_offsets: Vec::new(),
             field_names: None,
         }
-        .def(cx),
-        Abi::Scalar(ref scalar) => trans_scalar(cx, ty, scalar, None, is_immediate),
+        .def(span, cx),
+        Abi::Scalar(ref scalar) => trans_scalar(cx, span, ty, scalar, None, is_immediate),
         Abi::ScalarPair(ref one, ref two) => {
             // Note! Do not pass through is_immediate here - they're wrapped in a struct, hence, not immediate.
-            let one_spirv = trans_scalar(cx, ty, one, Some(0), false);
-            let two_spirv = trans_scalar(cx, ty, two, Some(1), false);
+            let one_spirv = trans_scalar(cx, span, ty, one, Some(0), false);
+            let two_spirv = trans_scalar(cx, span, ty, two, Some(1), false);
             // Note: We can't use auto_struct_layout here because the spirv types here might be undefined due to
             // recursive pointer types.
             let one_offset = Size::ZERO;
@@ -343,17 +360,17 @@ fn trans_type_impl<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>, is_immedia
                 field_offsets: vec![one_offset, two_offset],
                 field_names: None,
             }
-            .def(cx)
+            .def(span, cx)
         }
         Abi::Vector { ref element, count } => {
-            let elem_spirv = trans_scalar(cx, ty, element, None, is_immediate);
+            let elem_spirv = trans_scalar(cx, span, ty, element, None, is_immediate);
             SpirvType::Vector {
                 element: elem_spirv,
                 count: count as u32,
             }
-            .def(cx)
+            .def(span, cx)
         }
-        Abi::Aggregate { sized: _ } => trans_aggregate(cx, ty),
+        Abi::Aggregate { sized: _ } => trans_aggregate(cx, span, ty),
     }
 }
 
@@ -361,6 +378,7 @@ fn trans_type_impl<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>, is_immedia
 /// doing before calling this.
 pub fn scalar_pair_element_backend_type<'tcx>(
     cx: &CodegenCx<'tcx>,
+    span: Span,
     ty: TyAndLayout<'tcx>,
     index: usize,
     is_immediate: bool,
@@ -369,7 +387,7 @@ pub fn scalar_pair_element_backend_type<'tcx>(
         Abi::ScalarPair(a, b) => [a, b][index],
         other => bug!("scalar_pair_element_backend_type invalid abi: {:?}", other),
     };
-    trans_scalar(cx, ty, scalar, Some(index), is_immediate)
+    trans_scalar(cx, span, ty, scalar, Some(index), is_immediate)
 }
 
 /// A "scalar" is a basic building block: bools, ints, floats, pointers. (i.e. not something complex like a struct)
@@ -381,13 +399,14 @@ pub fn scalar_pair_element_backend_type<'tcx>(
 /// lead and doing what they want makes things go smoothly, so we'll implement it here too.
 fn trans_scalar<'tcx>(
     cx: &CodegenCx<'tcx>,
+    span: Span,
     ty: TyAndLayout<'tcx>,
     scalar: &Scalar,
     index: Option<usize>,
     is_immediate: bool,
 ) -> Word {
     if is_immediate && scalar.is_bool() {
-        return SpirvType::Bool.def(cx);
+        return SpirvType::Bool.def(span, cx);
     }
 
     match scalar.value {
@@ -395,10 +414,10 @@ fn trans_scalar<'tcx>(
             if cx.kernel_mode {
                 signedness = false;
             }
-            SpirvType::Integer(width.size().bits() as u32, signedness).def(cx)
+            SpirvType::Integer(width.size().bits() as u32, signedness).def(span, cx)
         }
-        Primitive::F32 => SpirvType::Float(32).def(cx),
-        Primitive::F64 => SpirvType::Float(64).def(cx),
+        Primitive::F32 => SpirvType::Float(32).def(span, cx),
+        Primitive::F64 => SpirvType::Float(64).def(span, cx),
         Primitive::Pointer => {
             let (storage_class, pointee_ty) = dig_scalar_pointee(cx, ty, index);
             // Default to function storage class.
@@ -412,10 +431,14 @@ fn trans_scalar<'tcx>(
             {
                 predefined_result
             } else {
-                let pointee = pointee_ty.spirv_type(cx);
-                cx.type_cache
-                    .recursive_pointee_cache
-                    .end(cx, pointee_ty, storage_class, pointee)
+                let pointee = pointee_ty.spirv_type(span, cx);
+                cx.type_cache.recursive_pointee_cache.end(
+                    cx,
+                    span,
+                    pointee_ty,
+                    storage_class,
+                    pointee,
+                )
             }
         }
     }
@@ -559,7 +582,7 @@ fn get_storage_class<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Optio
     None
 }
 
-fn trans_aggregate<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
+fn trans_aggregate<'tcx>(cx: &CodegenCx<'tcx>, span: Span, ty: TyAndLayout<'tcx>) -> Word {
     match ty.fields {
         FieldsShape::Primitive => cx.tcx.sess.fatal(&format!(
             "FieldsShape::Primitive not supported yet in trans_type: {:?}",
@@ -568,16 +591,16 @@ fn trans_aggregate<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
         FieldsShape::Union(_) => {
             assert_ne!(ty.size.bytes(), 0, "{:#?}", ty);
             assert!(!ty.is_unsized(), "{:#?}", ty);
-            let byte = SpirvType::Integer(8, false).def(cx);
-            let count = cx.constant_u32(ty.size.bytes() as u32);
+            let byte = SpirvType::Integer(8, false).def(span, cx);
+            let count = cx.constant_u32(span, ty.size.bytes() as u32);
             SpirvType::Array {
                 element: byte,
                 count,
             }
-            .def(cx)
+            .def(span, cx)
         }
         FieldsShape::Array { stride, count } => {
-            let element_type = trans_type_impl(cx, ty.field(cx, 0), false);
+            let element_type = trans_type_impl(cx, span, ty.field(cx, 0), false);
             if ty.is_unsized() {
                 // There's a potential for this array to be sized, but the element to be unsized, e.g. `[[u8]; 5]`.
                 // However, I think rust disallows all these cases, so assert this here.
@@ -585,7 +608,7 @@ fn trans_aggregate<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
                 SpirvType::RuntimeArray {
                     element: element_type,
                 }
-                .def(cx)
+                .def(span, cx)
             } else if count == 0 {
                 // spir-v doesn't support zero-sized arrays
                 SpirvType::Adt {
@@ -596,9 +619,9 @@ fn trans_aggregate<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
                     field_offsets: Vec::new(),
                     field_names: None,
                 }
-                .def(cx)
+                .def(span, cx)
             } else {
-                let count_const = cx.constant_u32(count as u32);
+                let count_const = cx.constant_u32(span, count as u32);
                 let element_spv = cx.lookup_type(element_type);
                 let stride_spv = element_spv
                     .sizeof(cx)
@@ -609,13 +632,13 @@ fn trans_aggregate<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
                     element: element_type,
                     count: count_const,
                 }
-                .def(cx)
+                .def(span, cx)
             }
         }
         FieldsShape::Arbitrary {
             offsets: _,
             memory_index: _,
-        } => trans_struct(cx, ty),
+        } => trans_struct(cx, span, ty),
     }
 }
 
@@ -645,7 +668,7 @@ pub fn auto_struct_layout<'tcx>(
 }
 
 // see struct_llfields in librustc_codegen_llvm for implementation hints
-fn trans_struct<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
+fn trans_struct<'tcx>(cx: &CodegenCx<'tcx>, span: Span, ty: TyAndLayout<'tcx>) -> Word {
     let name = name_of_struct(ty);
     if let TyKind::Foreign(_) = ty.ty.kind() {
         // "An unsized FFI type that is opaque to Rust", `extern type A;` (currently unstable)
@@ -655,7 +678,7 @@ fn trans_struct<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
             return SpirvType::Opaque {
                 name: "".to_string(),
             }
-            .def(cx);
+            .def(span, cx);
         }
         // otherwise fall back
     };
@@ -666,7 +689,7 @@ fn trans_struct<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
     let mut field_names = Vec::new();
     for i in ty.fields.index_by_increasing_offset() {
         let field_ty = ty.field(cx, i);
-        field_types.push(trans_type_impl(cx, field_ty, false));
+        field_types.push(trans_type_impl(cx, span, field_ty, false));
         let offset = ty.fields.offset(i);
         field_offsets.push(offset);
         if let Variants::Single { index } = ty.variants {
@@ -696,7 +719,7 @@ fn trans_struct<'tcx>(cx: &CodegenCx<'tcx>, ty: TyAndLayout<'tcx>) -> Word {
         field_offsets,
         field_names: Some(field_names),
     }
-    .def(cx)
+    .def(span, cx)
 }
 
 fn name_of_struct(ty: TyAndLayout<'_>) -> String {
@@ -715,6 +738,7 @@ fn name_of_struct(ty: TyAndLayout<'_>) -> String {
 
 fn trans_image<'tcx>(
     cx: &CodegenCx<'tcx>,
+    span: Span,
     ty: TyAndLayout<'tcx>,
     attr: SpirvAttribute,
 ) -> Option<Word> {
@@ -734,7 +758,7 @@ fn trans_image<'tcx>(
                 return None;
             }
             // Hardcode to float for now
-            let sampled_type = SpirvType::Float(32).def(cx);
+            let sampled_type = SpirvType::Float(32).def(span, cx);
             let ty = SpirvType::Image {
                 sampled_type,
                 dim,
@@ -745,7 +769,7 @@ fn trans_image<'tcx>(
                 image_format,
                 access_qualifier,
             };
-            Some(ty.def(cx))
+            Some(ty.def(span, cx))
         }
         SpirvAttribute::Sampler => {
             // see SpirvType::sizeof
@@ -753,7 +777,7 @@ fn trans_image<'tcx>(
                 cx.tcx.sess.err("#[spirv(sampler)] type must have size 4");
                 return None;
             }
-            Some(SpirvType::Sampler.def(cx))
+            Some(SpirvType::Sampler.def(span, cx))
         }
         _ => None,
     }

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -81,10 +81,10 @@ fn memset_dynamic_scalar(
     is_float: bool,
 ) -> Word {
     let composite_type = SpirvType::Vector {
-        element: SpirvType::Integer(8, false).def(builder),
+        element: SpirvType::Integer(8, false).def(builder.span(), builder),
         count: byte_width as u32,
     }
-    .def(builder);
+    .def(builder.span(), builder);
     let composite = builder
         .emit()
         .composite_construct(
@@ -100,7 +100,7 @@ fn memset_dynamic_scalar(
     };
     builder
         .emit()
-        .bitcast(result_type.def(builder), None, composite)
+        .bitcast(result_type.def(builder.span(), builder), None, composite)
         .unwrap()
 }
 
@@ -131,7 +131,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     | MemorySemantics::SEQUENTIALLY_CONSISTENT
             }
         };
-        let semantics = self.constant_u32(semantics.bits());
+        let semantics = self.constant_u32(self.span(), semantics.bits());
         if invalid_seq_cst {
             self.zombie(
                 semantics.def(self),
@@ -146,10 +146,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             SpirvType::Void => self.fatal("memset invalid on void pattern"),
             SpirvType::Bool => self.fatal("memset invalid on bool pattern"),
             SpirvType::Integer(width, _signedness) => match width {
-                8 => self.constant_u8(fill_byte).def(self),
-                16 => self.constant_u16(memset_fill_u16(fill_byte)).def(self),
-                32 => self.constant_u32(memset_fill_u32(fill_byte)).def(self),
-                64 => self.constant_u64(memset_fill_u64(fill_byte)).def(self),
+                8 => self.constant_u8(self.span(), fill_byte).def(self),
+                16 => self
+                    .constant_u16(self.span(), memset_fill_u16(fill_byte))
+                    .def(self),
+                32 => self
+                    .constant_u32(self.span(), memset_fill_u32(fill_byte))
+                    .def(self),
+                64 => self
+                    .constant_u64(self.span(), memset_fill_u64(fill_byte))
+                    .def(self),
                 _ => self.fatal(&format!(
                     "memset on integer width {} not implemented yet",
                     width
@@ -157,10 +163,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             },
             SpirvType::Float(width) => match width {
                 32 => self
-                    .constant_f32(f32::from_bits(memset_fill_u32(fill_byte)))
+                    .constant_f32(self.span(), f32::from_bits(memset_fill_u32(fill_byte)))
                     .def(self),
                 64 => self
-                    .constant_f64(f64::from_bits(memset_fill_u64(fill_byte)))
+                    .constant_f64(self.span(), f64::from_bits(memset_fill_u64(fill_byte)))
                     .def(self),
                 _ => self.fatal(&format!(
                     "memset on float width {} not implemented yet",
@@ -171,13 +177,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             SpirvType::Opaque { .. } => self.fatal("memset on opaque type is invalid"),
             SpirvType::Vector { element, count } => {
                 let elem_pat = self.memset_const_pattern(&self.lookup_type(element), fill_byte);
-                self.constant_composite(ty.clone().def(self), vec![elem_pat; count as usize])
-                    .def(self)
+                self.constant_composite(
+                    ty.clone().def(self.span(), self),
+                    vec![elem_pat; count as usize],
+                )
+                .def(self)
             }
             SpirvType::Array { element, count } => {
                 let elem_pat = self.memset_const_pattern(&self.lookup_type(element), fill_byte);
                 let count = self.builder.lookup_const_u64(count).unwrap() as usize;
-                self.constant_composite(ty.clone().def(self), vec![elem_pat; count])
+                self.constant_composite(ty.clone().def(self.span(), self), vec![elem_pat; count])
                     .def(self)
             }
             SpirvType::RuntimeArray { .. } => {
@@ -219,7 +228,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let count = self.builder.lookup_const_u64(count).unwrap() as usize;
                 self.emit()
                     .composite_construct(
-                        ty.clone().def(self),
+                        ty.clone().def(self.span(), self),
                         None,
                         std::iter::repeat(elem_pat).take(count),
                     )
@@ -229,7 +238,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let elem_pat = self.memset_dynamic_pattern(&self.lookup_type(element), fill_var);
                 self.emit()
                     .composite_construct(
-                        ty.clone().def(self),
+                        ty.clone().def(self.span(), self),
                         None,
                         std::iter::repeat(elem_pat).take(count as usize),
                     )
@@ -255,7 +264,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.store(pat, ptr, Align::from_bytes(0).unwrap());
         } else {
             for index in 0..count {
-                let const_index = self.constant_u32(index as u32);
+                let const_index = self.constant_u32(self.span(), index as u32);
                 let gep_ptr = self.gep(ptr, &[const_index]);
                 self.store(pat, gep_ptr, Align::from_bytes(0).unwrap());
             }
@@ -453,10 +462,6 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     }
 
     fn br(&mut self, dest: Self::BasicBlock) {
-        if !self.kernel_mode && self.basic_block == dest {
-            // TODO: Remove once structurizer is done.
-            self.zombie_even_in_user_code(dest, "Infinite loop before structurizer is done");
-        }
         self.emit().branch(dest).unwrap()
     }
 
@@ -667,7 +672,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         match self.lookup_type(val.ty) {
             SpirvType::Integer(_, _) => self.emit().not(val.ty, None, val.def(self)),
             SpirvType::Bool => {
-                let true_ = self.constant_bool(true);
+                let true_ = self.constant_bool(self.span(), true);
                 // intel-compute-runtime doesn't like OpLogicalNot
                 self.emit()
                     .logical_not_equal(val.ty, None, val.def(self), true_.def(self))
@@ -688,7 +693,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         lhs: Self::Value,
         rhs: Self::Value,
     ) -> (Self::Value, Self::Value) {
-        let fals = self.constant_bool(false);
+        let fals = self.constant_bool(self.span(), false);
         let result = match oop {
             OverflowOp::Add => (self.add(lhs, rhs), fals),
             OverflowOp::Sub => (self.sub(lhs, rhs), fals),
@@ -707,7 +712,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
     fn from_immediate(&mut self, val: Self::Value) -> Self::Value {
         if self.lookup_type(val.ty) == SpirvType::Bool {
-            let i8 = SpirvType::Integer(8, false).def(self);
+            let i8 = SpirvType::Integer(8, false).def(self.span(), self);
             self.zext(val, i8)
         } else {
             val
@@ -716,7 +721,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
     fn to_immediate_scalar(&mut self, val: Self::Value, scalar: &Scalar) -> Self::Value {
         if scalar.is_bool() {
-            let bool = SpirvType::Bool.def(self);
+            let bool = SpirvType::Bool.def(self.span(), self);
             return self.trunc(val, bool);
         }
         val
@@ -727,7 +732,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             storage_class: StorageClass::Function,
             pointee: ty,
         }
-        .def(self);
+        .def(self.span(), self);
         // "All OpVariable instructions in a function must be the first instructions in the first block."
         let mut builder = self.emit();
         builder.select_block(Some(0)).unwrap();
@@ -809,7 +814,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             )),
         };
         // TODO: Default to device scope
-        let memory = self.constant_u32(Scope::Device as u32);
+        let memory = self.constant_u32(self.span(), Scope::Device as u32);
         let semantics = self.ordering_to_semantics_def(order);
         let result = self
             .emit()
@@ -848,7 +853,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 // WARN! This does not go through to_immediate due to only having a Scalar, not a Ty, but it still does
                 // whatever to_immediate does!
                 if scalar.is_bool() {
-                    self.trunc(load, SpirvType::Bool.def(self))
+                    self.trunc(load, SpirvType::Bool.def(self.span(), self))
                 } else {
                     load
                 }
@@ -953,7 +958,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         };
         assert_ty_eq!(self, ptr_elem_ty, val.ty);
         // TODO: Default to device scope
-        let memory = self.constant_u32(Scope::Device as u32);
+        let memory = self.constant_u32(self.span(), Scope::Device as u32);
         let semantics = self.ordering_to_semantics_def(order);
         self.validate_atomic(val.ty, ptr.def(self));
         self.emit()
@@ -998,13 +1003,13 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             storage_class,
             pointee: result_pointee_type,
         }
-        .def(self);
+        .def(self.span(), self);
         // Important! LLVM, and therefore intel-compute-runtime, require the `getelementptr` instruction (and therefore
         // OpAccessChain) on structs to be a constant i32. Not i64! i32.
         if idx > u32::MAX as u64 {
             self.fatal("struct_gep bigger than u32::MAX");
         }
-        let index_const = self.constant_u32(idx as u32).def(self);
+        let index_const = self.constant_u32(self.span(), idx as u32).def(self);
         self.emit()
             .access_chain(
                 result_type,
@@ -1239,7 +1244,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         } else if let Some(indices) = self.try_pointercast_via_gep(val_pointee, dest_pointee) {
             let indices = indices
                 .into_iter()
-                .map(|idx| self.constant_u32(idx).def(self))
+                .map(|idx| self.constant_u32(self.span(), idx).def(self))
                 .collect::<Vec<_>>();
             self.emit()
                 .access_chain(dest_ty, None, val.def(self), indices)
@@ -1266,7 +1271,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         // Note: the signedness of the opcode doesn't have to match the signedness of the operands.
         use IntPredicate::*;
         assert_ty_eq!(self, lhs.ty, rhs.ty);
-        let b = SpirvType::Bool.def(self);
+        let b = SpirvType::Bool.def(self.span(), self);
         match self.lookup_type(lhs.ty) {
             SpirvType::Integer(_, _) => match op {
                 IntEQ => self.emit().i_equal(b, None, lhs.def(self), rhs.def(self)),
@@ -1407,7 +1412,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 // x > y  =>  x && !y
                 IntUGT => {
                     // intel-compute-runtime doesn't like OpLogicalNot
-                    let true_ = self.constant_bool(true);
+                    let true_ = self.constant_bool(self.span(), true);
                     let rhs = self
                         .emit()
                         .logical_not_equal(b, None, rhs.def(self), true_.def(self))
@@ -1416,7 +1421,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 }
                 // x >= y  =>  x || !y
                 IntUGE => {
-                    let true_ = self.constant_bool(true);
+                    let true_ = self.constant_bool(self.span(), true);
                     let rhs = self
                         .emit()
                         .logical_not_equal(b, None, rhs.def(self), true_.def(self))
@@ -1425,7 +1430,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 }
                 // x < y  =>  !x && y
                 IntULE => {
-                    let true_ = self.constant_bool(true);
+                    let true_ = self.constant_bool(self.span(), true);
                     let lhs = self
                         .emit()
                         .logical_not_equal(b, None, lhs.def(self), true_.def(self))
@@ -1434,7 +1439,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 }
                 // x <= y  =>  !x || y
                 IntULT => {
-                    let true_ = self.constant_bool(true);
+                    let true_ = self.constant_bool(self.span(), true);
                     let lhs = self
                         .emit()
                         .logical_not_equal(b, None, lhs.def(self), true_.def(self))
@@ -1458,10 +1463,10 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     fn fcmp(&mut self, op: RealPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
         use RealPredicate::*;
         assert_ty_eq!(self, lhs.ty, rhs.ty);
-        let b = SpirvType::Bool.def(self);
+        let b = SpirvType::Bool.def(self.span(), self);
         match op {
-            RealPredicateFalse => return self.cx.constant_bool(false),
-            RealPredicateTrue => return self.cx.constant_bool(true),
+            RealPredicateFalse => return self.cx.constant_bool(self.span(), false),
+            RealPredicateTrue => return self.cx.constant_bool(self.span(), true),
             RealOEQ => self
                 .emit()
                 .f_ord_equal(b, None, lhs.def(self), rhs.def(self)),
@@ -1659,7 +1664,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             element: elt.ty,
             count: num_elts as u32,
         }
-        .def(self);
+        .def(self.span(), self);
         if self.builder.lookup_const(elt).is_some() {
             self.constant_composite(result_type, vec![elt.def(self); num_elts])
         } else {
@@ -1789,7 +1794,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         assert_ty_eq!(self, dst_pointee_ty, src.ty);
         self.validate_atomic(dst_pointee_ty, dst.def(self));
         // TODO: Default to device scope
-        let memory = self.constant_u32(Scope::Device as u32);
+        let memory = self.constant_u32(self.span(), Scope::Device as u32);
         let semantics_equal = self.ordering_to_semantics_def(order);
         let semantics_unequal = self.ordering_to_semantics_def(failure_order);
         // Note: OpAtomicCompareExchangeWeak is deprecated, and has the same semantics
@@ -1828,7 +1833,9 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         assert_ty_eq!(self, dst_pointee_ty, src.ty);
         self.validate_atomic(dst_pointee_ty, dst.def(self));
         // TODO: Default to device scope
-        let memory = self.constant_u32(Scope::Device as u32).def(self);
+        let memory = self
+            .constant_u32(self.span(), Scope::Device as u32)
+            .def(self);
         let semantics = self.ordering_to_semantics_def(order).def(self);
         let mut emit = self.emit();
         use AtomicRmwBinOp::*;
@@ -1922,7 +1929,9 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     fn atomic_fence(&mut self, order: AtomicOrdering, _scope: SynchronizationScope) {
         // Ignore sync scope (it only has "single thread" and "cross thread")
         // TODO: Default to device scope
-        let memory = self.constant_u32(Scope::Device as u32).def(self);
+        let memory = self
+            .constant_u32(self.span(), Scope::Device as u32)
+            .def(self);
         let semantics = self.ordering_to_semantics_def(order).def(self);
         self.emit().memory_barrier(memory, semantics).unwrap();
     }

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -160,14 +160,16 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
     fn insert_inst(&mut self, id_map: &mut HashMap<&str, Word>, inst: dr::Instruction) {
         // Types declared must be registered in our type system.
         let new_result_id = match inst.class.opcode {
-            Op::TypeVoid => SpirvType::Void.def(self),
-            Op::TypeBool => SpirvType::Bool.def(self),
+            Op::TypeVoid => SpirvType::Void.def(self.span(), self),
+            Op::TypeBool => SpirvType::Bool.def(self.span(), self),
             Op::TypeInt => SpirvType::Integer(
                 inst.operands[0].unwrap_literal_int32(),
                 inst.operands[1].unwrap_literal_int32() != 0,
             )
-            .def(self),
-            Op::TypeFloat => SpirvType::Float(inst.operands[0].unwrap_literal_int32()).def(self),
+            .def(self.span(), self),
+            Op::TypeFloat => {
+                SpirvType::Float(inst.operands[0].unwrap_literal_int32()).def(self.span(), self)
+            }
             Op::TypeStruct => {
                 self.err("OpTypeStruct in asm! is not supported yet");
                 return;
@@ -175,12 +177,12 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             Op::TypeOpaque => SpirvType::Opaque {
                 name: inst.operands[0].unwrap_literal_string().to_string(),
             }
-            .def(self),
+            .def(self.span(), self),
             Op::TypeVector => SpirvType::Vector {
                 element: inst.operands[0].unwrap_id_ref(),
                 count: inst.operands[0].unwrap_literal_int32(),
             }
-            .def(self),
+            .def(self.span(), self),
             Op::TypeArray => {
                 self.err("OpTypeArray in asm! is not supported yet");
                 return;

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -10,31 +10,32 @@ use rustc_middle::mir::interpret::{read_target_uint, Allocation, GlobalAlloc, Po
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_mir::interpret::Scalar;
 use rustc_span::symbol::Symbol;
+use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::{self, AddressSpace, HasDataLayout, LayoutOf, Primitive, Size};
 
 impl<'tcx> CodegenCx<'tcx> {
-    pub fn constant_u8(&self, val: u8) -> SpirvValue {
-        let ty = SpirvType::Integer(8, false).def(self);
+    pub fn constant_u8(&self, span: Span, val: u8) -> SpirvValue {
+        let ty = SpirvType::Integer(8, false).def(span, self);
         self.builder.def_constant(SpirvConst::U32(ty, val as u32))
     }
 
-    pub fn constant_u16(&self, val: u16) -> SpirvValue {
-        let ty = SpirvType::Integer(16, false).def(self);
+    pub fn constant_u16(&self, span: Span, val: u16) -> SpirvValue {
+        let ty = SpirvType::Integer(16, false).def(span, self);
         self.builder.def_constant(SpirvConst::U32(ty, val as u32))
     }
 
-    pub fn constant_i32(&self, val: i32) -> SpirvValue {
-        let ty = SpirvType::Integer(32, !self.kernel_mode).def(self);
+    pub fn constant_i32(&self, span: Span, val: i32) -> SpirvValue {
+        let ty = SpirvType::Integer(32, !self.kernel_mode).def(span, self);
         self.builder.def_constant(SpirvConst::U32(ty, val as u32))
     }
 
-    pub fn constant_u32(&self, val: u32) -> SpirvValue {
-        let ty = SpirvType::Integer(32, false).def(self);
+    pub fn constant_u32(&self, span: Span, val: u32) -> SpirvValue {
+        let ty = SpirvType::Integer(32, false).def(span, self);
         self.builder.def_constant(SpirvConst::U32(ty, val))
     }
 
-    pub fn constant_u64(&self, val: u64) -> SpirvValue {
-        let ty = SpirvType::Integer(64, false).def(self);
+    pub fn constant_u64(&self, span: Span, val: u64) -> SpirvValue {
+        let ty = SpirvType::Integer(64, false).def(span, self);
         self.builder.def_constant(SpirvConst::U64(ty, val))
     }
 
@@ -80,14 +81,14 @@ impl<'tcx> CodegenCx<'tcx> {
         }
     }
 
-    pub fn constant_f32(&self, val: f32) -> SpirvValue {
-        let ty = SpirvType::Float(32).def(self);
+    pub fn constant_f32(&self, span: Span, val: f32) -> SpirvValue {
+        let ty = SpirvType::Float(32).def(span, self);
         self.builder
             .def_constant(SpirvConst::F32(ty, val.to_bits()))
     }
 
-    pub fn constant_f64(&self, val: f64) -> SpirvValue {
-        let ty = SpirvType::Float(64).def(self);
+    pub fn constant_f64(&self, span: Span, val: f64) -> SpirvValue {
+        let ty = SpirvType::Float(64).def(span, self);
         self.builder
             .def_constant(SpirvConst::F64(ty, val.to_bits()))
     }
@@ -107,8 +108,8 @@ impl<'tcx> CodegenCx<'tcx> {
         }
     }
 
-    pub fn constant_bool(&self, val: bool) -> SpirvValue {
-        let ty = SpirvType::Bool.def(self);
+    pub fn constant_bool(&self, span: Span, val: bool) -> SpirvValue {
+        let ty = SpirvType::Bool.def(span, self);
         self.builder.def_constant(SpirvConst::Bool(ty, val))
     }
 
@@ -142,24 +143,24 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
         self.constant_int(t, u as u64)
     }
     fn const_bool(&self, val: bool) -> Self::Value {
-        self.constant_bool(val)
+        self.constant_bool(DUMMY_SP, val)
     }
     fn const_i32(&self, i: i32) -> Self::Value {
-        self.constant_i32(i)
+        self.constant_i32(DUMMY_SP, i)
     }
     fn const_u32(&self, i: u32) -> Self::Value {
-        self.constant_u32(i)
+        self.constant_u32(DUMMY_SP, i)
     }
     fn const_u64(&self, i: u64) -> Self::Value {
-        self.constant_u64(i)
+        self.constant_u64(DUMMY_SP, i)
     }
     fn const_usize(&self, i: u64) -> Self::Value {
         let ptr_size = self.tcx.data_layout.pointer_size.bits() as u32;
-        let t = SpirvType::Integer(ptr_size, false).def(self);
+        let t = SpirvType::Integer(ptr_size, false).def(DUMMY_SP, self);
         self.constant_int(t, i)
     }
     fn const_u8(&self, i: u8) -> Self::Value {
-        self.constant_u8(i)
+        self.constant_u8(DUMMY_SP, i)
     }
     fn const_real(&self, t: Self::Type, val: f64) -> Self::Value {
         self.constant_float(t, val)
@@ -167,7 +168,10 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
 
     fn const_str(&self, s: Symbol) -> (Self::Value, Self::Value) {
         let len = s.as_str().len();
-        let ty = self.type_ptr_to(self.layout_of(self.tcx.types.str_).spirv_type(self));
+        let ty = self.type_ptr_to(
+            self.layout_of(self.tcx.types.str_)
+                .spirv_type(DUMMY_SP, self),
+        );
         let result = self.undef(ty);
         self.zombie_no_span(result.def_cx(self), "constant string");
         (result, self.const_usize(len as u64))
@@ -184,7 +188,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
             field_offsets,
             field_names: None,
         }
-        .def(self);
+        .def(DUMMY_SP, self);
         self.constant_composite(struct_ty, elts.iter().map(|f| f.def_cx(self)).collect())
     }
 
@@ -222,8 +226,8 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
                             self.constant_int(ty, data as u64)
                         }
                         SpirvType::Bool => match data {
-                            0 => self.constant_bool(false),
-                            1 => self.constant_bool(true),
+                            0 => self.constant_bool(DUMMY_SP, false),
+                            1 => self.constant_bool(DUMMY_SP, true),
                             _ => self
                                 .tcx
                                 .sess
@@ -235,12 +239,12 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
                         )),
                     },
                     Primitive::F32 => {
-                        let res = self.constant_f32(f32::from_bits(data as u32));
+                        let res = self.constant_f32(DUMMY_SP, f32::from_bits(data as u32));
                         assert_eq!(res.ty, ty);
                         res
                     }
                     Primitive::F64 => {
-                        let res = self.constant_f64(f64::from_bits(data as u64));
+                        let res = self.constant_f64(DUMMY_SP, f64::from_bits(data as u64));
                         assert_eq!(res.ty, ty);
                         res
                     }
@@ -322,7 +326,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
         offset: Size,
     ) -> PlaceRef<'tcx, Self::Value> {
         assert_eq!(offset, Size::ZERO);
-        let ty = layout.spirv_type(self);
+        let ty = layout.spirv_type(DUMMY_SP, self);
         let init = self.create_const_alloc(alloc, ty);
         let result = self.static_addr_of(init, alloc.align, None);
         PlaceRef::new_sized(result, layout)
@@ -368,7 +372,9 @@ impl<'tcx> CodegenCx<'tcx> {
                 .tcx
                 .sess
                 .fatal("Cannot create const alloc of type void"),
-            SpirvType::Bool => self.constant_bool(self.read_alloc_val(alloc, offset, 1) != 0),
+            SpirvType::Bool => {
+                self.constant_bool(DUMMY_SP, self.read_alloc_val(alloc, offset, 1) != 0)
+            }
             SpirvType::Integer(width, _) => {
                 let v = self.read_alloc_val(alloc, offset, (width / 8) as usize);
                 self.constant_int(ty, v as u64)
@@ -376,8 +382,8 @@ impl<'tcx> CodegenCx<'tcx> {
             SpirvType::Float(width) => {
                 let v = self.read_alloc_val(alloc, offset, (width / 8) as usize);
                 match width {
-                    32 => self.constant_f32(f32::from_bits(v as u32)),
-                    64 => self.constant_f64(f64::from_bits(v as u64)),
+                    32 => self.constant_f32(DUMMY_SP, f32::from_bits(v as u32)),
+                    64 => self.constant_f64(DUMMY_SP, f64::from_bits(v as u64)),
                     other => self
                         .tcx
                         .sess

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -35,23 +35,23 @@ impl<'tcx> LayoutOf for CodegenCx<'tcx> {
 
 impl<'tcx> LayoutTypeMethods<'tcx> for CodegenCx<'tcx> {
     fn backend_type(&self, layout: TyAndLayout<'tcx>) -> Self::Type {
-        layout.spirv_type(self)
+        layout.spirv_type(DUMMY_SP, self)
     }
 
     fn cast_backend_type(&self, ty: &CastTarget) -> Self::Type {
-        ty.spirv_type(self)
+        ty.spirv_type(DUMMY_SP, self)
     }
 
     fn fn_ptr_backend_type(&self, fn_abi: &FnAbi<'tcx, Ty<'tcx>>) -> Self::Type {
-        fn_abi.spirv_type(self)
+        fn_abi.spirv_type(DUMMY_SP, self)
     }
 
     fn reg_backend_type(&self, ty: &Reg) -> Self::Type {
-        ty.spirv_type(self)
+        ty.spirv_type(DUMMY_SP, self)
     }
 
     fn immediate_backend_type(&self, layout: TyAndLayout<'tcx>) -> Self::Type {
-        layout.spirv_type_immediate(self)
+        layout.spirv_type_immediate(DUMMY_SP, self)
     }
 
     fn is_backend_immediate(&self, layout: TyAndLayout<'tcx>) -> bool {
@@ -92,46 +92,46 @@ impl<'tcx> LayoutTypeMethods<'tcx> for CodegenCx<'tcx> {
         index: usize,
         immediate: bool,
     ) -> Self::Type {
-        crate::abi::scalar_pair_element_backend_type(self, layout, index, immediate)
+        crate::abi::scalar_pair_element_backend_type(self, DUMMY_SP, layout, index, immediate)
     }
 }
 
 impl<'tcx> CodegenCx<'tcx> {
     pub fn type_usize(&self) -> Word {
         let ptr_size = self.tcx.data_layout.pointer_size.bits() as u32;
-        SpirvType::Integer(ptr_size, false).def(self)
+        SpirvType::Integer(ptr_size, false).def(DUMMY_SP, self)
     }
 }
 
 impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
     fn type_i1(&self) -> Self::Type {
-        SpirvType::Bool.def(self)
+        SpirvType::Bool.def(DUMMY_SP, self)
     }
     fn type_i8(&self) -> Self::Type {
-        SpirvType::Integer(8, false).def(self)
+        SpirvType::Integer(8, false).def(DUMMY_SP, self)
     }
     fn type_i16(&self) -> Self::Type {
-        SpirvType::Integer(16, false).def(self)
+        SpirvType::Integer(16, false).def(DUMMY_SP, self)
     }
     fn type_i32(&self) -> Self::Type {
-        SpirvType::Integer(32, false).def(self)
+        SpirvType::Integer(32, false).def(DUMMY_SP, self)
     }
     fn type_i64(&self) -> Self::Type {
-        SpirvType::Integer(64, false).def(self)
+        SpirvType::Integer(64, false).def(DUMMY_SP, self)
     }
     fn type_i128(&self) -> Self::Type {
-        SpirvType::Integer(128, false).def(self)
+        SpirvType::Integer(128, false).def(DUMMY_SP, self)
     }
     fn type_isize(&self) -> Self::Type {
         let ptr_size = self.tcx.data_layout.pointer_size.bits() as u32;
-        SpirvType::Integer(ptr_size, false).def(self)
+        SpirvType::Integer(ptr_size, false).def(DUMMY_SP, self)
     }
 
     fn type_f32(&self) -> Self::Type {
-        SpirvType::Float(32).def(self)
+        SpirvType::Float(32).def(DUMMY_SP, self)
     }
     fn type_f64(&self) -> Self::Type {
-        SpirvType::Float(64).def(self)
+        SpirvType::Float(64).def(DUMMY_SP, self)
     }
 
     fn type_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type {
@@ -139,7 +139,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             return_type: ret,
             arguments: args.to_vec(),
         }
-        .def(self)
+        .def(DUMMY_SP, self)
     }
     fn type_struct(&self, els: &[Self::Type], _packed: bool) -> Self::Type {
         let (field_offsets, size, align) = crate::abi::auto_struct_layout(self, els);
@@ -151,7 +151,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             field_offsets,
             field_names: None,
         }
-        .def(self)
+        .def(DUMMY_SP, self)
     }
     fn type_kind(&self, ty: Self::Type) -> TypeKind {
         match self.lookup_type(ty) {
@@ -183,14 +183,14 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             storage_class: StorageClass::Function,
             pointee: ty,
         }
-        .def(self)
+        .def(DUMMY_SP, self)
     }
     fn type_ptr_to_ext(&self, ty: Self::Type, _address_space: AddressSpace) -> Self::Type {
         SpirvType::Pointer {
             storage_class: StorageClass::Function,
             pointee: ty,
         }
-        .def(self)
+        .def(DUMMY_SP, self)
     }
     fn element_type(&self, ty: Self::Type) -> Self::Type {
         match self.lookup_type(ty) {


### PR DESCRIPTION
This is pre-work to clean up the zombie system, tangentially related to fixing https://github.com/EmbarkStudios/rust-gpu/issues/274

This does two things:

- Removes the two remaining calls to zombie_even_in_user_code (other calls were cleaned up in previous PRs)
- Passes in a span to the type translator to improve error messages

The second bit causes a _lot_ of diff spam, so I'm submitting this as a separate PR. I did so because tracking down the errors caused by the type translator are absolutely horrible to figure out without span information (it's completely opaque what's going on). Unfortunately, quite a few places don't have span information, but still, most do, and those cases are useful. Examples of places without spans are `rustc_codegen_ssa` APIs that ask for, say, the type for a u64, completely without context or other information. So, we avoid calling those APIs ourselves, and instead try to call wrapper methods that _do_ take spans, hopefully minimizing the cases where that happens. `DUMMY_SP` is used where spans are not available.