### PR TITLE
Use rspirv::dr::Function's def_id convenience method.

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/dce.rs
+++ b/crates/rustc_codegen_spirv/src/linker/dce.rs
@@ -26,7 +26,7 @@ fn spread_roots(module: &Module, rooted: &mut HashSet<Word>) -> bool {
         }
     }
     for func in &module.functions {
-        if rooted.contains(&func.def.as_ref().unwrap().result_id.unwrap()) {
+        if rooted.contains(&func.def_id().unwrap()) {
             for inst in &func.def {
                 any |= root(inst, rooted);
             }

--- a/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
+++ b/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
@@ -139,7 +139,7 @@ fn kill_linkage_instructions(module: &mut Module, rewrite_rules: &HashMap<u32, u
     // drop imported functions
     module
         .functions
-        .retain(|f| !rewrite_rules.contains_key(&f.def.as_ref().unwrap().result_id.unwrap()));
+        .retain(|f| !rewrite_rules.contains_key(&f.def_id().unwrap()));
 
     // drop imported variables
     module.types_global_values.retain(|v| {

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -17,7 +17,7 @@ pub fn inline(module: &mut Module) {
     let functions = module
         .functions
         .iter()
-        .map(|f| (f.def.as_ref().unwrap().result_id.unwrap(), f.clone()))
+        .map(|f| (f.def_id().unwrap(), f.clone()))
         .collect();
     let disallowed_argument_types = compute_disallowed_argument_types(module);
     let void = module
@@ -32,7 +32,7 @@ pub fn inline(module: &mut Module) {
     module.functions.retain(|f| {
         if should_inline(&disallowed_argument_types, f) {
             // TODO: We should insert all defined IDs in this function.
-            dropped_ids.insert(f.def.as_ref().unwrap().result_id.unwrap());
+            dropped_ids.insert(f.def_id().unwrap());
             false
         } else {
             true

--- a/crates/rustc_codegen_spirv/src/linker/new_structurizer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/new_structurizer.rs
@@ -43,7 +43,7 @@ pub fn structurize(
             builder: &mut builder,
         };
 
-        let func_id = func.function().def.as_ref().unwrap().result_id.unwrap();
+        let func_id = func.function().def_id().unwrap();
 
         let loop_control = match unroll_loops_decorations.get(&func_id) {
             Some(UnrollLoopsDecoration {}) => LoopControl::UNROLL,

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -176,7 +176,7 @@ pub fn remove_zombies(sess: &Session, module: &mut Module) {
     if env::var("PRINT_ZOMBIE").is_ok() {
         for f in &module.functions {
             if let Some(reason) = is_zombie(f.def.as_ref().unwrap(), &zombies) {
-                let name_id = f.def.as_ref().unwrap().result_id.unwrap();
+                let name_id = f.def_id().unwrap();
                 let name = module.debugs.iter().find(|inst| {
                     inst.class.opcode == Op::Name && inst.operands[0].unwrap_id_ref() == name_id
                 });


### PR DESCRIPTION
I was checking if such a method exist and noticed code using `func.def.as_ref().unwrap().result_id` instead of `func.def_id()`.