### PR TITLE
Add `location` decoration attribute

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -169,6 +169,11 @@ impl<'tcx> CodegenCx<'tcx> {
                     );
                     has_location = false;
                 }
+                SpirvAttribute::Location(index) => {
+                    // Overwrite the current location value for the given storage class.
+                    // The decoration will be assigned below.
+                    decoration_locations.insert(storage_class, index);
+                }
                 SpirvAttribute::DescriptorSet(index) => {
                     self.emit_global().decorate(
                         variable,
@@ -195,7 +200,7 @@ impl<'tcx> CodegenCx<'tcx> {
         // Assign locations from left to right, incrementing each storage class
         // individually.
         // TODO: Is this right for UniformConstant? Do they share locations with
-        // input/outpus?
+        // input/outputs?
         if has_location {
             let location = decoration_locations
                 .entry(storage_class)

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -30,6 +30,7 @@ pub struct Symbols {
     pub spirv13: Symbol,
     pub spirv14: Symbol,
     pub spirv15: Symbol,
+    location: Symbol,
     descriptor_set: Symbol,
     binding: Symbol,
     image: Symbol,
@@ -383,6 +384,7 @@ impl Symbols {
             spirv13: Symbol::intern("spirv1.3"),
             spirv14: Symbol::intern("spirv1.4"),
             spirv15: Symbol::intern("spirv1.5"),
+            location: Symbol::intern("location"),
             descriptor_set: Symbol::intern("descriptor_set"),
             binding: Symbol::intern("binding"),
             image: Symbol::intern("image"),
@@ -442,6 +444,7 @@ pub enum SpirvAttribute {
     Builtin(BuiltIn),
     StorageClass(StorageClass),
     Entry(Entry),
+    Location(u32),
     DescriptorSet(u32),
     Binding(u32),
     ReallyUnsafeIgnoreBitcasts,
@@ -497,6 +500,11 @@ pub fn parse_attrs(
                 } else if arg.has_name(cx.sym.descriptor_set) {
                     match parse_attr_int_value(cx, arg) {
                         Some(x) => Some(SpirvAttribute::DescriptorSet(x)),
+                        None => None,
+                    }
+                } else if arg.has_name(cx.sym.location) {
+                    match parse_attr_int_value(cx, arg) {
+                        Some(x) => Some(SpirvAttribute::Location(x)),
                         None => None,
                     }
                 } else if arg.has_name(cx.sym.binding) {


### PR DESCRIPTION
Allows to explicity specify locations decorations for shader interfaces.
It's implemented backwards compatible in the way that locations will still be incremented for relevant interface types but specifying it explicitly will adjust the counter.

Example
```rust
#[allow(unused_attributes)]
#[spirv(vertex)]
pub fn main_vs(
    #[spirv(location = 0)] v_pos_world: Input<f32x2>,
    #[spirv(location = 1)] v_pos_curve: Input<f32x2>,
    #[spirv(location = 2)] v_curve_range: Input<u32x2>,
    #[spirv(location = 1)] mut a_curve_range: Output<u32x2>, // manually reorder output attribute
    #[spirv(location = 0)] mut a_pos_curve: Output<f32x2>,
    #[spirv(position)] mut gl_Position: Output<f32x4>,
    #[spirv(location = 0)] u_viewport: UniformConstant<f32x4>, // on non-opaque uniform constants as well for GL
) {
... 
```

There is one case where this can lead to issues right now:
```rust
#[spirv(location = 1)] v_pos_world: Input<f32x2>,
#[spirv(location = 0)] v_pos_curve: Input<f32x2>,
v_curve_range: Input<u32x2>, // implicit location 1 -> conflicts with `v_pos_world`