### PR TITLE
Upgrade winit v0.23 -> v0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54201c07dcf3a5ca33fececb8042aed767ee4bfd5a0235a8ceabcda956044b2"
+checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
 dependencies = [
  "bitflags",
  "block",
@@ -2972,12 +2972,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winit"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bc559da567d8aa671bbcd08304d49e982c7bf2cb91e10288b9188931c1b772"
+checksum = "da4eda6fce0eb84bd0a33e3c8794eb902e1033d0a1d5a31bc4f19b1b4bbff597"
 dependencies = [
  "bitflags",
- "cocoa 0.23.0",
+ "cocoa 0.24.0",
  "core-foundation 0.9.1",
  "core-graphics 0.22.1",
  "core-video-sys",

--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -15,7 +15,7 @@ use-compiled-tools = ["spirv-builder/use-compiled-tools"]
 [dependencies]
 ash = "0.31"
 ash-window = "0.5"
-winit = "0.23.0"
+winit = "0.24.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3.20"

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -20,7 +20,7 @@ cfg-if = "1.0.0"
 shared = { path = "../../shaders/shared" }
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 wgpu = "0.6.0"
-winit = { version = "0.23", features = ["web-sys"] }
+winit = { version = "0.24", features = ["web-sys"] }
 clap = "3.0.0-beta.2"
 strum = { version = "0.19", default_features = false, features = ["derive"] }
 


### PR DESCRIPTION
Fixes building and running the WGPU example for `aarch64-apple-darwin`

<img width="868" alt="image" src="https://user-images.githubusercontent.com/1262692/102697513-89a6a880-4236-11eb-84e9-26235ffd0557.png">
