### PR TITLE
Update to nightly-2020-12-11.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -1156,8 +1156,8 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 .bitcast(dest_ty, None, val.def(self))
                 .unwrap()
                 .with_type(dest_ty);
-            let val_is_ptr = matches!(self.lookup_type(val.ty), SpirvType::Pointer{..});
-            let dest_is_ptr = matches!(self.lookup_type(dest_ty), SpirvType::Pointer{..});
+            let val_is_ptr = matches!(self.lookup_type(val.ty), SpirvType::Pointer { .. });
+            let dest_is_ptr = matches!(self.lookup_type(dest_ty), SpirvType::Pointer { .. });
             if val_is_ptr || dest_is_ptr {
                 self.zombie_bitcast_ptr(result.def(self), val.ty, dest_ty);
             }

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -218,7 +218,7 @@ impl BuilderSpirv {
         let spirv_module = module.assemble();
         File::create(path)
             .unwrap()
-            .write_all(crate::slice_u32_to_u8(&spirv_module))
+            .write_all(spirv_tools::util::from_binary(&spirv_module))
             .unwrap();
     }
 

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -428,6 +428,7 @@ fn do_link(sess: &Session, objects: &[PathBuf], rlibs: &[PathBuf], legalize: boo
 
 /// As of right now, this is essentially a no-op, just plumbing through all the files.
 // TODO: WorkProduct impl
+#[allow(clippy::unnecessary_wraps)]
 pub(crate) fn run_thin(
     cgcx: &CodegenContext<SpirvCodegenBackend>,
     modules: Vec<(String, SpirvThinBuffer)>,

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -138,7 +138,7 @@ fn link_exe(
 
     {
         let save_modules_timer = sess.timer("link_save_modules");
-        if let Err(e) = std::fs::write(out_filename, crate::slice_u32_to_u8(&spv_binary)) {
+        if let Err(e) = std::fs::write(out_filename, spirv_tools::util::from_binary(&spv_binary)) {
             let mut err = sess.struct_err("failed to serialize spirv-binary to disk");
             err.note(&format!("module {:?}", out_filename));
             err.note(&format!("I/O error: {:#}", e));
@@ -395,7 +395,7 @@ fn do_link(sess: &Session, objects: &[PathBuf], rlibs: &[PathBuf], legalize: boo
         for (num, module) in modules.iter().enumerate() {
             File::create(path.join(format!("mod_{}.spv", num)))
                 .unwrap()
-                .write_all(crate::slice_u32_to_u8(&module.assemble()))
+                .write_all(spirv_tools::util::from_binary(&module.assemble()))
                 .unwrap();
         }
     }

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -77,7 +77,6 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, String> {
         file_loader: None,
         diagnostic_output: DiagnosticOutput::Raw(Box::new(write_diags)),
         stderr: None,
-        crate_name: None,
         lint_caps: Default::default(),
         register_lints: None,
         override_queries: None,

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -299,3 +299,13 @@ OpUnreachable
 OpFunctionEnd"#,
     );
 }
+
+#[test]
+fn signum() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main(i: Input<f32>, mut o: Output<f32>) {
+    o.store(i.load().signum());
+}"#);
+}

--- a/crates/spirv-builder/src/test/mod.rs
+++ b/crates/spirv-builder/src/test/mod.rs
@@ -54,6 +54,7 @@ static SRC_PREFIX: &str = r#"#![no_std]
 #![allow(unused_imports)]
 use spirv_std::*;
 use spirv_std::storage_class::*;
+use spirv_std::num_traits::Float;
 "#;
 
 fn setup(src: &str) -> Result<PathBuf, Box<dyn Error>> {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2020-11-24"
+channel = "nightly-2020-12-11"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
This is specifically for https://github.com/rust-lang/rust/pull/79801 - I'm not sure what else got fixed, but the added test used to fail with this:
```
error: OpBitcast on ptr without AddressingModel != Logical
    --> /home/eddy/.cargo/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.14/src/float.rs:1941:30
     |
1941 |     let bits: u32 = unsafe { mem::transmute(f) };
     |                              ^^^^^^^^^^^^^^^^^
     |
     = note: Stack:
             num_traits::float::integer_decode_f32
             <f32 as num_traits::float::FloatCore>::integer_decode
             <f32 as num_traits::float::FloatCore>::is_sign_negative
             <f32 as num_traits::float::FloatCore>::signum
             <f32 as num_traits::float::Float>::signum
             test_project::main
             Unnamed function ID %51
```