### PR TITLE
Better spirv-attrib

### DIFF
--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -5,34 +5,31 @@ use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut tokens = Vec::new();
     for tt in item {
-        match tt {
-            TokenTree::Group(group) => match group.delimiter() {
-                Delimiter::Parenthesis => {
-                    let mut sub_tokens = Vec::new();
-                    for tt in group.stream() {
-                        match tt {
-                            TokenTree::Group(group) => match group.delimiter() {
-                                Delimiter::Bracket => {
-                                    if group.stream().to_string().starts_with("spirv") {
-                                        sub_tokens.pop();
-                                    } else {
-                                        sub_tokens.push(TokenTree::from(group));
-                                    }
-                                }
-                                _ => sub_tokens.push(TokenTree::from(group)),
-                            },
-                            _ => sub_tokens.push(tt),
+        if let TokenTree::Group(group) = tt {
+            if let Delimiter::Parenthesis = group.delimiter() {
+                let mut sub_tokens = Vec::new();
+                for tt in group.stream() {
+                    if let TokenTree::Group(group) = tt {
+                        if let Delimiter::Bracket = group.delimiter() {
+                            if group.stream().to_string().starts_with("spirv") {
+                                sub_tokens.pop();
+                            } else {
+                                sub_tokens.push(TokenTree::from(group));
+                            }
                         }
+                    } else {
+                        sub_tokens.push(tt);
                     }
-
-                    tokens.push(TokenTree::from(Group::new(
-                        Delimiter::Parenthesis,
-                        TokenStream::from_iter(sub_tokens),
-                    )));
                 }
-                _ => tokens.push(TokenTree::from(group)),
-            },
-            _ => tokens.push(tt),
+                tokens.push(TokenTree::from(Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter(sub_tokens),
+                )));
+            } else {
+                tokens.push(TokenTree::from(group));
+            }
+        } else {
+            tokens.push(tt);
         }
     }
 

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro_attribute]
 pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let mut tokens: Vec<TokenTree> = Vec::new();
+    let mut tokens = Vec::new();
     for tt in item {
         match tt {
             TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis => {

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -1,5 +1,4 @@
 use core::iter::FromIterator;
-use core::iter::IntoIterator;
 use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro_attribute]

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -1,4 +1,3 @@
-use core::iter::FromIterator;
 use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro_attribute]
@@ -22,7 +21,7 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
                 tokens.push(TokenTree::from(Group::new(
                     Delimiter::Parenthesis,
-                    TokenStream::from_iter(sub_tokens),
+                    sub_tokens.into_iter().collect(),
                 )));
             }
             _ => tokens.push(tt),

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -30,6 +30,5 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         tokens.push(tt);
     }
-
     TokenStream::from_iter(tokens)
 }

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -10,7 +10,8 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
             if let Delimiter::Parenthesis = group.delimiter() {
                 let mut sub_tokens = Vec::new();
                 for tt in group.stream() {
-                    if matches!(tt.clone(), TokenTree::Group(group) if group.delimiter() == Delimiter::Bracket && matches!(group.stream().into_iter().next(), Some(TokenTree::Ident(ident)) if ident.to_string() == "spirv"))
+                    if matches!(tt.clone(), TokenTree::Group(group) if group.delimiter() == Delimiter::Bracket 
+                        && matches!(group.stream().into_iter().next(), Some(TokenTree::Ident(ident)) if ident.to_string() == "spirv"))
                         && matches!(sub_tokens.last(), Some(TokenTree::Punct(p)) if p.as_char() == '#')
                     {
                         sub_tokens.pop();

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -3,13 +3,13 @@ use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro_attribute]
 pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let mut tokens = Vec::new();
+    let mut tokens: Vec<TokenTree> = Vec::new();
     for tt in item {
-        match tt.clone() {
+        match tt {
             TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis => {
                 let mut sub_tokens = Vec::new();
                 for tt in group.stream() {
-                    match tt.clone() {
+                    match tt {
                         TokenTree::Group(group)
                             if group.delimiter() == Delimiter::Bracket
                                 && matches!(group.stream().into_iter().next(), Some(TokenTree::Ident(ident)) if ident.to_string() == "spirv")
@@ -28,5 +28,5 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
             _ => tokens.push(tt),
         }
     }
-    TokenStream::from_iter(tokens)
+    tokens.into_iter().collect()
 }

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -4,9 +4,8 @@ use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro_attribute]
 pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let mut iterator = item.into_iter();
     let mut tokens = Vec::new();
-    for tt in &mut iterator {
+    for tt in item.into_iter() {
         match tt {
             TokenTree::Group(group) => match group.delimiter() {
                 Delimiter::Parenthesis => {

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -10,14 +10,16 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
             if let Delimiter::Parenthesis = group.delimiter() {
                 let mut sub_tokens = Vec::new();
                 for tt in group.stream() {
-                    if matches!(tt.clone(), TokenTree::Group(group) if group.delimiter() == Delimiter::Bracket 
-                        && matches!(group.stream().into_iter().next(), Some(TokenTree::Ident(ident)) if ident.to_string() == "spirv"))
-                        && matches!(sub_tokens.last(), Some(TokenTree::Punct(p)) if p.as_char() == '#')
-                    {
-                        sub_tokens.pop();
-                        continue;
+                    match tt.clone() {
+                        TokenTree::Group(group)
+                            if group.delimiter() == Delimiter::Bracket
+                                && matches!(group.stream().into_iter().next(), Some(TokenTree::Ident(ident)) if ident.to_string() == "spirv")
+                                && matches!(sub_tokens.last(), Some(TokenTree::Punct(p)) if p.as_char() == '#') =>
+                        {
+                            sub_tokens.pop();
+                        }
+                        _ => sub_tokens.push(tt),
                     }
-                    sub_tokens.push(tt);
                 }
                 tokens.push(TokenTree::from(Group::new(
                     Delimiter::Parenthesis,

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -1,36 +1,31 @@
 use core::iter::FromIterator;
+use core::iter::IntoIterator;
 use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro_attribute]
 pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut tokens = Vec::new();
     for tt in item {
-        if let TokenTree::Group(group) = tt {
+        if let TokenTree::Group(group) = tt.clone() {
             if let Delimiter::Parenthesis = group.delimiter() {
                 let mut sub_tokens = Vec::new();
                 for tt in group.stream() {
-                    if let TokenTree::Group(group) = tt {
-                        if let Delimiter::Bracket = group.delimiter() {
-                            if group.stream().to_string().starts_with("spirv") {
-                                sub_tokens.pop();
-                            } else {
-                                sub_tokens.push(TokenTree::from(group));
-                            }
-                        }
-                    } else {
-                        sub_tokens.push(tt);
+                    if matches!(tt.clone(), TokenTree::Group(group) if group.delimiter() == Delimiter::Bracket && matches!(group.stream().into_iter().next(), Some(TokenTree::Ident(ident)) if ident.to_string() == "spirv"))
+                        && matches!(sub_tokens.last(), Some(TokenTree::Punct(p)) if p.as_char() == '#')
+                    {
+                        sub_tokens.pop();
+                        continue;
                     }
+                    sub_tokens.push(tt);
                 }
                 tokens.push(TokenTree::from(Group::new(
                     Delimiter::Parenthesis,
                     TokenStream::from_iter(sub_tokens),
                 )));
-            } else {
-                tokens.push(TokenTree::from(group));
+                continue;
             }
-        } else {
-            tokens.push(tt);
         }
+        tokens.push(tt);
     }
 
     TokenStream::from_iter(tokens)

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -1,16 +1,15 @@
 use core::iter::FromIterator;
-use core::iter::IntoIterator;
 use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro_attribute]
 pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut tokens = Vec::new();
-    for tt in item.into_iter() {
+    for tt in item {
         match tt {
             TokenTree::Group(group) => match group.delimiter() {
                 Delimiter::Parenthesis => {
                     let mut sub_tokens = Vec::new();
-                    for tt in group.stream().into_iter() {
+                    for tt in group.stream() {
                         match tt {
                             TokenTree::Group(group) => match group.delimiter() {
                                 Delimiter::Bracket => {
@@ -28,7 +27,7 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     tokens.push(TokenTree::from(Group::new(
                         Delimiter::Parenthesis,
-                        TokenStream::from_iter(sub_tokens.into_iter()),
+                        TokenStream::from_iter(sub_tokens),
                     )));
                 }
                 _ => tokens.push(TokenTree::from(group)),
@@ -37,5 +36,5 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    TokenStream::from_iter(tokens.into_iter())
+    TokenStream::from_iter(tokens)
 }

--- a/crates/spirv-attrib/src/lib.rs
+++ b/crates/spirv-attrib/src/lib.rs
@@ -6,8 +6,8 @@ use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut tokens = Vec::new();
     for tt in item {
-        if let TokenTree::Group(group) = tt.clone() {
-            if let Delimiter::Parenthesis = group.delimiter() {
+        match tt.clone() {
+            TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis => {
                 let mut sub_tokens = Vec::new();
                 for tt in group.stream() {
                     match tt.clone() {
@@ -25,10 +25,9 @@ pub fn spirv(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     Delimiter::Parenthesis,
                     TokenStream::from_iter(sub_tokens),
                 )));
-                continue;
             }
+            _ => tokens.push(tt),
         }
-        tokens.push(tt);
     }
     TokenStream::from_iter(tokens)
 }


### PR DESCRIPTION
Feedback related to https://github.com/EmbarkStudios/rust-gpu/pull/340

proc macro pseudo code:
```markdown
create empty vec of tokens

for input tokenstream
    if token is group
        create token list for inner tokenstream
        for token in group's tokenstream
            if token is bracket && starts with [spirv
                don't insert token, pop last token as well to rmeove #
            else
                insert token into inner token vec.
            insert new token created from the inner token vec
    else
        insert token into token vec.

return new tokenstream from vec of tokens.
```

How can I do this in a better way?