### PR TITLE
Make capability computation less strict, strings in asm!

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -181,7 +181,6 @@ impl BuilderSpirv {
         }
         // The linker will always be ran on this module
         builder.capability(Capability::Linkage);
-        // TODO: Remove these eventually?
         builder.capability(Capability::Int8);
         builder.capability(Capability::Int16);
         builder.capability(Capability::Int64);

--- a/crates/rustc_codegen_spirv/src/linker/capability_computation.rs
+++ b/crates/rustc_codegen_spirv/src/linker/capability_computation.rs
@@ -19,8 +19,6 @@ pub fn remove_extra_capabilities(module: &mut Module) {
         .difference(&used_capabilities)
         .copied()
         .collect();
-    eprintln!("Detected capabilities: {:?}", used_capabilities);
-    eprintln!("Removing capabilities: {:?}", to_remove);
     remove_capabilities(module, &to_remove);
 }
 

--- a/crates/rustc_codegen_spirv/src/linker/capability_computation.rs
+++ b/crates/rustc_codegen_spirv/src/linker/capability_computation.rs
@@ -3,11 +3,28 @@ use rspirv::spirv::{Capability, Op};
 use std::collections::HashSet;
 
 pub fn remove_extra_capabilities(module: &mut Module) {
-    remove_capabilities(module, &compute_capabilities(module));
+    let used_capabilities = used_capabilities(module);
+    let removable_capabilities: HashSet<Capability> = [
+        Capability::Int8,
+        Capability::Int16,
+        Capability::Int64,
+        Capability::Float16,
+        Capability::Float64,
+        Capability::IntegerFunctions2INTEL,
+    ]
+    .iter()
+    .copied()
+    .collect();
+    let to_remove = removable_capabilities
+        .difference(&used_capabilities)
+        .copied()
+        .collect();
+    eprintln!("Detected capabilities: {:?}", used_capabilities);
+    eprintln!("Removing capabilities: {:?}", to_remove);
+    remove_capabilities(module, &to_remove);
 }
 
-// TODO: This is enormously unimplemented
-fn compute_capabilities(module: &Module) -> HashSet<Capability> {
+fn used_capabilities(module: &Module) -> HashSet<Capability> {
     let mut set = HashSet::new();
     for inst in module.all_inst_iter() {
         set.extend(inst.class.capabilities);
@@ -36,18 +53,12 @@ fn compute_capabilities(module: &Module) -> HashSet<Capability> {
             _ => {}
         }
     }
-    // always keep these capabilities, for now
-    set.insert(Capability::Addresses);
-    set.insert(Capability::Kernel);
-    set.insert(Capability::Shader);
-    set.insert(Capability::VariablePointers);
-    set.insert(Capability::VulkanMemoryModel);
     set
 }
 
 fn remove_capabilities(module: &mut Module, set: &HashSet<Capability>) {
     module.capabilities.retain(|inst| {
-        inst.class.opcode != Op::Capability || set.contains(&inst.operands[0].unwrap_capability())
+        inst.class.opcode != Op::Capability || !set.contains(&inst.operands[0].unwrap_capability())
     });
 }
 


### PR DESCRIPTION
This makes this work:

```rust
#[cfg(target_arch = "spirv")]
unsafe {
    asm!(
        "OpExtension \"SPV_KHR_multiview\"",
        "OpCapability MultiView"
    );
}
```

Kind of gross lexing code, but whatever, we can refactor if it needs to be more complicated.