### PR TITLE
Fix image operands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,12 +1852,12 @@ dependencies = [
 [[package]]
 name = "rspirv"
 version = "0.7.0"
-source = "git+https://github.com/gfx-rs/rspirv.git?rev=7111e6c5a8bb43563d280825fa65623032ee052d#7111e6c5a8bb43563d280825fa65623032ee052d"
+source = "git+https://github.com/gfx-rs/rspirv.git?rev=8a4eb0e334dcad61664f6cd28a4602614e233c3f#8a4eb0e334dcad61664f6cd28a4602614e233c3f"
 dependencies = [
  "derive_more",
  "fxhash",
  "num-traits",
- "spirv_headers 1.5.0 (git+https://github.com/gfx-rs/rspirv.git?rev=7111e6c5a8bb43563d280825fa65623032ee052d)",
+ "spirv_headers 1.5.0 (git+https://github.com/gfx-rs/rspirv.git?rev=8a4eb0e334dcad61664f6cd28a4602614e233c3f)",
 ]
 
 [[package]]
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "spirv_headers"
 version = "1.5.0"
-source = "git+https://github.com/gfx-rs/rspirv.git?rev=7111e6c5a8bb43563d280825fa65623032ee052d#7111e6c5a8bb43563d280825fa65623032ee052d"
+source = "git+https://github.com/gfx-rs/rspirv.git?rev=8a4eb0e334dcad61664f6cd28a4602614e233c3f#8a4eb0e334dcad61664f6cd28a4602614e233c3f"
 dependencies = [
  "bitflags",
  "num-traits",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -29,7 +29,7 @@ use-compiled-tools = ["spirv-tools/use-compiled-tools"]
 [dependencies]
 bimap = "0.6"
 indexmap = "1.6.0"
-rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "7111e6c5a8bb43563d280825fa65623032ee052d" }
+rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "8a4eb0e334dcad61664f6cd28a4602614e233c3f" }
 rustc-demangle = "0.1.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -953,7 +953,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                 match parse_bitflags_operand(IMAGE_OPERANDS, word) {
                     Some(x) => {
                         inst.operands.push(dr::Operand::ImageOperands(x));
-                        while let Some(token) = tokens.next() {
+                        for token in tokens {
                             match self.parse_id_in(id_map, token) {
                                 Some(id) => {
                                     inst.operands.push(dr::Operand::IdRef(id));

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -951,7 +951,23 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
             (OperandKind::ImageOperands, Some(word)) => {
                 match parse_bitflags_operand(IMAGE_OPERANDS, word) {
-                    Some(x) => inst.operands.push(dr::Operand::ImageOperands(x)),
+                    Some(x) => {
+                        inst.operands.push(dr::Operand::ImageOperands(x));
+                        for _ in 0..x.bits().count_ones() {
+                            match tokens
+                                .next()
+                                .and_then(|token| self.parse_id_in(id_map, token))
+                            {
+                                Some(id) => {
+                                    inst.operands.push(dr::Operand::IdRef(id));
+                                }
+                                None => {
+                                    self.err("expected operand id after image operand");
+                                    break;
+                                }
+                            }
+                        }
+                    }
                     None => self.err(&format!("Unknown ImageOperands {}", word)),
                 }
             }

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -953,11 +953,8 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                 match parse_bitflags_operand(IMAGE_OPERANDS, word) {
                     Some(x) => {
                         inst.operands.push(dr::Operand::ImageOperands(x));
-                        for _ in 0..x.bits().count_ones() {
-                            match tokens
-                                .next()
-                                .and_then(|token| self.parse_id_in(id_map, token))
-                            {
+                        while let Some(token) = tokens.next() {
+                            match self.parse_id_in(id_map, token) {
                                 Some(id) => {
                                     inst.operands.push(dr::Operand::IdRef(id));
                                 }


### PR DESCRIPTION
Fixes https://github.com/EmbarkStudios/rust-gpu/issues/369

Updates `rspirv` to latest main which includes fix for handling of the image operands bits.
Image operands require the following IdRefs to be parsed as well depending on the numbers of bits in the bitmask.
