### PR TITLE
Add step about copying rust-toolchain into your project

### DIFF
--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -45,7 +45,7 @@ need to do a couple of steps first to build the compiler backend.
 
 1. Clone the `rust-gpu` repository
 2. Copy the [`rust-toolchain`] file to your project. (You must use the same version of Rust as `rust-gpu`.)
-2. `cargo build --release` in `rust-gpu`.
+3. `cargo build --release` in `rust-gpu`.
 
 Now you should have a `librustc_codegen_spirv` dynamic library available in
 `target/release`. You'll need to keep this somewhere stable that you can

--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -24,7 +24,11 @@ There are two main ways to setup your shader project.
 If you're writing a bigger application and you want to integrate SPIR-V shader
 crates to display, it's recommended to use `spirv-builder` in a build script.
 
+1. Copy the [`rust-toolchain`] file to your project. (You must use the same version of Rust as `rust-gpu`.)
+2. Create a `build.rs` in your project root.
+
 #### `build.rs`
+Paste the following into the `main` for your build script.
 ```rust,no_run
 SpirvBuilder::new(path_to_shader)
         .spirv_version(1, 0)
@@ -38,13 +42,16 @@ const SHADER: &[u8] = include_bytes!(env!("<shader_name>.spv"));
 ```
 
 ### Using `.cargo/config`
+
+> **Note** This method will require manually rebuilding `rust-gpu` each
+  time there has been changes to the repository.
+
 If you just want to compile a build a shader crate, and don't need to
 automatically compile the SPIR-V binary at build time, you can use
 `.cargo/config` to set the necessary flags. Before you can do that however you
 need to do a couple of steps first to build the compiler backend.
 
 1. Clone the `rust-gpu` repository
-2. Copy the [`rust-toolchain`] file to your project. (You must use the same version of Rust as `rust-gpu`.)
 3. `cargo build --release` in `rust-gpu`.
 
 Now you should have a `librustc_codegen_spirv` dynamic library available in

--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -44,7 +44,8 @@ automatically compile the SPIR-V binary at build time, you can use
 need to do a couple of steps first to build the compiler backend.
 
 1. Clone the `rust-gpu` repository
-2. `cargo build --release`
+2. Copy the [`rust-toolchain`] file to your project. (You must use the same version of Rust as `rust-gpu`.)
+2. `cargo build --release` in `rust-gpu`.
 
 Now you should have a `librustc_codegen_spirv` dynamic library available in
 `target/release`. You'll need to keep this somewhere stable that you can
@@ -55,7 +56,6 @@ Now we need to add our `.cargo/config` file. This tells cargo to build for the
 that target. We have to also provide `-Zbuild-std` as the
 `spirv-unknown-unknown` sysroot is not currently available in the
 default installation.
-
 
 ```toml
 [build]
@@ -76,3 +76,5 @@ cargo build
 
 Now you should have `<project_name>.spv` SPIR-V file in `target/debug` that you
 can give to a renderer.
+
+[`rust-toolchain`]: https://github.com/EmbarkStudios/rust-gpu/blob/main/rust-toolchain


### PR DESCRIPTION
Following a few reports about people getting stuck when they have different version in their project than what they built with `rust-gpu`.