### PR TITLE
Add vector_insert_dynamic

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -461,6 +461,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
     ) -> Option<Word> {
         use crate::spirv_type_constraints::{instruction_signatures, InstSig, TyListPat, TyPat};
 
+        #[derive(Debug)]
         struct Mismatch;
 
         /// Recursively match `ty` against `pat`, returning one of:

--- a/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
@@ -371,8 +371,10 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         // 3.37.12. Composite Instructions
         Op::VectorExtractDynamic => sig! { (Vector(T), _) -> T },
         Op::VectorInsertDynamic => sig! {
-            // FIXME(eddyb) missing equality constraint between input and output vectors.
-            // (Vector(T), T, _) -> Vector(T)
+            // FIXME(eddyb) was `(Vector(T), T, _) -> Vector(T)` but that was
+            // missing an equality constraint between input and output vectors;
+            // we should use `(Vector(T, N), T, _) -> Vector(T, N)`, or constrain
+            // input and output vectors to have the same type some other way.
             (T, _, _) -> T
         },
         Op::VectorShuffle => sig! { (Vector(T), Vector(T)) -> Vector(T) },

--- a/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
@@ -22,7 +22,7 @@
 use rspirv::spirv::Op;
 
 /// Pattern for a SPIR-V type, dynamic representation (see module-level docs).
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TyPat<'a> {
     /// Unconstrained type.
     Any,
@@ -97,7 +97,7 @@ impl TyPat<'_> {
 ///
 /// "Type lists" are used for `OpTypeStruct` fields, `OpTypeFunction` parameters,
 /// and operand types of instructions signatures.
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TyListPat<'a> {
     /// Unconstrained type list (any length, and the types can freely vary).
     Any,
@@ -126,7 +126,7 @@ impl TyListPat<'_> {
 }
 
 /// Instruction "signature", dynamic representation (see module-level docs).
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct InstSig<'a> {
     /// Patterns for the complete list of types of the instruction's value operands.
     pub inputs: &'a TyListPat<'a>,
@@ -372,7 +372,8 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         Op::VectorExtractDynamic => sig! { (Vector(T), _) -> T },
         Op::VectorInsertDynamic => sig! {
             // FIXME(eddyb) missing equality constraint between input and output vectors.
-            (Vector(T), T, _) -> Vector(T)
+            // (Vector(T), T, _) -> Vector(T)
+            (T, _, _) -> T
         },
         Op::VectorShuffle => sig! { (Vector(T), Vector(T)) -> Vector(T) },
         Op::CompositeConstruct => sig! {

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -384,6 +384,33 @@ pub fn main() {
 }
 
 #[test]
+fn vector_insert_dynamic() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let vector = glam::Vec2::new(1.0, 2.0);
+    let expected = glam::Vec2::new(1.0, 3.0);
+    let new_vector = unsafe { spirv_std::arch::vector_insert_dynamic(vector, 1, 3.0) };
+    assert!(new_vector == expected);
+}
+"#);
+}
+
+#[test]
+fn copy_object() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let vector = glam::Vec2::new(1.0, 2.0);
+    let new_vector = unsafe { spirv_std::arch::copy_object(vector) };
+    assert!(new_vector == vector);
+}
+"#);
+}
+
+#[test]
 fn mat3_vec3_multiply() {
     val(r#"
 #[allow(unused_attributes)]

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -398,19 +398,6 @@ pub fn main() {
 }
 
 #[test]
-fn copy_object() {
-    val(r#"
-#[allow(unused_attributes)]
-#[spirv(fragment)]
-pub fn main() {
-    let vector = glam::Vec2::new(1.0, 2.0);
-    let new_vector = unsafe { spirv_std::arch::copy_object(vector) };
-    assert!(new_vector == vector);
-}
-"#);
-}
-
-#[test]
 fn mat3_vec3_multiply() {
     val(r#"
 #[allow(unused_attributes)]

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -37,12 +37,17 @@ pub unsafe fn vector_extract_dynamic<T: Scalar, V: Vector<T>>(vector: V, index: 
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpVectorInsertDynamic")]
 #[inline]
-pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T>>(vector: V, index: usize, element: T) -> V {
+pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T>>(
+    vector: V,
+    index: usize,
+    element: T,
+) -> V {
     let mut result = V::default();
 
     asm! {
         "%vector = OpLoad _ {vector}",
-        "%new_vector = OpVectorInsertDynamic _ %vector {element} {index}",
+        "%element = OpLoad _ {element}",
+        "%new_vector = OpVectorInsertDynamic _ %vector %element {index}",
         "OpStore {result} %new_vector",
         vector = in(reg) &vector,
         index = in(reg) index,
@@ -51,23 +56,4 @@ pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T>>(vector: V, index: u
     }
 
     result
-}
-
-/// Make a copy of `object`.
-/// 
-/// # Safety
-/// `T` must be a composite type (vector, array, or matrix).
-#[spirv_std_macros::gpu_only]
-#[doc(alias = "OpCopyObject")]
-#[inline]
-pub unsafe fn copy_object<T>(object: T) -> T {
-    let mut result = core::mem::MaybeUninit::uninit();
-
-    asm! {
-        "{copy} = OpCopyObject {object}",
-        object = in(reg) &object,
-        copy = in(reg) result.as_mut_ptr(),
-    }
-
-    result.assume_init()
 }

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -54,6 +54,9 @@ pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T>>(vector: V, index: u
 }
 
 /// Make a copy of `object`.
+/// 
+/// # Safety
+/// `T` must be a composite type (vector, array, or matrix).
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpCopyObject")]
 #[inline]

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -1,5 +1,5 @@
 /// Abstract trait representing a SPIR-V vector type.
-pub trait Vector<T: crate::scalar::Scalar>: crate::sealed::Sealed {}
+pub trait Vector<T: crate::scalar::Scalar>: crate::sealed::Sealed + Default {}
 
 impl Vector<bool> for glam::BVec2 {}
 impl Vector<bool> for glam::BVec3 {}


### PR DESCRIPTION
Adds two new simple instructions to the arch module that map to `OpVectorInsertDynamic` and `OpCopyObject` instructions.