### PR TITLE
`#[spirv(block)]` for `Block` decorations on `struct`s.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -187,6 +187,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
             field_types,
             field_offsets,
             field_names: None,
+            is_block: false,
         }
         .def(DUMMY_SP, self);
         self.constant_composite(struct_ty, elts.iter().map(|f| f.def_cx(self)).collect())

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -150,6 +150,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             field_types: els.to_vec(),
             field_offsets,
             field_names: None,
+            is_block: false,
         }
         .def(DUMMY_SP, self)
     }

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -118,6 +118,7 @@ use rustc_session::Session;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_target::spec::abi::Abi;
 use rustc_target::spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetTriple};
+pub use spirv_tools;
 use std::any::Any;
 use std::env;
 use std::fs::{create_dir_all, File};

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -336,6 +336,7 @@ impl Symbols {
                 SpirvAttribute::ReallyUnsafeIgnoreBitcasts,
             ),
             ("sampler", SpirvAttribute::Sampler),
+            ("block", SpirvAttribute::Block),
         ]
         .iter()
         .cloned();
@@ -451,6 +452,7 @@ pub enum SpirvAttribute {
         access_qualifier: Option<AccessQualifier>,
     },
     Sampler,
+    Block,
 }
 
 // Note that we could mark the attr as used via cx.tcx.sess.mark_attr_used(attr), but unused

--- a/crates/spirv-builder/src/test/mod.rs
+++ b/crates/spirv-builder/src/test/mod.rs
@@ -90,6 +90,25 @@ fn val(src: &str) {
     build(src);
 }
 
+/// While `val` runs baseline SPIR-V validation, for some tests we want the
+/// stricter Vulkan validation (`vulkan1.2` specifically), which may produce
+/// additional errors (such as missing Vulkan-specific decorations).
+fn val_vulkan(src: &str) {
+    use rustc_codegen_spirv::spirv_tools::{
+        util::to_binary,
+        val::{self, Validator},
+        TargetEnv,
+    };
+
+    let validator = val::create(Some(TargetEnv::Vulkan_1_2));
+
+    let _lock = global_lock();
+    let bytes = std::fs::read(build(src)).unwrap();
+    if let Err(e) = validator.validate(to_binary(&bytes).unwrap(), None) {
+        panic!("Vulkan validation failed:\n{}", e.to_string());
+    }
+}
+
 fn assert_str_eq(expected: &str, result: &str) {
     let expected = expected
         .split('\n')

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -14,6 +14,8 @@ use spirv_std::glam::Vec3;
 use spirv_std::num_traits::Float;
 
 #[derive(Copy, Clone)]
+#[allow(unused_attributes)]
+#[spirv(block)]
 pub struct ShaderConstants {
     pub width: u32,
     pub height: u32,


### PR DESCRIPTION
Fixes #247, but sadly overlaps with #289.

I added a Vulkan validation test to `spirv-builder` tests, hope reusing `spirv_tools` through `rustc_codegen_spirv` is okay.
(Do we care whether that validation is Vulkan 1.2 vs 1.1?)

Also confirmed with `spirv-val --target-env vulkan1.1` that the error is gone from `sky_shader.spv`.