### PR TITLE
Update spirv-tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: .github/workflows/test.sh ${{ runner.os }}
 
-      - name: Build WPGU for Android
+      - name: Build WGPU Example for Android
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         shell: bash
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: macOS-latest
             target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: aarch64-linux-android
     runs-on: ${{ matrix.os }}
     env:
       spirv_tools_version: "20200928"
@@ -53,33 +55,25 @@ jobs:
       - name: cargo fetch --locked
         run: cargo fetch --locked --target ${{ matrix.target }}
       - name: Run tests
+        if: ${{ matrix.target != 'aarch64-linux-android' }}
         shell: bash
         run: .github/workflows/test.sh ${{ runner.os }}
 
-      - name: Install cargo-apk
-        run: cargo install cargo-apk
-
-      - if: runner.os == 'Windows'
-        name: Create symlink to Android SDK/NDK without spaces
+      - name: Build WPGU for Android
+        if: ${{ matrix.target == 'aarch64-linux-android' }}
+        shell: bash
         run: |
-          $oldAndroidPath = $env:ANDROID_HOME
-          $sdk_root = "C:\Android"
-          New-Item -Path $sdk_root -ItemType SymbolicLink -Value $oldAndroidPath
+          echo "::group::Install cargo-apk"
+          cargo install cargo-apk
+          echo "::endgroup::"
 
-          echo "ANDROID_SDK_ROOT=$sdk_root" >> $env:GITHUB_ENV
-          echo "ANDROID_NDK_ROOT=$sdk_root\ndk-bundle" >> $env:GITHUB_ENV
-
-          # Update legacy path for ndk-build:
-          echo "ANDROID_HOME=$sdk_root" >> $env:GITHUB_ENV
-
-          # Unset legacy paths:
-          echo "ANDROID_NDK_HOME=" >> $env:GITHUB_ENV
-          echo "ANDROID_NDK_PATH=" >> $env:GITHUB_ENV
-
-      - name: Compile WGPU example for Android
-        run: |
+          echo "::group::Add aarch64-linux-android target"
           rustup target add aarch64-linux-android
+          echo "::endgroup::"
+
+          echo "::group::Build WGPU example for Android"
           cargo apk build --manifest-path examples/runners/wgpu/Cargo.toml --features use-installed-tools --no-default-features
+          echo "::endgroup::"
 
   lint:
     name: Lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,9 +2217,9 @@ version = "0.1.0"
 
 [[package]]
 name = "spirv-tools"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3343abd20c146c483e7cdfe4d6fa87960b988f3a0617eeb570a625d3f81a8b"
+checksum = "90ceb7a6ccbd753bbbde0ea344a6135058b47baf8facb324ac47202fb41c85ec"
 dependencies = [
  "memchr",
  "spirv-tools-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,9 +2217,9 @@ version = "0.1.0"
 
 [[package]]
 name = "spirv-tools"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44be438c81cc340ce795532a7e40c0e09b7219a8b95c748a3e28ebdb1a0eb359"
+checksum = "5d3343abd20c146c483e7cdfe4d6fa87960b988f3a0617eeb570a625d3f81a8b"
 dependencies = [
  "memchr",
  "spirv-tools-sys",
@@ -2228,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools-sys"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1f35217731380e8c0665c3013b63aa34fd528863f8563735e4a052a847fb52"
+checksum = "dcb1ab3befe9cfd45c166b6d0487d8020eb8c3afaea3f86437bd85eef7b393d1"
 dependencies = [
  "cc",
 ]

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -33,7 +33,7 @@ rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "01ca0d2e5b667a0e
 rustc-demangle = "0.1.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-spirv-tools = { version = "0.2.0", default-features = false }
+spirv-tools = { version = "0.3.0", default-features = false }
 tar = "0.4.30"
 topological-sort = "0.1"
 


### PR DESCRIPTION
This updates spirv-tools to 0.3.0 which fixes several bugs in both the optimizer and validator so that they actually...work.

It also splits out Android in CI into its own job so that android isn't installed/built on every host platform which was wasteful.

Resolves: #344 