### PR TITLE
Add dummy binding for compute shader example

### DIFF
--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -1,5 +1,5 @@
-use core::num::NonZeroU64;
 use super::{shader_module, Options};
+use core::num::NonZeroU64;
 
 fn create_device_queue() -> (wgpu::Device, wgpu::Queue) {
     async fn create_device_queue_async() -> (wgpu::Device, wgpu::Queue) {
@@ -52,8 +52,8 @@ pub fn start(options: &Options) {
                     dynamic: false,
                     min_binding_size: Some(NonZeroU64::new(1).unwrap()),
                     readonly: false,
-                }
-            }
+                },
+            },
         ],
     });
 
@@ -84,7 +84,7 @@ pub fn start(options: &Options) {
         layout: &bind_group_layout,
         entries: &[wgpu::BindGroupEntry {
             binding: 0,
-            resource: wgpu::BindingResource::Buffer(buf.slice(..))
+            resource: wgpu::BindingResource::Buffer(buf.slice(..)),
         }],
     });
 


### PR DESCRIPTION
I ran into this:

```
     Running `target\debug\example-runner-wgpu.exe --shader Compute`
error: process didn't exit successfully: `target\debug\example-runner-wgpu.exe --shader Compute` (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
```

When trying to run the example compute shader locally. Some googling (thankfully) led me to gfx-rs/wgpu#240. I'm running on a similar GPU to the one described in that issue.

That prompted the fix here (create a dummy binding), which got the example to stop segfaulting. I'm not sure this is the appropriate fix, but wanted to share in case anyone else runs into the same issue.

Also: the example compute shader appears currently to be completely empty. Would there be any interest in a PR for a more fleshed out example? I'm currently starting work on a path tracer, and could probably make a very basic variant to share here. I'll need to start with something like [this](https://bheisler.github.io/post/writing-raytracer-in-rust-part-1/0) anyway.