### PR TITLE
Flesh out compute example

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -51,3 +51,4 @@ cargo_test examples/runners/wgpu
 cargo_test_no_features examples/runners/cpu
 cargo_test_no_features examples/shaders/sky-shader
 cargo_test_no_features examples/shaders/simplest-shader
+cargo_test_no_features examples/shaders/compute-shader

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
+name = "bytemuck"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41aa2ec95ca3b5c54cf73c91acf06d24f4495d5f1b1c12506ae3483d646177ac"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "syn 1.0.56",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +667,7 @@ dependencies = [
 name = "example-runner-wgpu"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.0",
  "clap 3.0.0-beta.2",
  "console_error_panic_hook",

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -23,6 +23,7 @@ wgpu = "0.6.0"
 winit = { version = "0.24", features = ["web-sys"] }
 clap = "3.0.0-beta.2"
 strum = { version = "0.19", default_features = false, features = ["derive"] }
+bytemuck = { version = "1.4", features = ["derive"] }
 
 [build-dependencies]
 spirv-builder = { path = "../../../crates/spirv-builder", default-features = false }

--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -1,12 +1,13 @@
 use super::{shader_module, Options};
-use core::num::NonZeroU64;
+use std::convert::TryInto;
+use wgpu::util::DeviceExt;
 
-fn create_device_queue() -> (wgpu::Device, wgpu::Queue) {
+async fn create_device_queue() -> (wgpu::Device, wgpu::Queue) {
     async fn create_device_queue_async() -> (wgpu::Device, wgpu::Queue) {
         let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::default(),
+                power_preference: wgpu::PowerPreference::Default,
                 compatible_surface: None,
             })
             .await
@@ -28,33 +29,57 @@ fn create_device_queue() -> (wgpu::Device, wgpu::Queue) {
         if #[cfg(target_arch = "wasm32")] {
             wasm_bindgen_futures::spawn_local(create_device_queue_async())
         } else {
-            futures::executor::block_on(create_device_queue_async())
+            create_device_queue_async().await
         }
     }
 }
 
-pub fn start(options: &Options) {
-    let (device, queue) = create_device_queue();
+pub async fn start(options: &Options) -> Vec<u32> {
+    wgpu_subscriber::initialize_default_subscriber(None);
+    let numbers: Vec<u32> = vec![1, 2, 3, 4];
+    let slice_size = numbers.len() * std::mem::size_of::<u32>();
+    let size = slice_size as wgpu::BufferAddress;
 
-    // Load the shaders from disk
-    let module = device.create_shader_module(shader_module(options.shader));
+    let (device, queue) = create_device_queue().await;
+
+    let cs_module = device.create_shader_module(shader_module(options.shader));
+
+    let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size,
+        usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let storage_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Storage Buffer"),
+        contents: bytemuck::cast_slice(&numbers),
+        usage: wgpu::BufferUsage::STORAGE
+            | wgpu::BufferUsage::COPY_DST
+            | wgpu::BufferUsage::COPY_SRC,
+    });
 
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: None,
-        entries: &[
-            // XXX - some graphics cards do not support empty bind layout groups, so
-            // create a dummy entry.
-            wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                count: None,
-                visibility: wgpu::ShaderStage::COMPUTE,
-                ty: wgpu::BindingType::StorageBuffer {
-                    dynamic: false,
-                    min_binding_size: Some(NonZeroU64::new(1).unwrap()),
-                    readonly: false,
-                },
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStage::COMPUTE,
+            ty: wgpu::BindingType::StorageBuffer {
+                dynamic: false,
+                readonly: false,
+                min_binding_size: wgpu::BufferSize::new(4),
             },
-        ],
+            count: None,
+        }],
+    });
+
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &bind_group_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: wgpu::BindingResource::Buffer(storage_buffer.slice(..)),
+        }],
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -67,36 +92,49 @@ pub fn start(options: &Options) {
         label: None,
         layout: Some(&pipeline_layout),
         compute_stage: wgpu::ProgrammableStageDescriptor {
-            module: &module,
+            module: &cs_module,
             entry_point: "main_cs",
         },
     });
 
-    let buf = device.create_buffer(&wgpu::BufferDescriptor {
-        label: None,
-        size: 1,
-        usage: wgpu::BufferUsage::STORAGE,
-        mapped_at_creation: false,
-    });
-
-    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        label: None,
-        layout: &bind_group_layout,
-        entries: &[wgpu::BindGroupEntry {
-            binding: 0,
-            resource: wgpu::BindingResource::Buffer(buf.slice(..)),
-        }],
-    });
-
     let mut encoder =
         device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
     {
         let mut cpass = encoder.begin_compute_pass();
-        cpass.set_bind_group(0, &bind_group, &[]);
         cpass.set_pipeline(&compute_pipeline);
-        cpass.dispatch(1, 1, 1);
+        cpass.set_bind_group(0, &bind_group, &[]);
+        cpass.insert_debug_marker("compute collatz iterations");
+        cpass.dispatch(numbers.len() as u32, 1, 1);
     }
-
+    encoder.copy_buffer_to_buffer(&storage_buffer, 0, &staging_buffer, 0, size);
     queue.submit(Some(encoder.finish()));
+    // Note that we're not calling `.await` here.
+
+    let buffer_slice = staging_buffer.slice(..);
+    let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
+
+    // Poll the device in a blocking manner so that our future resolves.
+    // In an actual application, `device.poll(...)` should
+    // be called in an event loop or on another thread.
+    device.poll(wgpu::Maintain::Wait);
+
+    if let Ok(()) = buffer_future.await {
+        let data = buffer_slice.get_mapped_range();
+        let result = data
+            .chunks_exact(4)
+            .map(|b| u32::from_ne_bytes(b.try_into().unwrap()))
+            .collect();
+
+        // With the current interface, we have to make sure all mapped views are
+        // dropped before we unmap the buffer.
+        drop(data);
+        staging_buffer.unmap();
+
+        println!("Times: {:?}", result);
+        #[cfg(target_arch = "wasm32")]
+        log::info!("Times: {:?}", result);
+        result
+    } else {
+        panic!("failed to run compute on gpu!")
+    }
 }

--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -139,7 +139,7 @@ pub async fn start(options: &Options, numbers: Vec<u32>) -> Vec<u32> {
     }
 }
 
-#[cfg(test)]
+// #[cfg(test)]
 mod tests {
     use super::*;
 

--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -34,9 +34,9 @@ async fn create_device_queue() -> (wgpu::Device, wgpu::Queue) {
     }
 }
 
-pub async fn start(options: &Options) -> Vec<u32> {
+pub async fn start(options: &Options, numbers: Vec<u32>) -> Vec<u32> {
     wgpu_subscriber::initialize_default_subscriber(None);
-    let numbers: Vec<u32> = vec![1, 2, 3, 4];
+
     let slice_size = numbers.len() * std::mem::size_of::<u32>();
     let size = slice_size as wgpu::BufferAddress;
 
@@ -136,5 +136,23 @@ pub async fn start(options: &Options) -> Vec<u32> {
         result
     } else {
         panic!("failed to run compute on gpu!")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_1() {
+        let input = vec![1, 2, 3, 4];
+        futures::executor::block_on(assert_start(input, vec![0, 1, 7, 2]));
+    }
+
+    async fn assert_start(input: Vec<u32>, expected: Vec<u32>) {
+        let options: Options = Options {
+            shader: crate::RustGPUShader::Compute,
+        };
+        assert_eq!(start(&options, input).await, expected);
     }
 }

--- a/examples/runners/wgpu/src/graphics.rs
+++ b/examples/runners/wgpu/src/graphics.rs
@@ -261,7 +261,7 @@ async fn run(
     });
 }
 
-pub fn start(options: &Options) {
+pub async fn start(options: &Options) {
     let event_loop = EventLoop::new();
     let window = winit::window::WindowBuilder::new()
         .with_title("Rust GPU - wgpu")
@@ -282,16 +282,16 @@ pub fn start(options: &Options) {
                     body.append_child(&web_sys::Element::from(window.canvas()))
                         .ok()
                 })
-                .expect("couldn't append canvas to document body");
+            .expect("couldn't append canvas to document body");
             // Temporarily avoid srgb formats for the swapchain on the web
             wasm_bindgen_futures::spawn_local(run(
-                event_loop,
-                window,
-                wgpu::TextureFormat::Bgra8Unorm,
+                    event_loop,
+                    window,
+                    wgpu::TextureFormat::Bgra8Unorm,
             ));
         } else {
             wgpu_subscriber::initialize_default_subscriber(None);
-            futures::executor::block_on(run(
+            run(
                 options,
                 event_loop,
                 window,
@@ -300,7 +300,7 @@ pub fn start(options: &Options) {
                 } else {
                     wgpu::TextureFormat::Bgra8UnormSrgb
                 },
-            ));
+            ).await;
         }
     }
 }

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -36,8 +36,8 @@ pub fn main() {
     let options: Options = Options::parse();
 
     if is_compute_shader(options.shader) {
-        compute::start(&options)
+        futures::executor::block_on(compute::start(&options));
     } else {
-        graphics::start(&options);
+        futures::executor::block_on(graphics::start(&options));
     }
 }

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -36,7 +36,7 @@ pub fn main() {
     let options: Options = Options::parse();
 
     if is_compute_shader(options.shader) {
-        futures::executor::block_on(compute::start(&options));
+        futures::executor::block_on(compute::start(&options, vec![1, 2, 3, 4]));
     } else {
         futures::executor::block_on(graphics::start(&options));
     }

--- a/examples/runners/wgpu/src/main.rs
+++ b/examples/runners/wgpu/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    example_runner_wgpu::main()
+    example_runner_wgpu::main();
 }

--- a/examples/shaders/compute-shader/src/lib.rs
+++ b/examples/shaders/compute-shader/src/lib.rs
@@ -11,6 +11,34 @@ extern crate spirv_std;
 #[macro_use]
 pub extern crate spirv_std_macros;
 
+use spirv_std::storage_class::{Input, StorageBuffer};
+
+// The Collatz Conjecture states that for any integer n:
+// If n is even, n = n/2
+// If n is odd, n = 3n+1
+// And repeat this process for each new n, you will always eventually reach 1.
+// Though the conjecture has not been proven, no counterexample has ever been found.
+// This function returns how many times this recurrence needs to be applied to reach 1.
+pub fn collatz_iterations(mut n: i32) -> i32 {
+    let mut i = 0;
+    while n != 1 {
+        if n.rem_euclid(2) == 0 {
+            n /= 2;
+        } else {
+            n = 3 * n + 1;
+        }
+        i += 1;
+    }
+    i
+}
+
 #[allow(unused_attributes)]
-#[spirv(gl_compute)]
-pub fn main_cs() {}
+#[spirv(gl_compute(local_size_x = 1))]
+pub fn main_cs(
+    #[spirv(global_invocation_id)] gid: Input<i32>,
+    #[spirv(storage_buffer)] mut storage: StorageBuffer<u32>,
+) {
+    let gid = gid.load();
+    let result = collatz_iterations(gid);
+    storage.store(result as u32)
+}


### PR DESCRIPTION
Just a copy of wgpu-rs's 'hello-compute' example: https://github.com/gfx-rs/wgpu-rs/tree/v0.6/examples/hello-compute

I'm not sure if this is even possible at the moment? Not to mention that this is my first time using rust-gpu (which is such a great project). I get a compiler error:

```
RUST_BACKTRACE=full cargo run --bin example-runner-wgpu -- --shader Compute
   Compiling example-runner-wgpu v0.1.0 (/home/tombh/Software/rust-gpu/examples/runners/wgpu)
thread 'rustc' panicked at 'Failed to recover key for generics_of(b445f41739b0d39c-316db2fba229b0a9) with hash b445f41739b0d39c-316db2fba229b0a9', compiler/rustc_middle/src/ty/query/mod.rs:235:5
stack backtrace:
   0:     0x7f763a45a6b7 - std::backtrace_rs::backtrace::libunwind::trace::h746c3e9529d524bc
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/../../backtrace/src/backtrace/libunwind.rs:90:5
   1:     0x7f763a45a6b7 - std::backtrace_rs::backtrace::trace_unsynchronized::h86340908ff889faa
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7f763a45a6b7 - std::sys_common::backtrace::_print_fmt::h43f85f9b18230404
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/sys_common/backtrace.rs:67:5
   3:     0x7f763a45a6b7 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hc132ae1a5b5aa7cd
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/sys_common/backtrace.rs:46:22
   4:     0x7f763a4ce5ac - core::fmt::write::hdf023a0036d2a25f
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/core/src/fmt/mod.rs:1078:17
   5:     0x7f763a44c6a2 - std::io::Write::write_fmt::h8580846154bcb66a
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/io/mod.rs:1519:15
   6:     0x7f763a45e3b5 - std::sys_common::backtrace::_print::h7ee55fed88d107a3
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/sys_common/backtrace.rs:49:5
   7:     0x7f763a45e3b5 - std::sys_common::backtrace::print::h54a7d3e52a524177
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/sys_common/backtrace.rs:36:9
   8:     0x7f763a45e3b5 - std::panicking::default_hook::{{closure}}::h60921e857bf55a40
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/panicking.rs:208:50
   9:     0x7f763a45df0a - std::panicking::default_hook::hf0f9afb1017317fc
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/panicking.rs:225:9
  10:     0x7f763ad16648 - rustc_driver::report_ice::hff78d76a39ffbb86
  11:     0x7f7628d8e9f6 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h85ca59ae85d698fe
                               at /home/tombh/.rustup/toolchains/nightly-2020-12-11-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1342:9
  12:     0x7f7628d7c41b - proc_macro::bridge::client::<impl proc_macro::bridge::Bridge>::enter::{{closure}}::{{closure}}::h54ab91f59daab13a
                               at /home/tombh/.rustup/toolchains/nightly-2020-12-11-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/proc_macro/src/bridge/client.rs:320:21
  13:     0x7f763a45ecb6 - std::panicking::rust_panic_with_hook::h8d66bf42b407aaea
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/panicking.rs:595:17
  14:     0x7f763a45e7d7 - std::panicking::begin_panic_handler::{{closure}}::hde71edcd925d0c5e
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/panicking.rs:497:13
  15:     0x7f763a45ab7c - std::sys_common::backtrace::__rust_end_short_backtrace::h8a3c7d6cea578919
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/sys_common/backtrace.rs:141:18
  16:     0x7f763a45e739 - rust_begin_unwind
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/panicking.rs:493:5
  17:     0x7f763a45e6eb - std::panicking::begin_panic_fmt::hee67ce14b77d0396
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/panicking.rs:435:5
  18:     0x7f763d6fb880 - rustc_middle::ty::query::try_load_from_on_disk_cache::{{closure}}::h0702bbc1f260c0e9
  19:     0x7f763d6fb7fb - rustc_middle::ty::query::try_load_from_on_disk_cache::hfa4775df5c5e0180
  20:     0x7f763c9d740e - rustc_query_system::dep_graph::graph::DepGraph<K>::exec_cache_promotions::h8caa69177622351e
  21:     0x7f763c9efce1 - rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps::hab5675af7737b3e6
  22:     0x7f763c992a8b - rustc_incremental::persist::save::save_in::h7f4f43356280dc0a
  23:     0x7f763c98de61 - rustc_data_structures::sync::join::h0120008f852881ce
  24:     0x7f763c9eed82 - rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps::h2893ce60eec57bb6
  25:     0x7f763c991fbf - rustc_incremental::persist::save::save_dep_graph::hffd3fb2ecc639a78
  26:     0x7f763c86e77a - rustc_codegen_ssa::base::finalize_tcx::h68106e2729498b3e
  27:     0x7f763b185087 - <rustc_codegen_llvm::LlvmCodegenBackend as rustc_codegen_ssa::traits::backend::CodegenBackend>::codegen_crate::h067fffb3870bc5b0
  28:     0x7f763af342ee - rustc_session::utils::<impl rustc_session::session::Session>::time::had158f21ec5bf4d1
  29:     0x7f763af767dc - rustc_interface::passes::QueryContext::enter::h40067ad7feabcbd0
  30:     0x7f763afcea63 - rustc_interface::queries::Queries::ongoing_codegen::h4fc36fc05972247d
  31:     0x7f763acbec59 - rustc_interface::queries::<impl rustc_interface::interface::Compiler>::enter::hd899306a06575d0c
  32:     0x7f763ad3fa07 - rustc_span::with_source_map::ha4e07ff263d0dc1d
  33:     0x7f763acbfe0b - rustc_interface::interface::create_compiler_and_run::h1d6d732867d1f489
  34:     0x7f763ad6ce50 - scoped_tls::ScopedKey<T>::set::h39c0aa543118d3f3
  35:     0x7f763ad73456 - std::sys_common::backtrace::__rust_begin_short_backtrace::h1e5aa72fb9cd6d86
  36:     0x7f763acc7cca - core::ops::function::FnOnce::call_once{{vtable.shim}}::hc793837e985b77ce
  37:     0x7f763a46e6ea - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hea1090dbdcecbf5a
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/alloc/src/boxed.rs:1328:9
  38:     0x7f763a46e6ea - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h8d5723d3912bd325
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/alloc/src/boxed.rs:1328:9
  39:     0x7f763a46e6ea - std::sys::unix::thread::Thread::new::thread_start::hc17a425ca2995724
                               at /rustc/d32c320d7eee56706486fef6be778495303afe9e/library/std/src/sys/unix/thread.rs:71:17
  40:     0x7f763a3823e9 - start_thread
  41:     0x7f763a29d293 - __GI___clone
  42:                0x0 - <unknown>

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.50.0-nightly (d32c320d7 2020-12-10) running on x86_64-unknown-linux-gnu

note: compiler flags: -C embed-bitcode=no -C debuginfo=2 -C incremental --crate-type lib --crate-type cdylib

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
end of query stack
error: could not compile `example-runner-wgpu`
```