### PR TITLE
Add autolinks to silence rustdoc warnings

### DIFF
--- a/crates/spirv-builder/src/depfile.rs
+++ b/crates/spirv-builder/src/depfile.rs
@@ -1,5 +1,5 @@
 //! Reading Makefile-style dependency files.
-//! Taken with permission from https://github.com/m-ou-se/ninj/blob/master/lib/depfile/mod.rs
+//! Taken with permission from <https://github.com/m-ou-se/ninj/blob/master/lib/depfile/mod.rs>
 
 use raw_string::{RawStr, RawString};
 use std::fs::File;

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -1,4 +1,4 @@
-//! Ported to Rust from https://github.com/Tw1ddle/Sky-Shader/blob/master/src/shaders/glsl/sky.fragment
+//! Ported to Rust from <https://github.com/Tw1ddle/Sky-Shader/blob/master/src/shaders/glsl/sky.fragment>
 
 #![cfg_attr(
     target_arch = "spirv",
@@ -58,7 +58,7 @@ pub fn exp(v: Vec3) -> Vec3 {
     vec3(v.x.exp(), v.y.exp(), v.z.exp())
 }
 
-/// Based on: https://seblagarde.wordpress.com/2014/12/01/inverse-trigonometric-functions-gpu-optimization-for-amd-gcn-architecture/
+/// Based on: <https://seblagarde.wordpress.com/2014/12/01/inverse-trigonometric-functions-gpu-optimization-for-amd-gcn-architecture/>
 pub fn acos_approx(v: f32) -> f32 {
     let x = v.abs();
     let mut res = -0.155972 * x + 1.56467; // p(x)

--- a/examples/shaders/sky-shader/src/lib.rs
+++ b/examples/shaders/sky-shader/src/lib.rs
@@ -1,4 +1,4 @@
-//! Ported to Rust from https://github.com/Tw1ddle/Sky-Shader/blob/master/src/shaders/glsl/sky.fragment
+//! Ported to Rust from <https://github.com/Tw1ddle/Sky-Shader/blob/master/src/shaders/glsl/sky.fragment>
 
 #![cfg_attr(
     target_arch = "spirv",


### PR DESCRIPTION
Just adds auto links as rustdoc keeps warning about these links not being made links in the output.