### PR TITLE
Mouse support for the wgpu runner, and a shader to demonstrate it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mouse-shader"
+version = "0.1.0"
+dependencies = [
+ "shared",
+ "spirv-std",
+]
+
+[[package]]
 name = "naga"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "examples/shaders/sky-shader",
     "examples/shaders/simplest-shader",
     "examples/shaders/compute-shader",
+    "examples/shaders/mouse-shader",
 
     "crates/rustc_codegen_spirv",
     "crates/spirv-builder",

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -815,6 +815,16 @@ fn main() {
                         width: 1280, // ash runner currently does not support resizing.
                         height: 720,
                         time: start.elapsed().as_secs_f32(),
+
+                        // FIXME(eddyb) implement mouse support for the ash runner.
+                        cursor_x: 0.0,
+                        cursor_y: 0.0,
+                        drag_start_x: 0.0,
+                        drag_start_y: 0.0,
+                        drag_end_x: 0.0,
+                        drag_end_y: 0.0,
+                        mouse_button_pressed: 0,
+                        mouse_button_press_time: [f32::NEG_INFINITY; 3],
                     };
 
                     device.cmd_push_constants(

--- a/examples/runners/cpu/src/main.rs
+++ b/examples/runners/cpu/src/main.rs
@@ -40,6 +40,16 @@ fn main() {
         width: WIDTH as u32,
         height: HEIGHT as u32,
         time: 0f32,
+
+        // FIXME(eddyb) implement mouse support for the cpu runner.
+        cursor_x: 0.0,
+        cursor_y: 0.0,
+        drag_start_x: 0.0,
+        drag_start_y: 0.0,
+        drag_end_x: 0.0,
+        drag_end_y: 0.0,
+        mouse_button_pressed: 0,
+        mouse_button_press_time: [f32::NEG_INFINITY; 3],
     };
 
     // Limit to max ~60 fps update rate

--- a/examples/runners/wgpu/build.rs
+++ b/examples/runners/wgpu/build.rs
@@ -12,5 +12,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     build_shader("../../shaders/sky-shader")?;
     build_shader("../../shaders/simplest-shader")?;
     build_shader("../../shaders/compute-shader")?;
+    build_shader("../../shaders/mouse-shader")?;
     Ok(())
 }

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -9,6 +9,7 @@ pub enum RustGPUShader {
     Simplest,
     Sky,
     Compute,
+    Mouse,
 }
 
 fn shader_module(shader: RustGPUShader) -> wgpu::ShaderModuleSource<'static> {
@@ -16,6 +17,7 @@ fn shader_module(shader: RustGPUShader) -> wgpu::ShaderModuleSource<'static> {
         RustGPUShader::Simplest => wgpu::include_spirv!(env!("simplest_shader.spv")),
         RustGPUShader::Sky => wgpu::include_spirv!(env!("sky_shader.spv")),
         RustGPUShader::Compute => wgpu::include_spirv!(env!("compute_shader.spv")),
+        RustGPUShader::Mouse => wgpu::include_spirv!(env!("mouse_shader.spv")),
     }
 }
 

--- a/examples/shaders/mouse-shader/Cargo.toml
+++ b/examples/shaders/mouse-shader/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mouse-shader"
+version = "0.1.0"
+authors = ["Embark <opensource@embark-studios.com>"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+shared = { path = "../../shaders/shared" }
+spirv-std = { path = "../../../crates/spirv-std" }

--- a/examples/shaders/mouse-shader/src/lib.rs
+++ b/examples/shaders/mouse-shader/src/lib.rs
@@ -1,0 +1,270 @@
+#![cfg_attr(target_arch = "spirv", no_std)]
+#![feature(lang_items)]
+#![feature(register_attr)]
+#![register_attr(spirv)]
+
+use core::f32::consts::PI;
+use shared::*;
+use spirv_std::glam::{const_vec4, vec2, vec3, Mat2, Vec2, Vec3, Vec4, Vec4Swizzles};
+use spirv_std::storage_class::{Input, Output, PushConstant};
+
+// Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
+// we tie #[no_std] above to the same condition, so it's fine.
+#[cfg(target_arch = "spirv")]
+use spirv_std::num_traits::Float;
+
+trait Shape: Copy {
+    /// Distances indicate where the point is in relation to the shape:
+    /// * negative distance: the point is "inside" the shape
+    /// * distance of `0.0`: the point is "on" the shape
+    /// * positive distance: the point is "outside" the shape
+    fn distance(self, p: Vec2) -> f32;
+
+    fn union<S>(self, other: S) -> Union<Self, S> {
+        Union(self, other)
+    }
+
+    fn intersect<S>(self, other: S) -> Intersect<Self, S> {
+        Intersect(self, other)
+    }
+
+    fn stroke(self, thickness: f32) -> Stroke<Self> {
+        Stroke {
+            shape: self,
+            thickness,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+struct Union<A, B>(A, B);
+
+impl<A: Shape, B: Shape> Shape for Union<A, B> {
+    fn distance(self, p: Vec2) -> f32 {
+        self.0.distance(p).min(self.1.distance(p))
+    }
+}
+
+#[derive(Copy, Clone)]
+struct Intersect<A, B>(A, B);
+
+impl<A: Shape, B: Shape> Shape for Intersect<A, B> {
+    fn distance(self, p: Vec2) -> f32 {
+        self.0.distance(p).max(self.1.distance(p))
+    }
+}
+
+#[derive(Copy, Clone)]
+struct Stroke<S> {
+    shape: S,
+    thickness: f32,
+}
+
+impl<S: Shape> Shape for Stroke<S> {
+    fn distance(self, p: Vec2) -> f32 {
+        self.shape.distance(p).abs() - self.thickness / 2.0
+    }
+}
+
+#[derive(Copy, Clone)]
+struct Line(Vec2, Vec2);
+
+impl Shape for Line {
+    fn distance(self, p: Vec2) -> f32 {
+        let Line(a, b) = self;
+        let ap = p - a;
+        let ab = b - a;
+
+        // The projection of `p` into the line passing through `a` and `b`,
+        // in relative terms, i.e. `proj` is:
+        // * `0` when the projection is on `a`
+        // * between `0` and `1` when the projection between `a` and `b`
+        // * `1` when the project is on `b`
+        let proj = ap.dot(ab) / ab.dot(ab);
+
+        // Distance from `p` onto the line, i.e. from `p` to its projection.
+        let dist_ortho = p.distance(a.lerp(b, proj));
+
+        // Distance from the projection of `p` on the line, away from
+        // either end of the line segment (i.e. towards its "outside").
+        let dist_in_line = (0.0 - proj).max(proj - 1.0).max(0.0) * ab.length();
+
+        dist_ortho.max(dist_in_line)
+    }
+}
+
+#[derive(Copy, Clone)]
+struct Circle {
+    center: Vec2,
+    radius: f32,
+}
+
+impl Shape for Circle {
+    fn distance(self, p: Vec2) -> f32 {
+        p.distance(self.center) - self.radius
+    }
+}
+
+#[derive(Copy, Clone)]
+struct Rectangle {
+    center: Vec2,
+    size: Vec2,
+}
+
+impl Shape for Rectangle {
+    fn distance(self, p: Vec2) -> f32 {
+        ((p - self.center).abs() - self.size / 2.0).max_element()
+    }
+}
+
+struct Painter {
+    frag_coord: Vec2,
+    color: Vec3,
+}
+
+impl Painter {
+    fn fill(&mut self, shape: impl Shape, color: Vec4) {
+        let alpha = smoothstep(2.0, 0.0, shape.distance(self.frag_coord));
+        self.color = self.color.lerp(color.xyz(), alpha * color.w);
+    }
+
+    /// Fill and add a constrasting border (0.5px thick stroke of inverted color).
+    fn fill_with_contrast_border(&mut self, shape: impl Shape, color: Vec4) {
+        self.fill(shape, color);
+        self.fill(
+            shape.stroke(0.5),
+            (Vec3::one() - color.xyz()).extend(color.w),
+        );
+    }
+}
+
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main_fs(
+    #[spirv(frag_coord)] in_frag_coord: Input<Vec4>,
+    constants: PushConstant<ShaderConstants>,
+    mut output: Output<Vec4>,
+) {
+    let constants = constants.load();
+
+    let frag_coord = vec2(in_frag_coord.load().x, in_frag_coord.load().y);
+
+    let cursor = vec2(constants.cursor_x, constants.cursor_y);
+    let drag_start = vec2(constants.drag_start_x, constants.drag_start_y);
+    let drag_end = vec2(constants.drag_end_x, constants.drag_end_y);
+
+    let background = {
+        let resolution = vec2(constants.width as f32, constants.height as f32);
+        let from_coord = move |coord: Vec2| (coord / resolution) * 2.0 - Vec2::splat(1.0);
+        let v = from_coord(frag_coord);
+        let mut distance = v.length();
+        if drag_start != drag_end {
+            distance /= 1.0
+                + (v - from_coord(drag_start))
+                    .extend(0.0)
+                    .cross((from_coord(drag_end) - from_coord(drag_start)).extend(0.0))
+                    .length()
+                    .min(1.0)
+                    .powf(2.0);
+        }
+        let t = constants.time;
+        let rot = move |factor: f32| {
+            (Mat2::from_angle((t / 3.0 + distance * factor).sin() * 3.0) * v).normalize()
+        };
+        let seed = rot(7.0).x;
+        let rg = rot(2.0 + seed); // yellow
+        let rb = rot(3.0 + seed + rg.y); // magenta
+        let gb = rot(5.0 + seed + rb.x); // cyan
+        let color = (vec3(rg.x - rb.x, rg.y - gb.x, rb.y - gb.y).abs() / 2.0)
+            .min(Vec3::splat(1.0))
+            .powf(1.2);
+        let vignette = smoothstep(1.0, 0.0, (v.x * v.y).abs());
+        let grayscale = Vec3::splat((color.x + color.y + color.z) / 3.0);
+        grayscale.lerp(color, vignette) * vignette
+    };
+
+    let mut painter = Painter {
+        frag_coord,
+        color: background,
+    };
+
+    const WHITE: Vec4 = const_vec4!([1.0, 1.0, 1.0, 1.0]);
+    const RED: Vec4 = const_vec4!([1.0, 0.0, 0.0, 1.0]);
+
+    if drag_start != drag_end {
+        let drag_dir = (drag_end - drag_start).normalize();
+        let arrow_head = |p: Vec2| {
+            Line(p - Mat2::from_angle(-PI / 4.0) * drag_dir * 16.0, p)
+                .union(Line(p - Mat2::from_angle(PI / 4.0) * drag_dir * 16.0, p))
+        };
+        let arrow = arrow_head(drag_start - drag_dir).union(Line(drag_start, drag_end));
+
+        if drag_end != cursor {
+            painter.fill_with_contrast_border(
+                arrow.union(arrow_head(drag_end + drag_dir)).stroke(4.0),
+                WHITE,
+            );
+        } else {
+            painter.fill_with_contrast_border(arrow.stroke(4.0), WHITE);
+        }
+    }
+
+    let mouse_circle = Circle {
+        center: cursor,
+        radius: 32.0,
+    };
+    let mouse_button = |i: usize| {
+        let size = Vec2::splat(mouse_circle.radius * 2.0) / vec2(3.0, 2.0);
+        Rectangle {
+            center: mouse_circle.center + size * vec2(i as f32 - 1.0, -0.5),
+            size,
+        }
+        .intersect(mouse_circle)
+    };
+
+    // FIXME(eddyb) use a `for i in 0..3` loop when that works.
+    let mut i = 0;
+    while i < 3 {
+        painter.fill(
+            mouse_button(i),
+            RED.lerp(
+                WHITE
+                    .xyz()
+                    .extend(((constants.mouse_button_pressed >> i) & 1) as f32),
+                smoothstep(
+                    0.0,
+                    1.0,
+                    constants.time - constants.mouse_button_press_time[i],
+                ),
+            ),
+        );
+        i += 1;
+    }
+
+    painter.fill_with_contrast_border(
+        mouse_circle
+            .stroke(4.0)
+            .union(mouse_button(0).stroke(3.0))
+            .union(mouse_button(1).stroke(3.0))
+            .union(mouse_button(2).stroke(3.0)),
+        WHITE,
+    );
+
+    output.store(painter.color.extend(1.0));
+}
+
+#[allow(unused_attributes)]
+#[spirv(vertex)]
+pub fn main_vs(
+    #[spirv(vertex_index)] vert_idx: Input<i32>,
+    #[spirv(position)] mut builtin_pos: Output<Vec4>,
+) {
+    let vert_idx = vert_idx.load();
+
+    // Create a "full screen triangle" by mapping the vertex index.
+    // ported from https://www.saschawillems.de/blog/2016/08/13/vulkan-tutorial-on-rendering-a-fullscreen-quad-without-buffers/
+    let uv = vec2(((vert_idx << 1) & 2) as f32, (vert_idx & 2) as f32);
+    let pos = 2.0 * uv - Vec2::one();
+
+    builtin_pos.store(pos.extend(0.0).extend(1.0));
+}

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -14,12 +14,30 @@ use spirv_std::glam::{vec3, Vec3};
 use spirv_std::num_traits::Float;
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 #[allow(unused_attributes)]
 #[spirv(block)]
 pub struct ShaderConstants {
     pub width: u32,
     pub height: u32,
     pub time: f32,
+
+    pub cursor_x: f32,
+    pub cursor_y: f32,
+    pub drag_start_x: f32,
+    pub drag_start_y: f32,
+    pub drag_end_x: f32,
+    pub drag_end_y: f32,
+
+    /// Bit mask of the pressed buttons (0 = Left, 1 = Middle, 2 = Right).
+    pub mouse_button_pressed: u32,
+
+    /// The last time each mouse button (Left, Middle or Right) was pressed,
+    /// or `f32::NEG_INFINITY` for buttons which haven't been pressed yet.
+    ///
+    /// If this is the first frame after the press of some button, that button's
+    /// entry in `mouse_button_press_time` will exactly equal `time`.
+    pub mouse_button_press_time: [f32; 3],
 }
 
 pub fn saturate(x: f32) -> f32 {


### PR DESCRIPTION
The integration is similar to https://github.com/LykenSol/rust-gpu-shadertoys/pull/6 and https://github.com/LykenSol/rust-gpu-shadertoys/pull/12, but generalized to support all 3 mouse buttons (Left, Middle, Right). Only dragging is limited to a specific mouse button (Left).

In order to demonstrate the functionality, I've also written a new shader, using an SDF-like abstraction (AFAICT - at least it seems similar to SDF) to render basic shapes.
It also includes a colored background to interactively distort (for which tweaking/replacement is welcome - I didn't want to copy existing code so I had to make do with my own `sin`s).

In the screenshot below:
* the arrow indicates the drag trajectory (which is also what is distorting an otherwise more circular color pattern)
* the vaguely-mouse-looking circle is centered on the cursor
* the Middle and Right mouse buttons were recently pressed in quick succession, and so they are in the process of turning their color from red ("the button went down *just now*") to white ("the button is being held down")
  * the Middle button was pressed earlier, and thus it's closer to white than the Right button

![Screenshot_20201212_015055](https://user-images.githubusercontent.com/77424/101965234-9adf2c00-3c1c-11eb-9e13-10556f94166d.png)
