### PR TITLE
Remove different OpNames that target the same ID

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -269,8 +269,8 @@ pub fn remove_duplicate_types(module: &mut Module) {
         .annotations
         .retain(|inst| anno_set.insert(inst.assemble()));
     // Same thing with OpName
-    let mut debug_set = HashSet::new();
-    module
-        .debugs
-        .retain(|inst| debug_set.insert(inst.assemble()));
+    let mut name_ids = HashSet::new();
+    module.debugs.retain(|inst| {
+        inst.class.opcode != Op::Name || name_ids.insert(inst.operands[0].unwrap_id_ref())
+    });
 }


### PR DESCRIPTION
There's a bit of unfortunate interaction in the way we link binaries. Here's an order of operations:

1) We emit OpNames for everything, to make it easier for us to look at binaries and debug them.
2) We link the module, merging identical types etc. into the same construct. Relevant OpNames get rewritten to point at the same construct.
3) We strip dead code, types, etc.

This becomes a problem: things like ZSTs and other extremely common types are emitted a *lot*, with *many* different names. They're all merged in step 2, but then we have an absolute heap of names all pointing at the same ID, and that ID happens to be used in a few places, so we barf gazillions of strings into the binary.

So, only keep the first name we encounter for any particular ID. This will likely be the "incorrect" name (probably a name that's actually never used and would have been DCE stripped if we never merged identical constructs), but oh well, that name *does* correspond to the type, close enough.

This reduces ark's spir-v binary size **from 743KiB to 93KiB**