### PR TITLE
Add gpu_only proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,10 @@ dependencies = [
 [[package]]
 name = "spirv-std-macros"
 version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "spirv-tools"

--- a/crates/spirv-std-macros/Cargo.toml
+++ b/crates/spirv-std-macros/Cargo.toml
@@ -8,3 +8,7 @@ repository = "https://github.com/EmbarkStudios/rust-gpu"
 
 [lib]
 proc-macro = true
+
+[dependencies]
+quote = "1.0.8"
+syn = { version = "1.0.58", features=["full"] }

--- a/crates/spirv-std/src/derivative.rs
+++ b/crates/spirv-std/src/derivative.rs
@@ -56,10 +56,8 @@ macro_rules! deriv_caps {
 
 macro_rules! deriv_fn {
     ($name:ident, $inst:ident, $needs_caps:tt) => {
+        #[spirv_std_macros::gpu_only]
         fn $name(self) -> Self {
-            #[cfg(not(target_arch = "spirv"))]
-            panic!(concat!(stringify!($name), " is not supported on the CPU"));
-            #[cfg(target_arch = "spirv")]
             unsafe {
                 let mut o = Default::default();
                 deriv_caps!($needs_caps);

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -52,8 +52,8 @@ pub use num_traits;
 pub use textures::*;
 
 /// Calls the `OpDemoteToHelperInvocationEXT` instruction, which corresponds to discard() in HLSL
+#[spirv_std_macros::gpu_only]
 pub fn demote_to_helper_invocation() {
-    #[cfg(target_arch = "spirv")]
     unsafe {
         asm!(
             "OpExtension \"SPV_EXT_demote_to_helper_invocation\"",
@@ -64,8 +64,8 @@ pub fn demote_to_helper_invocation() {
 }
 
 /// Calls the `OpKill` instruction, which corresponds to discard() in GLSL
+#[spirv_std_macros::gpu_only]
 pub fn discard() {
-    #[cfg(target_arch = "spirv")]
     unsafe {
         asm!("OpKill", "%unused = OpLabel");
     }

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -23,14 +23,8 @@ pub struct Image2d {
 }
 
 impl Image2d {
+    #[spirv_std_macros::gpu_only]
     pub fn sample(&self, sampler: Sampler, coord: Vec2) -> Vec4 {
-        #[cfg(not(target_arch = "spirv"))]
-        {
-            let _ = sampler;
-            let _ = coord;
-            panic!("Image sampling not supported on CPU");
-        }
-        #[cfg(target_arch = "spirv")]
         unsafe {
             let mut result = Default::default();
             asm!(
@@ -66,14 +60,8 @@ pub struct Image2dArray {
 }
 
 impl Image2dArray {
+    #[spirv_std_macros::gpu_only]
     pub fn sample(&self, sampler: Sampler, coord: Vec3A) -> Vec4 {
-        #[cfg(not(target_arch = "spirv"))]
-        {
-            let _ = sampler;
-            let _ = coord;
-            panic!("Image sampling not supported on CPU");
-        }
-        #[cfg(target_arch = "spirv")]
         unsafe {
             let mut result = Default::default();
             asm!(
@@ -101,13 +89,8 @@ pub struct SampledImage<I> {
 }
 
 impl SampledImage<Image2d> {
+    #[spirv_std_macros::gpu_only]
     pub fn sample(&self, coord: Vec2) -> Vec4 {
-        #[cfg(not(target_arch = "spirv"))]
-        {
-            let _ = coord;
-            panic!("Image sampling not supported on CPU");
-        }
-        #[cfg(target_arch = "spirv")]
         unsafe {
             let mut result = Default::default();
             asm!(


### PR DESCRIPTION
This PR adds a `#[gpu_only]` macro to `spirv-std-macros`, which essentially expands to the following. Which we were doing a lot in the code already, and will only add more in the future.

```rust
#[gpu_only]
fn foo() {
    // SPIR-V fn body.
}

// Generates

fn foo() {
     #[cfg(target_arch = "spriv")] {
        // SPIR-V fn body.
     }
     
     #[cfg(not(target_arch = "spriv"))] {
         unimplemented!()
     }
}