### PR TITLE
Do not merge zombie and non-zombies

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
+++ b/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
@@ -39,6 +39,7 @@ fn find_import_export_pairs_and_killed_params(
             return Err(ErrorReported);
         }
     }
+    let mut has_err = false;
     // Then, collect all the imports, and create the rewrite rules.
     for annotation in &module.annotations {
         let (import_id, name) = match get_linkage_inst(annotation) {
@@ -48,7 +49,8 @@ fn find_import_export_pairs_and_killed_params(
         let (export_id, export_type) = match exports.get(name) {
             None => {
                 sess.err(&format!("Unresolved symbol {:?}", name));
-                return Err(ErrorReported);
+                has_err = true;
+                continue;
             }
             Some(&x) => x,
         };
@@ -61,6 +63,9 @@ fn find_import_export_pairs_and_killed_params(
                 killed_parameters.insert(param);
             }
         }
+    }
+    if has_err {
+        return Err(ErrorReported);
     }
 
     Ok((rewrite_rules, killed_parameters))

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -97,6 +97,23 @@ OpFunctionEnd"#,
     );
 }
 
+// TODO: While the "checked sub is not implemented yet" issue is fixed and so this repro should be
+// fixed, a further underlying issue gets triggered instead, which is that the current structurizer
+// doesn't handle this case. Remove `#[ignore]` once fixed.
+#[test]
+#[ignore]
+fn logical_and() {
+    val(r#"
+fn f(x: bool, y: bool) -> bool {
+    x && y
+}
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    f(false, true);
+}"#);
+}
+
 // TODO: Implement strings to make this compile
 #[test]
 #[ignore]


### PR DESCRIPTION
Fixes https://github.com/EmbarkStudios/rust-gpu/issues/274

Tried to do a clever with refactoring the whole zombie system to be much cooler and failed, so, this is just the simple patch onto the current system.

The test case would likely be fine with https://github.com/EmbarkStudios/rust-gpu/pull/287 in, but oh well, `#[ignore]` it is. Heck, 287 could revert its change to `result.1.def(self)` if _this_ was in. What a race condition, wau!

---

... also the changes to `import_export_link.rs` are completely unrelated, sorry, just got annoyed by poor error messages when debugging my failed refactor.