### PR TITLE
Added new method for specifying storage classes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,6 +1988,8 @@ dependencies = [
  "pretty_assertions",
  "rspirv",
  "rustc-demangle",
+ "serde",
+ "serde_json",
  "spirv-tools",
  "tar",
  "tempfile",

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -185,7 +185,7 @@ impl<'tcx> CodegenCx<'tcx> {
             storage_class,
             StorageClass::Input | StorageClass::Output | StorageClass::UniformConstant
         );
-        // Note: this *declares* the variable too
+        // Note: this *declares* the variable too.
         let variable = self.emit_global().variable(arg, None, storage_class, None);
         if let PatKind::Binding(_, _, ident, _) = &hir_param.pat.kind {
             self.emit_global().name(variable, ident.to_string());

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -155,18 +155,15 @@ impl<'tcx> CodegenCx<'tcx> {
         // FIXME: This could be cleaned up and merged with the location logic
         let mut parameter_storage_class = None;
         for attr in parse_attrs(self, hir_param.attrs) {
-            match attr {
-                SpirvAttribute::StorageClass(s) => {
-                    if parameter_storage_class.is_none() {
-                        parameter_storage_class.replace(s);
-                    } else {
-                        // FIXME: Add span
-                        self.tcx
-                            .sess
-                            .fatal("Multiple storage class attributes for entry parameter!")
-                    }
+            if let SpirvAttribute::StorageClass(s) = attr {
+                if parameter_storage_class.is_none() {
+                    parameter_storage_class.replace(s);
+                } else {
+                    // FIXME: Add span
+                    self.tcx
+                        .sess
+                        .fatal("Multiple storage class attributes for entry parameter!")
                 }
-                _ => (),
             }
         }
         // Only the new way as above or the old way via Input<T> are allowed, not both


### PR DESCRIPTION
Related to #300.  This is a preliminary step that adds the means to do:

    fn main (#[spirv(input)] input: &f32, #[spirv(output)] output: &mut f32) {} 

In this case, the variables input and output would be declared with input and output storage class. In order to actually work, addition logic in the linker stage will have to be added.

This does not conflict and does not remove the current logic, and so is not a breaking change. 

Potentially work related to #300 could be applied to a new "infer-storage-class"  branch, since this this is only useful to users when and if additional functionality is added. 