### PR TITLE
Split introduction into two separate sections

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,6 +2,8 @@
 
 - [Introduction](./introduction.md)
 - [Attribute syntax](./attributes.md)
+- [Building Rust-GPU](./building-rust-gpu.md)
 - [Platform Support](./platform-support.md)
+- [Writing Shader Crates](./writing-shader-crates.md)
 - [RFCs]()
     - [001. Resource Binding Syntax](./rfcs/001-resource-binding-syntax.md)

--- a/docs/src/building-rust-gpu.md
+++ b/docs/src/building-rust-gpu.md
@@ -1,0 +1,57 @@
+# Building Rust-GPU
+
+## Getting started
+1. Clone the repository.
+
+    ```shell
+    git clone --recurse-submodules https://github.com/EmbarkStudios/rust-gpu
+    ```
+
+1. Install the prerequisites using the provided setup script. From the root of the project, run:
+
+    MacOS, Linux:
+
+    ```shell
+    sh setup.sh
+    ```
+
+    Windows:
+
+    ```shell
+    setup.bat
+    ```
+
+    The setup script installs nightly Rust (required for now, see [#78](https://github.com/EmbarkStudios/rust-gpu/issues/78) for tracking issue).
+
+1. **optional** Install [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools#downloads) and add it to your `PATH`. You can skip this step if you just want to run examples with the defaults. See [Using installed SPIRV-Tools](#using-installed-spirv-tools) if you decide to go with this option.
+
+1. Next, look at the [examples] folder. There are two kinds of targets here: [runners] and [shaders]. The projects inside `shaders` are "GPU crates", i.e. ones that will be compiled one or more SPIR-V modules. The `runner` projects are normal, CPU crates that use some graphics backend (currently, we have a [`wgpu` runner][examples/runners/wgpu], a [Vulkan runner][examples/runners/ash] through `ash`, and a barebones pure software [CPU runner][examples/runners/cpu]) to actually run one of the "GPU crate" shaders.
+
+    Run the example:
+
+    ```shell
+    cargo run --bin example-runner-wgpu
+    ```
+
+    This will build `rustc_codegen_spirv`, the compiler, then use that compiler to build [`sky-shader`](examples/shaders/sky-shader) into a SPIR-V module, then finally, build a `wgpu` sample app (modified from [`wgpu`'s examples](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/hello-triangle)) using the built SPIR-V module to display the shader in a window.
+
+## Using installed SPIRV-Tools
+
+By default, all of the crates and examples in this repo will compile the [`spirv-tools-sys`](https://crates.io/crates/spirv-tools-sys) crate, including a lot of C++ code from [SPIRV-Tools](https://github.com/EmbarkStudios/SPIRV-Tools). If you don't want to build the C++ code because you already have [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools#downloads) installed, or just don't want to spend more time compiling, you can build/run the crate with the `use-installed-tools` feature.
+
+```shell
+cargo run \
+    --manifest-path examples/example-runner/Cargo.toml \
+    --features use-installed-tools \
+    --no-default-features
+```
+
+You should see `warning: use-installed-tools feature on, skipping compilation of C++ code` during the compilation, but otherwise the build will function just the same as if you compiled the C++ code, with the exception that it will fail if you don't have SPIRV-Tools installed correctly.
+
+[spirv-builder]: https://embarkstudios.github.io/rust-gpu/api/spirv_builder/index.html
+[examples]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples
+[examples/runners]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners
+[examples/runners/ash]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners/ash
+[examples/runners/cpu]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners/cpu
+[examples/runners/wgpu]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners/wgpu
+[examples/shaders]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/shaders

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -3,86 +3,10 @@
 Welcome to the Rust-GPU dev guide! This documentation is meant for documenting
 how to use and develop on Rust-GPU.
 
-## Getting started
+If you're looking to get started with writing your own shaders in Rust, 
+check out the [_"Writing Shader Crates"_](./writing-shader-crates.md) section for
+more information on how to get started.
 
-1. Clone the repository.
+Alternatively if you're looking to contribute to the `rust-gpu` project, have
+a look at [_"Building Rust-GPU"_](./building-rust-gpu.md) section.
 
-    ```shell
-    git clone --recurse-submodules https://github.com/EmbarkStudios/rust-gpu
-    ```
-
-1. Install the prerequisites using the provided setup script. From the root of the project, run:
-
-    MacOS, Linux:
-
-    ```shell
-    sh setup.sh
-    ```
-
-    Windows:
-
-    ```shell
-    setup.bat
-    ```
-
-    The setup script installs nightly Rust (required for now, see [#78](https://github.com/EmbarkStudios/rust-gpu/issues/78) for tracking issue).
-
-1. **optional** Install [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools#downloads) and add it to your `PATH`. You can skip this step if you just want to run examples with the defaults. See [Using installed SPIRV-Tools](#using-installed-spirv-tools) if you decide to go with this option.
-
-1. Next, look at the [examples] folder. There are two kinds of targets here: [runners] and [shaders]. The projects inside `shaders` are "GPU crates", i.e. ones that will be compiled one or more SPIR-V modules. The `runner` projects are normal, CPU crates that use some graphics backend (currently, we have a [`wgpu` runner][examples/runners/wgpu], a [Vulkan runner][examples/runners/ash] through `ash`, and a barebones pure software [CPU runner][examples/runners/cpu]) to actually run one of the "GPU crate" shaders.
-
-    Run the example:
-
-    ```shell
-    cargo run --bin example-runner-wgpu
-    ```
-
-    This will build `rustc_codegen_spirv`, the compiler, then use that compiler to build [`sky-shader`](examples/shaders/sky-shader) into a SPIR-V module, then finally, build a `wgpu` sample app (modified from [`wgpu`'s examples](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/hello-triangle)) using the built SPIR-V module to display the shader in a window.
-
-    All of this is orchestrated by the [spirv-builder] crate, which is used in each of the example runners' [`build.rs` files](examples/runners/wgpu/build.rs). Please look at that file, as well as both example projects in general, to see how to set up your own shaders!
-
-Be aware that this project is in a very early phase - if the above doesn't work, please [file an issue](https://github.com/EmbarkStudios/rust-gpu/issues)!
-
-## Getting started, for power users who don't want to use spirv-builder
-
-If you would like to build the compiler, `rustc_codegen_spirv` is the relevant folder. Install the prerequisites, as above, then, `cd rustc_codegen_spirv && cargo build`. This produces an .so file, located at `./target/debug/librustc_codegen_spirv.so` (or `.dll`/`.dylib` depending on your platform).
-
-This file is a dynamically loaded backend for rustc - you may tell rustc to use it as a backend through the `-Z codegen-backend=...` flag. To pass this to rustc through cargo, set the environment variable `RUSTFLAGS="-Z codegen-backend=$PATH_TO_FILE"`.
-
-Then, when building a GPU crate, we need to configure some flags when we call cargo. First, we need to build libcore ourselves - we obviously have no SPIR-V libcore installed on our system! Use the flag `-Z build-std=core`. Then, we need to tell rustc to generate SPIR-V instead of x86 code: `--target spirv-unknown-unknown`.
-
-Overall, building your own SPIR-V crate looks like:
-
-```shell
-export RUSTFLAGS="-Zcodegen-backend=$THIS_REPO/target/debug/librustc_codegen_spirv.so"
-cargo build -Z build-std=core --target spirv-unknown-unknown --release
-```
-
-(with an appropriate path for `$THIS_REPO`, and replacing `export` with `set` if you're on windows as well as the proper dll name)
-
-This will produce a `target/spirv-unknown-unknown/release/crate_name.spv` file.
-
-To create a GPU crate, look at the crates in [examples/shaders]. In short, reference the `spirv-std` crate, and use intrinsics defined there to create your shader.
-
-This is all a little convoluted, hence the [spirv-builder] crate handles a lot of this.
-
-## Using installed SPIRV-Tools
-
-By default, all of the crates and examples in this repo will compile the [`spirv-tools-sys`](https://crates.io/crates/spirv-tools-sys) crate, including a lot of C++ code from [SPIRV-Tools](https://github.com/EmbarkStudios/SPIRV-Tools). If you don't want to build the C++ code because you already have [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools#downloads) installed, or just don't want to spend more time compiling, you can build/run the crate with the `use-installed-tools` feature.
-
-```shell
-cargo run \
-    --manifest-path examples/example-runner/Cargo.toml \
-    --features use-installed-tools \
-    --no-default-features
-```
-
-You should see `warning: use-installed-tools feature on, skipping compilation of C++ code` during the compilation, but otherwise the build will function just the same as if you compiled the C++ code, with the exception that it will fail if you don't have SPIRV-Tools installed correctly.
-
-[spirv-builder]: https://embarkstudios.github.io/rust-gpu/api/spirv_builder/index.html
-[examples]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples
-[examples/runners]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners
-[examples/runners/ash]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners/ash
-[examples/runners/cpu]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners/cpu
-[examples/runners/wgpu]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/runners/wgpu
-[examples/shaders]: https://github.com/EmbarkStudios/rust-gpu/tree/main/examples/shaders

--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -1,0 +1,75 @@
+# Writing Shader Crates
+
+This is section is going to walk you through writing a shader in Rust and
+setting up your shader crate.
+
+Be aware that this project is in a very early phase, please [file an
+issue](https://github.com/EmbarkStudios/rust-gpu/issues) if there's something
+not working or unclear.
+
+## Setup
+There are two main ways to setup your shader project.
+
+1. Using the `spirv-builder` crate.
+   The `spirv-builder` is a crate designed to automate the process of building
+   and linking the `rust-gpu` to be able to compile SPIR-V shaders into your
+   main Rust crate.
+2. Using `.cargo/config`.
+   Alternatively if you're willing to do the setup yourself you can manually set
+   flags in your cargo configuration to enable you to run `cargo build` in your
+   shader crate.
+
+
+### Using `spirv-builder`
+If you're writing a bigger application and you want to integrate SPIR-V shader
+crates to display, it's recommended to use `spirv-builder` in a build script.
+
+#### `build.rs`
+```rust,no_run
+SpirvBuilder::new(path_to_shader)
+        .spirv_version(1, 0)
+        .print_metadata()
+        .build()?;
+```
+
+#### `main.rs`
+```rust,no_run
+const SHADER: &[u8] = include_bytes!(env!("<shader_name>.spv"));
+```
+
+### Using `.cargo/config`
+If you just want to compile a build a shader crate, and don't need to
+automatically compile the SPIR-V binary at build time, you can use
+`.cargo/config` to set the necessary flags. Before you can do that however you
+need to do a couple of steps first to build the compiler backend.
+
+1. Clone the `rust-gpu` repository
+2. `cargo build --release`
+
+Now you should have a `librustc_codegen_spirv` dynamic library available in
+`target/release`. You'll need to keep this somewhere stable that you can
+reference from your shader project.
+
+Now we need to add our `.cargo/config` file. This tells cargo to build for the
+`spirv-unknown-unknown` target, and provides a path to the codegen backend for
+that target. We have to also provide `-Zbuild-std` as the
+`spirv-unknown-unknown` sysroot is not currently available in the
+default installation.
+
+
+```toml
+[build]
+target = "spirv-unknown-unknown"
+rustflags = ["-Zcodegen-backend=<path_to_librustc_codegen_spirv>"]
+
+[unstable]
+build-std=["core"]
+```
+
+Now we can build our crate with cargo as normal. 
+```bash
+cargo build
+```
+
+Now you should have `<project_name>.spv` SPIR-V file in `target/debug` that you
+can give to a renderer.


### PR DESCRIPTION
This splits up the introduction into two separate sections, one focused on users who want to write shader crates, and the other who want to contribute to Rust-GPU directly.