### PR TITLE
Simplify setup.{sh,bat} and work around rust-lang/rustup#2601.

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,3 +1,6 @@
 setlocal
 
-rustup toolchain install nightly-2020-11-24 --component rust-src rustc-dev llvm-tools-preview
+rem HACK(eddyb) including `rust-std` works around this `rustup` bug:
+rem https://github.com/rust-lang/rustup/issues/2601
+
+rustup component add rust-std rust-src rustc-dev llvm-tools-preview

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
-rustup toolchain install nightly-2020-11-24 --component rust-src rustc-dev llvm-tools-preview
+# HACK(eddyb) including `rust-std` works around this `rustup` bug:
+# https://github.com/rust-lang/rustup/issues/2601
+
+rustup component add rust-std rust-src rustc-dev llvm-tools-preview


### PR DESCRIPTION
`rustup component add` will install the toolchain if it isn't already, and will respect `rust-toolchain`, so hardcoding the value from `rust-toolchain` into `setup.sh` and `setup.bat` isn't necessary.

It also works around https://github.com/rust-lang/rustup/issues/2601, which I've seen a handful of people hit (including myself), usually due to IDE integration installing the `rust-src` component using `rustup component add`, before `./setup.sh` is ran.

The inclusion of `rust-std` is a second level of workaround, it *somehow* avoids the problem described in https://github.com/rust-lang/rustup/issues/2601#issuecomment-741592459, where running the new `setup.sh`/`setup.bat` for the same toolchain that the old `setup.sh`/`setup.bat` was already ran (and it executed `rustup toolchain install ... --component rust-src`, putting the components list in a broken/suboptimal state).

More specifically, installing `rust-std` (even on its own) makes `rustup` decide to remove the (wrong) `rust-src-$host` component and install the (correct) `rust-src` one, if the former happens to be installed.
(The two versions of `rust-src` are the same component "package", only their names in `lib/rustlib/components` differ)