### PR TITLE
Don't require 1:1 mapping between `OpTypeStruct`s and their names.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -182,7 +182,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
         let field_types = elts.iter().map(|f| f.ty).collect::<Vec<_>>();
         let (field_offsets, size, align) = crate::abi::auto_struct_layout(self, &field_types);
         let struct_ty = SpirvType::Adt {
-            name: "<const_struct>".to_string(),
+            def_id: None,
             size,
             align,
             field_types,

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -144,7 +144,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
     fn type_struct(&self, els: &[Self::Type], _packed: bool) -> Self::Type {
         let (field_offsets, size, align) = crate::abi::auto_struct_layout(self, els);
         SpirvType::Adt {
-            name: "<generated_struct>".to_string(),
+            def_id: None,
             align,
             size,
             field_types: els.to_vec(),

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -1,14 +1,17 @@
-use crate::abi::RecursivePointeeCache;
+use crate::abi::{RecursivePointeeCache, TyLayoutNameKey};
 use crate::builder_spirv::SpirvValue;
 use crate::codegen_cx::CodegenCx;
 use bimap::BiHashMap;
+use indexmap::IndexSet;
 use rspirv::dr::Operand;
 use rspirv::spirv::{
     AccessQualifier, Capability, Decoration, Dim, ImageFormat, StorageClass, Word,
 };
+use rustc_span::def_id::DefId;
 use rustc_span::Span;
 use rustc_target::abi::{Align, Size};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fmt;
 use std::iter;
 use std::lazy::SyncLazy;
@@ -28,7 +31,11 @@ pub enum SpirvType {
     Float(u32),
     /// This uses the rustc definition of "adt", i.e. a struct, enum, or union
     Adt {
-        name: String,
+        /// Not emitted into SPIR-V, but used to avoid too much deduplication,
+        /// which could result in one SPIR-V `OpType*` having many names
+        /// (not in itself an issue, but it makes error reporting harder).
+        def_id: Option<DefId>,
+
         align: Align,
         size: Option<Size>,
         field_types: Vec<Word>,
@@ -124,7 +131,7 @@ impl SpirvType {
                 result
             }
             Self::Adt {
-                ref name,
+                def_id: _,
                 align: _,
                 size: _,
                 ref field_types,
@@ -136,7 +143,6 @@ impl SpirvType {
                 // Ensure a unique struct is emitted each time, due to possibly having different OpMemberDecorates
                 let id = emit.id();
                 let result = emit.type_struct_id(Some(id), field_types.iter().cloned());
-                emit.name(result, name);
                 // The struct size is only used in our own sizeof_in_bits() (used in e.g. ArrayStride decoration)
                 if !cx.kernel_mode {
                     // TODO: kernel mode can't do this??
@@ -269,6 +275,24 @@ impl SpirvType {
         result
     }
 
+    /// In addition to `SpirvType::def`, also name the resulting type (with `OpName`).
+    pub fn def_with_name<'tcx>(
+        self,
+        cx: &CodegenCx<'tcx>,
+        def_span: Span,
+        name_key: TyLayoutNameKey<'tcx>,
+    ) -> Word {
+        let id = self.def(def_span, cx);
+
+        // Only emit `OpName` if this is the first time we see this name.
+        let mut type_names = cx.type_cache.type_names.borrow_mut();
+        if type_names.entry(id).or_default().insert(name_key) {
+            cx.emit_global().name(id, name_key.to_string());
+        }
+
+        id
+    }
+
     /// Use this if you want a pretty type printing that recursively prints the types within (e.g. struct fields)
     pub fn debug<'cx, 'tcx>(
         self,
@@ -364,7 +388,7 @@ impl fmt::Debug for SpirvTypePrinter<'_, '_> {
                 .field("width", &width)
                 .finish(),
             SpirvType::Adt {
-                ref name,
+                def_id,
                 align,
                 size,
                 ref field_types,
@@ -378,7 +402,7 @@ impl fmt::Debug for SpirvTypePrinter<'_, '_> {
                     .collect::<Vec<_>>();
                 f.debug_struct("Adt")
                     .field("id", &self.id)
-                    .field("name", &name)
+                    .field("def_id", &def_id)
                     .field("align", &align)
                     .field("size", &size)
                     .field("field_types", &fields)
@@ -512,7 +536,7 @@ impl SpirvTypePrinter<'_, '_> {
             }
             SpirvType::Float(width) => write!(f, "f{}", width),
             SpirvType::Adt {
-                ref name,
+                def_id: _,
                 align: _,
                 size: _,
                 ref field_types,
@@ -523,7 +547,27 @@ impl SpirvTypePrinter<'_, '_> {
                 if is_block {
                     write!(f, "#[spirv(block)] ")?;
                 }
-                write!(f, "struct {} {{ ", name)?;
+
+                write!(f, "struct")?;
+
+                // HACK(eddyb) use the first name (in insertion order, i.e.
+                // from the first invocation of `def_with_name` for this type)
+                // even when this may not be correct - a better solution could
+                // be to pick the shortest name (which could work well when
+                // newtypes are involved).
+                let first_name = {
+                    let type_names = self.cx.type_cache.type_names.borrow();
+                    type_names
+                        .get(&self.id)
+                        .and_then(|names| names.iter().next().copied())
+                };
+
+                if let Some(name) = first_name {
+                    write!(f, " {}", name)?;
+                }
+
+                write!(f, " {{ ")?;
+
                 for (index, &field) in field_types.iter().enumerate() {
                     let suffix = if index + 1 == field_types.len() {
                         ""
@@ -614,6 +658,10 @@ pub struct TypeCache<'tcx> {
     pub type_defs: RefCell<BiHashMap<Word, SpirvType>>,
     /// Recursive pointer breaking
     pub recursive_pointee_cache: RecursivePointeeCache<'tcx>,
+    /// Set of names for a type (only `SpirvType::Adt` currently).
+    /// The same `OpType*` may have multiple names if it's e.g. a generic
+    /// `struct` where the generic parameters result in the same field types.
+    type_names: RefCell<HashMap<Word, IndexSet<TyLayoutNameKey<'tcx>>>>,
 }
 
 impl TypeCache<'_> {

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -382,3 +382,16 @@ pub fn main() {
 }
 "#);
 }
+
+#[test]
+fn mat3_vec3_multiply() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main(input: Input<glam::Mat3>, mut output: Output<glam::Vec3>) {
+    let input = input.load();
+    let vector = input * glam::Vec3::new(1.0, 2.0, 3.0);
+    output.store(vector);
+}
+"#);
+}


### PR DESCRIPTION
The linker deduplicates types based on their definition anyway (though maybe we should do less of that - see https://github.com/EmbarkStudios/rust-gpu/pull/398#issuecomment-769037295), so the main side-effect of `SpirvType::Adt` having contained a `name: String` was that some types would be considered different during codegen itself (even when otherwise compatible). Specifically, the added test used to fail with:
```
error: Cannot cast between pointer types
   --> /home/eddy/.cargo/registry/src/github.com-1ecc6299db9ec823/glam-0.12.0/src/mat3.rs:462:1
    |
462 | impl_mat3_traits!(f32, mat3, Mat3, Vec3);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: from: *{Function} struct spirv_std::glam::Mat3 { 0: struct spirv_std::glam::core::storage::Vector3x3<spirv_std::glam::XYZ<f32>> { x_axis: f32x3, y_axis: f32x3, z_axis: f32x3 } }
    = note: to: *{Function} struct spirv_std::glam::core::storage::Vector3x3<spirv_std::glam::Vec3> { x_axis: f32x3, y_axis: f32x3, z_axis: f32x3 }
```

But with this PR, a single type definition is generated, and it gets two `OpName`s, instead:
```llvm
OpName %5 "spirv_std::glam::core::storage::Vector3x3<spirv_std::glam::XYZ<f32>>"
OpName %5 "spirv_std::glam::core::storage::Vector3x3<spirv_std::glam::Vec3>"
```
(snippet obtained via `DUMP_PRE_LINK`, to avoid linker deduplication, #398, etc.)

If we had some compile failure tests akin to `ui` tests in `rust-lang/rust`, it would've been useful to see how bad the "show the first name" approach can get. If we think printing `SpirvType`s in errors is relatively rare, we could show all names even etc.