### PR TITLE
Builder now always builds with nightly

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -149,6 +149,7 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
     );
     let mut cargo = Command::new("cargo");
     cargo.args(&[
+        "+nightly-2020-12-11",
         "build",
         "--message-format=json-render-diagnostics",
         "-Z",


### PR DESCRIPTION
This allows a lot more flexibility in using the builder in stable repositories.
Note that it doesn't install components.