### PR TITLE
Support "Unroll" Loop Control via function-scoped `#[spirv(unroll_loops)]`.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -1,6 +1,7 @@
 use super::CodegenCx;
 use crate::abi::ConvSpirvType;
 use crate::builder_spirv::{SpirvConst, SpirvValue, SpirvValueExt};
+use crate::decorations::UnrollLoopsDecoration;
 use crate::spirv_type::SpirvType;
 use crate::symbols::{parse_attrs, SpirvAttribute};
 use rspirv::spirv::{FunctionControl, LinkageType, StorageClass, Word};
@@ -120,6 +121,11 @@ impl<'tcx> CodegenCx<'tcx> {
                     self.really_unsafe_ignore_bitcasts
                         .borrow_mut()
                         .insert(declared);
+                }
+                SpirvAttribute::UnrollLoops => {
+                    self.unroll_loops_decorations
+                        .borrow_mut()
+                        .insert(fn_id, UnrollLoopsDecoration {});
                 }
                 _ => {}
             }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -5,7 +5,7 @@ mod type_;
 
 use crate::builder::{ExtInst, InstructionTable};
 use crate::builder_spirv::{BuilderCursor, BuilderSpirv, SpirvValue, SpirvValueKind};
-use crate::finalizing_passes::export_zombies;
+use crate::decorations::{CustomDecoration, SerializedSpan, ZombieDecoration};
 use crate::spirv_type::{SpirvType, SpirvTypePrinter, TypeCache};
 use crate::symbols::Symbols;
 use rspirv::dr::{Module, Operand};
@@ -47,7 +47,7 @@ pub struct CodegenCx<'tcx> {
     /// Invalid spir-v IDs that should be stripped from the final binary,
     /// each with its own reason and span that should be used for reporting
     /// (in the event that the value is actually needed)
-    zombie_values: RefCell<HashMap<Word, (&'static str, Span)>>,
+    zombie_decorations: RefCell<HashMap<Word, ZombieDecoration>>,
     pub kernel_mode: bool,
     /// Cache of all the builtin symbols we need
     pub sym: Box<Symbols>,
@@ -105,7 +105,7 @@ impl<'tcx> CodegenCx<'tcx> {
             type_cache: Default::default(),
             vtables: Default::default(),
             ext_inst: Default::default(),
-            zombie_values: Default::default(),
+            zombie_decorations: Default::default(),
             kernel_mode,
             sym,
             instruction_table: InstructionTable::new(),
@@ -153,24 +153,24 @@ impl<'tcx> CodegenCx<'tcx> {
     ///
     /// Finally, if *user* code is marked as zombie, then this means that the user tried to do
     /// something that isn't supported, and should be an error.
-    pub fn zombie_with_span(&self, word: Word, span: Span, reason: &'static str) {
+    pub fn zombie_with_span(&self, word: Word, span: Span, reason: &str) {
         if self.is_system_crate() {
-            self.zombie_values.borrow_mut().insert(word, (reason, span));
+            self.zombie_even_in_user_code(word, span, reason);
         } else {
             self.tcx.sess.span_err(span, reason);
         }
     }
-    pub fn zombie_no_span(&self, word: Word, reason: &'static str) {
-        if self.is_system_crate() {
-            self.zombie_values
-                .borrow_mut()
-                .insert(word, (reason, DUMMY_SP));
-        } else {
-            self.tcx.sess.err(reason);
-        }
+    pub fn zombie_no_span(&self, word: Word, reason: &str) {
+        self.zombie_with_span(word, DUMMY_SP, reason)
     }
-    pub fn zombie_even_in_user_code(&self, word: Word, span: Span, reason: &'static str) {
-        self.zombie_values.borrow_mut().insert(word, (reason, span));
+    pub fn zombie_even_in_user_code(&self, word: Word, span: Span, reason: &str) {
+        self.zombie_decorations.borrow_mut().insert(
+            word,
+            ZombieDecoration {
+                reason: reason.to_string(),
+                span: SerializedSpan::from_rustc(span, self.tcx.sess.source_map()),
+            },
+        );
     }
 
     pub fn is_system_crate(&self) -> bool {
@@ -185,10 +185,11 @@ impl<'tcx> CodegenCx<'tcx> {
 
     pub fn finalize_module(self) -> Module {
         let mut result = self.builder.finalize();
-        export_zombies(
-            &mut result,
-            &self.zombie_values.borrow(),
-            self.tcx.sess.source_map(),
+        result.annotations.extend(
+            self.zombie_decorations
+                .into_inner()
+                .into_iter()
+                .map(|(id, zombie)| zombie.encode(id)),
         );
         result
     }

--- a/crates/rustc_codegen_spirv/src/decorations.rs
+++ b/crates/rustc_codegen_spirv/src/decorations.rs
@@ -97,6 +97,16 @@ impl<'a, D: Deserialize<'a>> LazilyDeserialized<'a, D> {
     }
 }
 
+/// An `OpFunction` with `#[spirv(unroll_loops)]` on the Rust `fn` definition,
+/// which should get `LoopControl::UNROLL` applied to all of its loops'
+/// `OpLoopMerge` instructions, during structuralization.
+#[derive(Deserialize, Serialize)]
+pub struct UnrollLoopsDecoration {}
+
+impl CustomDecoration for UnrollLoopsDecoration {
+    const ENCODING_PREFIX: &'static str = "U";
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct ZombieDecoration {
     pub reason: String,

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -84,7 +84,7 @@ mod abi;
 mod builder;
 mod builder_spirv;
 mod codegen_cx;
-mod finalizing_passes;
+mod decorations;
 mod link;
 mod linker;
 mod spirv_type;

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -1,3 +1,4 @@
+use crate::decorations::{CustomDecoration, ZombieDecoration};
 use rspirv::binary::Assemble;
 use rspirv::dr::{Instruction, Module, Operand};
 use rspirv::spirv::{Op, Word};
@@ -154,7 +155,7 @@ pub fn remove_duplicate_types(module: &mut Module) {
     // Keep in mind, this algorithm requires forward type references to not exist - i.e. it's a valid spir-v module.
 
     // Include zombies in the key to not merge zombies with non-zombies
-    let zombies: HashSet<Word> = super::zombies::collect_zombies(module)
+    let zombies: HashSet<Word> = ZombieDecoration::decode_all(module)
         .map(|(z, _)| z)
         .collect();
 

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -339,6 +339,7 @@ impl Symbols {
             ("block", SpirvAttribute::Block),
             ("flat", SpirvAttribute::Flat),
             ("sampled_image", SpirvAttribute::SampledImage),
+            ("unroll_loops", SpirvAttribute::UnrollLoops),
         ]
         .iter()
         .cloned();
@@ -457,6 +458,7 @@ pub enum SpirvAttribute {
     SampledImage,
     Block,
     Flat,
+    UnrollLoops,
 }
 
 // Note that we could mark the attr as used via cx.tcx.sess.mark_attr_used(attr), but unused


### PR DESCRIPTION
This required generalizing the zombie decoration system (see the first commit), because `OpLoopMerge` (where the `Unroll` "Loop Control" has to be applied) are created during linking, by the structurizer, *not* in the original crate (which is the one understanding the mapping between SPIR-V `OpFunctions` and Rust `fn`s).

It's not as nice as I would've hoped, but because of all the RAUW (Replace All Uses With) happening during linking, we can't just decode all of the decorations eagerly and keep them in e.g. a `HashMap`, as the IDs being decorated by them won't be replaced by RAUW.

So instead of centralizing such `rustc_codegen_spirv` decorations into a single `enum` and `HashMap`, each type that implements the `CustomDecoration` `trait` has to be independently decoded and removed from the SPIR-V module.