### PR TITLE
Track spans for zombies, even cross-crate.

### DIFF
--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -31,6 +31,8 @@ bimap = "0.5"
 indexmap = "1.6.0"
 rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "01ca0d2e5b667a0e4ff1bc1804511e38f9a08759" }
 rustc-demangle = "0.1.18"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 spirv-tools = { version = "0.1.0", default-features = false }
 tar = "0.4.30"
 topological-sort = "0.1"

--- a/crates/rustc_codegen_spirv/src/finalizing_passes.rs
+++ b/crates/rustc_codegen_spirv/src/finalizing_passes.rs
@@ -1,9 +1,136 @@
 use rspirv::dr::{Instruction, Module, Operand};
 use rspirv::spirv::{Decoration, Op, Word};
+use rustc_span::{source_map::SourceMap, FileName, Pos, Span};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-pub fn export_zombies(module: &mut Module, zombies: &HashMap<Word, &'static str>) {
-    for (&id, &reason) in zombies {
+#[derive(Deserialize, Serialize)]
+pub struct ZombieDecoration {
+    pub reason: String,
+
+    #[serde(flatten)]
+    pub span: Option<ZombieSpan>,
+}
+
+/// Representation of a `rustc` `Span` that can be turned into a `Span` again
+/// in another compilation, by reloading the file. However, note that this will
+/// fail if the file changed since, which is detected using the serialized `hash`.
+#[derive(Deserialize, Serialize)]
+pub struct ZombieSpan {
+    file: PathBuf,
+    hash: serde_adapters::SourceFileHash,
+    lo: u32,
+    hi: u32,
+}
+
+// HACK(eddyb) `rustc_span` types implement only `rustc_serialize` traits, but
+// not `serde` traits, and the easiest workaround is to have our own types.
+mod serde_adapters {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    pub enum SourceFileHashAlgorithm {
+        Md5,
+        Sha1,
+        Sha256,
+    }
+
+    impl From<rustc_span::SourceFileHashAlgorithm> for SourceFileHashAlgorithm {
+        fn from(kind: rustc_span::SourceFileHashAlgorithm) -> Self {
+            match kind {
+                rustc_span::SourceFileHashAlgorithm::Md5 => Self::Md5,
+                rustc_span::SourceFileHashAlgorithm::Sha1 => Self::Sha1,
+                rustc_span::SourceFileHashAlgorithm::Sha256 => Self::Sha256,
+            }
+        }
+    }
+
+    #[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    pub struct SourceFileHash {
+        kind: SourceFileHashAlgorithm,
+        value: [u8; 32],
+    }
+
+    impl From<rustc_span::SourceFileHash> for SourceFileHash {
+        fn from(hash: rustc_span::SourceFileHash) -> Self {
+            let bytes = hash.hash_bytes();
+            let mut hash = SourceFileHash {
+                kind: hash.kind.into(),
+                value: Default::default(),
+            };
+            hash.value[..bytes.len()].copy_from_slice(bytes);
+            hash
+        }
+    }
+}
+
+impl ZombieSpan {
+    fn from_rustc(span: Span, source_map: &SourceMap) -> Option<Self> {
+        // Zombies may not always have valid spans.
+        // FIXME(eddyb) reduce the sources of this as much as possible.
+        if span.is_dummy() {
+            return None;
+        }
+
+        let (lo, hi) = (span.lo(), span.hi());
+        if !(lo <= hi) {
+            // FIXME(eddyb) broken `Span` - potentially turn this into an assert?
+            return None;
+        }
+
+        let file = source_map.lookup_source_file(lo);
+        if !(file.start_pos <= lo && hi <= file.end_pos) {
+            // FIXME(eddyb) broken `Span` - potentially turn this into an assert?
+            return None;
+        }
+
+        Some(ZombieSpan {
+            file: match &file.name {
+                // We can only support real files, not "synthetic" ones (which
+                // are almost never exposed to the compiler backend anyway).
+                FileName::Real(real_name) => real_name.local_path().to_path_buf(),
+                _ => return None,
+            },
+            hash: file.src_hash.into(),
+            lo: (lo - file.start_pos).to_u32(),
+            hi: (hi - file.start_pos).to_u32(),
+        })
+    }
+
+    pub fn to_rustc(self, source_map: &SourceMap) -> Option<Span> {
+        let file = source_map.load_file(&self.file).ok()?;
+
+        // If the file has changed since serializing, there's not much we can do,
+        // other than avoid creating invalid/confusing `Span`s.
+        // FIXME(eddyb) we could still indicate some of this to the user.
+        if self.hash != file.src_hash.into() {
+            return None;
+        }
+
+        // Sanity check - assuming `ZombieSpan` isn't corrupted, this assert
+        // could only ever fail because of a hash collision.
+        assert!(self.lo <= self.hi && self.hi <= file.byte_length());
+
+        Some(Span::with_root_ctxt(
+            file.start_pos + Pos::from_u32(self.lo),
+            file.start_pos + Pos::from_u32(self.hi),
+        ))
+    }
+}
+
+pub fn export_zombies(
+    module: &mut Module,
+    zombies: &HashMap<Word, (&'static str, Span)>,
+    source_map: &SourceMap,
+) {
+    for (&id, &(reason, span)) in zombies {
+        let encoded = serde_json::to_string(&ZombieDecoration {
+            reason: reason.to_string(),
+            span: ZombieSpan::from_rustc(span, source_map),
+        })
+        .unwrap();
+
         // TODO: Right now we just piggyback off UserTypeGOOGLE since we never use it elsewhere. We should, uh, fix this
         // to use non_semantic or something.
         // https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_non_semantic_info.html
@@ -14,7 +141,7 @@ pub fn export_zombies(module: &mut Module, zombies: &HashMap<Word, &'static str>
             vec![
                 Operand::IdRef(id),
                 Operand::Decoration(Decoration::UserTypeGOOGLE),
-                Operand::LiteralString(reason.to_string()),
+                Operand::LiteralString(encoded),
             ],
         );
         module.annotations.push(inst);

--- a/crates/rustc_codegen_spirv/src/finalizing_passes.rs
+++ b/crates/rustc_codegen_spirv/src/finalizing_passes.rs
@@ -55,7 +55,7 @@ mod serde_adapters {
     impl From<rustc_span::SourceFileHash> for SourceFileHash {
         fn from(hash: rustc_span::SourceFileHash) -> Self {
             let bytes = hash.hash_bytes();
-            let mut hash = SourceFileHash {
+            let mut hash = Self {
                 kind: hash.kind.into(),
                 value: Default::default(),
             };
@@ -74,7 +74,7 @@ impl ZombieSpan {
         }
 
         let (lo, hi) = (span.lo(), span.hi());
-        if !(lo <= hi) {
+        if lo > hi {
             // FIXME(eddyb) broken `Span` - potentially turn this into an assert?
             return None;
         }
@@ -85,7 +85,7 @@ impl ZombieSpan {
             return None;
         }
 
-        Some(ZombieSpan {
+        Some(Self {
             file: match &file.name {
                 // We can only support real files, not "synthetic" ones (which
                 // are almost never exposed to the compiler backend anyway).
@@ -98,7 +98,7 @@ impl ZombieSpan {
         })
     }
 
-    pub fn to_rustc(self, source_map: &SourceMap) -> Option<Span> {
+    pub fn to_rustc(&self, source_map: &SourceMap) -> Option<Span> {
         let file = source_map.load_file(&self.file).ok()?;
 
         // If the file has changed since serializing, there's not much we can do,

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -1,21 +1,26 @@
 //! See documentation on `CodegenCx::zombie` for a description of the zombie system.
 
+use crate::finalizing_passes::ZombieDecoration;
 use rspirv::dr::{Instruction, Module};
 use rspirv::spirv::{Decoration, Op, Word};
 use rustc_session::Session;
+use rustc_span::{Span, DUMMY_SP};
 use std::collections::HashMap;
 use std::env;
 use std::iter::once;
 
-pub fn collect_zombies(module: &Module) -> impl Iterator<Item = (Word, String)> + '_ {
+// HACK(eddyb) `impl FnOnce() -> ...` allows some callers to avoid deserialization.
+pub fn collect_zombies(
+    module: &Module,
+) -> impl Iterator<Item = (Word, impl FnOnce() -> ZombieDecoration + '_)> + '_ {
     module.annotations.iter().filter_map(|inst| {
         // TODO: Temp hack. We hijack UserTypeGOOGLE right now, since the compiler never emits this.
         if inst.class.opcode == Op::DecorateString
             && inst.operands[1].unwrap_decoration() == Decoration::UserTypeGOOGLE
         {
             let id = inst.operands[0].unwrap_id_ref();
-            let reason = inst.operands[2].unwrap_literal_string();
-            return Some((id, reason.to_string()));
+            let encoded = inst.operands[2].unwrap_literal_string();
+            return Some((id, move || serde_json::from_str(encoded).unwrap()));
         }
         None
     })
@@ -31,19 +36,22 @@ fn remove_zombie_annotations(module: &mut Module) {
 #[derive(Clone)]
 struct ZombieInfo<'a> {
     reason: &'a str,
+    span: Span,
     stack: Vec<Word>,
 }
 
 impl<'a> ZombieInfo<'a> {
-    fn from_reason(reason: &'a str) -> Self {
+    fn new(reason: &'a str, span: Span) -> Self {
         Self {
             reason,
+            span,
             stack: Vec::new(),
         }
     }
     fn push_stack(&self, word: Word) -> Self {
         Self {
             reason: self.reason,
+            span: self.span,
             stack: self.stack.iter().cloned().chain(once(word)).collect(),
         }
     }
@@ -151,16 +159,26 @@ fn report_error_zombies(sess: &Session, module: &Module, zombie: &HashMap<Word, 
                 .chain(stack)
                 .collect::<Vec<_>>()
                 .join("\n");
-            sess.struct_err(reason.reason).note(&stack_note).emit();
+            sess.struct_span_err(reason.span, reason.reason)
+                .note(&stack_note)
+                .emit();
         }
     }
 }
 
 pub fn remove_zombies(sess: &Session, module: &mut Module) {
-    let zombies_owned = collect_zombies(module).collect::<Vec<_>>();
+    let zombies_owned = collect_zombies(module)
+        .map(|(id, decode)| {
+            let ZombieDecoration { reason, span } = decode();
+            let span = span
+                .and_then(|span| span.to_rustc(sess.source_map()))
+                .unwrap_or(DUMMY_SP);
+            (id, (reason, span))
+        })
+        .collect::<Vec<_>>();
     let mut zombies = zombies_owned
         .iter()
-        .map(|(a, b)| (*a, ZombieInfo::from_reason(b)))
+        .map(|(id, (reason, span))| (*id, ZombieInfo::new(reason, *span)))
         .collect();
     remove_zombie_annotations(module);
     // Note: This is O(n^2).


### PR DESCRIPTION
Before:
```
  error: OpBitcast on ptr without AddressingModel != Logical
```
After:
```
  error: OpBitcast on ptr without AddressingModel != Logical
    --> /home/eddy/.rustup/toolchains/nightly-2020-11-24-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:50:38
     |
  50 |     panic_fmt(fmt::Arguments::new_v1(&[expr], &[]));
     |                                      ^^^^^^^
     |
```

I wasn't sure whether we should start moving from immediate errors, to zombies, even for non-system code.

And for constants we still need some kind of `Span` propagation system, because only `SpirValue::def` knows the `Span`, the code creating the value originally does not. It might be a good idea for `SpirValue` itself to track "unspanned zombies" in general.