### PR TITLE
fix coordinate type for SampleImage<Image2D>

### DIFF
--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -103,7 +103,7 @@ pub struct SampledImage<I> {
 }
 
 impl SampledImage<Image2d> {
-    pub fn sample(&self, coord: Vec3A) -> Vec4 {
+    pub fn sample(&self, coord: Vec2) -> Vec4 {
         #[cfg(not(target_arch = "spirv"))]
         {
             let _ = coord;


### PR DESCRIPTION
The last component is not needed and will be silently discarded.
Thanks to localhorse for reporting!