### PR TITLE
Update .cargo/config Shader Compilation Setup

### DIFF
--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -60,7 +60,10 @@ default installation.
 ```toml
 [build]
 target = "spirv-unknown-unknown"
-rustflags = ["-Zcodegen-backend=<path_to_librustc_codegen_spirv>"]
+rustflags = [
+   "-Zcodegen-backend=<path_to_librustc_codegen_spirv>",
+   "-Zsymbol-mangling-version=v0"
+]
 
 [unstable]
 build-std=["core"]


### PR DESCRIPTION
Hey there! I was just trying this out and found out that there is an extra rustc flag that needed to be added to get it to compile and also to get it to match the settings passed in by the spirv-builder build process.