### PR TITLE
Intercept panic calls and replace them with aborts.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -6,6 +6,7 @@ use rspirv::dr::{Block, Builder, Module, Operand};
 use rspirv::spirv::{AddressingModel, Capability, MemoryModel, Op, Word};
 use rspirv::{binary::Assemble, binary::Disassemble};
 use rustc_middle::bug;
+use rustc_span::{Span, DUMMY_SP};
 use std::cell::{RefCell, RefMut};
 use std::{fs::File, io::Write, path::Path};
 
@@ -20,7 +21,10 @@ pub enum SpirvValueKind {
     /// pointers to constants, or function pointers. So, instead, we create this ConstantPointer
     /// "meta-value": directly using it is an error, however, if it is attempted to be
     /// dereferenced, the "load" is instead a no-op that returns the underlying value directly.
-    ConstantPointer(Word),
+    ConstantPointer {
+        initializer: Word,
+        zombie: Word,
+    },
 }
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -32,7 +36,10 @@ pub struct SpirvValue {
 impl SpirvValue {
     pub fn const_ptr_val(self, cx: &CodegenCx<'_>) -> Option<Self> {
         match self.kind {
-            SpirvValueKind::ConstantPointer(word) => {
+            SpirvValueKind::ConstantPointer {
+                initializer,
+                zombie: _,
+            } => {
                 let ty = match cx.lookup_type(self.ty) {
                     SpirvType::Pointer {
                         storage_class: _,
@@ -40,7 +47,7 @@ impl SpirvValue {
                     } => pointee,
                     ty => bug!("load called on variable that wasn't a pointer: {:?}", ty),
                 };
-                Some(word.with_type(ty))
+                Some(initializer.with_type(ty))
             }
             SpirvValueKind::Def(_) => None,
         }
@@ -50,43 +57,31 @@ impl SpirvValue {
     // contexts where the emitter is already locked. Doing so may cause subtle
     // rare bugs.
     pub fn def(self, bx: &builder::Builder<'_, '_>) -> Word {
-        match self.kind {
-            SpirvValueKind::Def(word) => word,
-            SpirvValueKind::ConstantPointer(_) => {
-                if bx.is_system_crate() {
-                    *bx.zombie_undefs_for_system_constant_pointers
-                        .borrow()
-                        .get(&self.ty)
-                        .expect("ConstantPointer didn't go through proper undef registration")
-                } else {
-                    bx.err("Cannot use this pointer directly, it must be dereferenced first");
-                    // Because we never get beyond compilation (into e.g. linking),
-                    // emitting an invalid ID reference here is OK.
-                    0
-                }
-            }
-        }
+        self.def_with_span(bx, bx.span())
     }
 
     // def and def_cx are separated, because Builder has a span associated with
     // what it's currently emitting.
     pub fn def_cx(self, cx: &CodegenCx<'_>) -> Word {
+        self.def_with_span(cx, DUMMY_SP)
+    }
+
+    pub fn def_with_span(self, cx: &CodegenCx<'_>, span: Span) -> Word {
         match self.kind {
             SpirvValueKind::Def(word) => word,
-            SpirvValueKind::ConstantPointer(_) => {
-                if cx.is_system_crate() {
-                    *cx.zombie_undefs_for_system_constant_pointers
-                        .borrow()
-                        .get(&self.ty)
-                        .expect("ConstantPointer didn't go through proper undef registration")
-                } else {
-                    cx.tcx
-                        .sess
-                        .err("Cannot use this pointer directly, it must be dereferenced first");
-                    // Because we never get beyond compilation (into e.g. linking),
-                    // emitting an invalid ID reference here is OK.
-                    0
-                }
+            SpirvValueKind::ConstantPointer {
+                initializer: _,
+                zombie,
+            } => {
+                // HACK(eddyb) we don't know whether this constant originated
+                // in a system crate, so it's better to always zombie.
+                cx.zombie_even_in_user_code(
+                    zombie,
+                    span,
+                    "Cannot use this pointer directly, it must be dereferenced first",
+                );
+
+                zombie
             }
         }
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -4,7 +4,7 @@ use crate::builder_spirv::{SpirvConst, SpirvValue, SpirvValueExt};
 use crate::spirv_type::SpirvType;
 use rspirv::spirv::Word;
 use rustc_codegen_ssa::mir::place::PlaceRef;
-use rustc_codegen_ssa::traits::{BaseTypeMethods, ConstMethods, MiscMethods, StaticMethods};
+use rustc_codegen_ssa::traits::{ConstMethods, MiscMethods, StaticMethods};
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::{read_target_uint, Allocation, GlobalAlloc, Pointer};
 use rustc_middle::ty::layout::TyAndLayout;
@@ -168,13 +168,14 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
 
     fn const_str(&self, s: Symbol) -> (Self::Value, Self::Value) {
         let len = s.as_str().len();
-        let ty = self.type_ptr_to(
-            self.layout_of(self.tcx.types.str_)
-                .spirv_type(DUMMY_SP, self),
-        );
-        let result = self.undef(ty);
-        self.zombie_no_span(result.def_cx(self), "constant string");
-        (result, self.const_usize(len as u64))
+        let str_ty = self
+            .layout_of(self.tcx.types.str_)
+            .spirv_type(DUMMY_SP, self);
+        // FIXME(eddyb) include the actual byte data.
+        (
+            self.make_constant_pointer(DUMMY_SP, self.undef(str_ty)),
+            self.const_usize(len as u64),
+        )
     }
     fn const_struct(&self, elts: &[Self::Value], _packed: bool) -> Self::Value {
         // Presumably this will get bitcasted to the right type?
@@ -471,7 +472,13 @@ impl<'tcx> CodegenCx<'tcx> {
                 *data = *c + asdf->y[*c];
                 }
                 */
-                self.zombie_no_span(result.def_cx(self), "constant runtime array value");
+                // HACK(eddyb) we don't know whether this constant originated
+                // in a system crate, so it's better to always zombie.
+                self.zombie_even_in_user_code(
+                    result.def_cx(self),
+                    DUMMY_SP,
+                    "constant runtime array value",
+                );
                 result
             }
             SpirvType::Pointer { .. } => {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -142,6 +142,13 @@ impl<'tcx> CodegenCx<'tcx> {
             }
         }
 
+        if Some(instance_def_id) == self.tcx.lang_items().panic_fn() {
+            self.panic_fn_id.set(Some(fn_id));
+        }
+        if Some(instance_def_id) == self.tcx.lang_items().panic_bounds_check_fn() {
+            self.panic_bounds_check_fn_id.set(Some(fn_id));
+        }
+
         declared
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -202,15 +202,16 @@ impl<'tcx> CodegenCx<'tcx> {
         .def(span, self);
         let initializer = value.def_cx(self);
 
-        // Create these undefs up front instead of on demand in SpirvValue::def because
+        // Create these up front instead of on demand in SpirvValue::def because
         // SpirvValue::def can't use cx.emit()
-        // We want a unique ID for these undefs, so don't use the caching system.
-        let zombie = self.emit_global().undef(ty, None);
+        let global_var =
+            self.emit_global()
+                .variable(ty, None, StorageClass::Function, Some(initializer));
 
         SpirvValue {
             kind: SpirvValueKind::ConstantPointer {
                 initializer,
-                zombie,
+                global_var,
             },
             ty,
         }

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -121,7 +121,15 @@ fn make_type_key(
         }
     }
     if let Some(id) = inst.result_id {
-        data.push(if zombies.contains(&id) { 1 } else { 0 });
+        data.push(if zombies.contains(&id) {
+            if inst.result_type.is_some() {
+                id
+            } else {
+                1
+            }
+        } else {
+            0
+        });
         if let Some(annos) = annotations.get(&id) {
             data.extend_from_slice(annos)
         }

--- a/crates/rustc_codegen_spirv/src/linker/new_structurizer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/new_structurizer.rs
@@ -240,8 +240,14 @@ impl Structurizer<'_> {
 
                 // Move all of the contents of the original `block` into the
                 // new loop body, but keep labels and indices intact.
+                // Also update the existing merge if it happens to be the `block`
+                // we just moved (this should only be relevant to infinite loops).
                 self.func.blocks_mut()[while_body_block].instructions =
                     mem::replace(&mut self.func.blocks_mut()[block].instructions, vec![]);
+                if region.merge == block {
+                    region.merge = while_body_block;
+                    region.merge_id = while_body_block_id;
+                }
 
                 // Create a separate merge block for the loop body, as the original
                 // one might be used by an `OpSelectionMerge` and cannot be reused.

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -167,3 +167,13 @@ pub fn main(constants: PushConstant<ShaderConstants>) {
 "#,
     );
 }
+
+#[test]
+fn infinite_loop() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    loop {}
+}"#);
+}

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -110,15 +110,43 @@ pub fn main() {
 }"#);
 }
 
-// TODO: Implement strings to make this compile
 #[test]
-#[ignore]
 fn panic() {
     val(r#"
 #[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     panic!("aaa");
+}
+"#);
+}
+
+#[test]
+fn panic_builtin() {
+    val(r#"
+fn int_div(x: usize) -> usize {
+    1 / x
+}
+
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    int_div(0);
+}
+"#);
+}
+
+#[test]
+fn panic_builtin_bounds_check() {
+    val(r#"
+fn array_bounds_check(x: [u32; 4], i: usize) -> u32 {
+    x[i]
+}
+
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    array_bounds_check([0, 1, 2, 3], 5);
 }
 "#);
 }


### PR DESCRIPTION
Where "abort" currently is equivalent to `loop {}`, but we could try to do something better in the future.

(Ideally we'd use a future variant of `OpKill` that works in all shaders, and ideally has the right semantics of leaving some kind of indication that there was an error in *some* shader invocation, but that might be asking for too much)

<hr/>

~~The reason this is "WIP", even if it does work (see the test changes), is because, in order to defer errors from creating unsupported constants (mostly `&panic::Location`) passed to panic entry-points, I had to turn them into zombies.
So the tests only work because the panic calls are replaced with "abort"s, and the zombie constants never used.~~

~~From my discussion with @khyperia, we should be able to use zombies here (and in other places), *if* we can properly track `Span`s for them, and I believe that's doable, but haven't gotten around to it.~~

**EDIT**: that's all done, thanks to #311!