### PR TITLE
Remove `#[spirv(push_constant)]` from function parameters.

### DIFF
--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -141,9 +141,7 @@ pub struct ShaderConstants {
 
 #[allow(unused_attributes)]
 #[spirv(fragment)]
-pub fn main(
-    #[spirv(push_constant)] constants: PushConstant<ShaderConstants>,
-) {
+pub fn main(constants: PushConstant<ShaderConstants>) {
     let _constants = constants.load();
 }
 "#);
@@ -167,9 +165,7 @@ pub struct ShaderConstants {
 
 #[allow(unused_attributes)]
 #[spirv(fragment)]
-pub fn main(
-    #[spirv(push_constant)] constants: PushConstant<ShaderConstants>,
-) {
+pub fn main(constants: PushConstant<ShaderConstants>) {
     let _constants = constants.load();
 }
 "#,

--- a/examples/shaders/sky-shader/src/lib.rs
+++ b/examples/shaders/sky-shader/src/lib.rs
@@ -154,7 +154,7 @@ pub fn fs(constants: &ShaderConstants, frag_coord: Vec2) -> Vec4 {
 #[spirv(fragment)]
 pub fn main_fs(
     #[spirv(frag_coord)] in_frag_coord: Input<Vec4>,
-    #[spirv(push_constant)] constants: PushConstant<ShaderConstants>,
+    constants: PushConstant<ShaderConstants>,
     mut output: Output<Vec4>,
 ) {
     let constants = constants.load();


### PR DESCRIPTION
They don't do anything there - see https://github.com/EmbarkStudios/rust-gpu/pull/295#discussion_r533432345.