### PR TITLE
Add a missing `err.emit();` for the "spirv-opt failed" error.

### DIFF
--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -202,6 +202,7 @@ fn do_spirv_opt(sess: &Session, spv_binary: Vec<u32>, filename: &Path) -> Vec<u3
             let mut err = sess.struct_warn(&e.to_string());
             err.note("spirv-opt failed, leaving as unoptimized");
             err.note(&format!("module {:?}", filename));
+            err.emit();
             spv_binary
         }
     }


### PR DESCRIPTION
Without that `.emit()`, the diagnostic would get dropped, which ICEs:
<details>
<summary>(click to open an example log of the ICE)</summary>

```
  error: The following forward referenced IDs have not been defined:
  3[%in_frag_coord] 4[%constants] 5[%output] 7[%vert_idx] 8[%builtin_pos]
    |
    = note: module "/home/eddy/Projects/rust-gpu/target/spirv-builder/spirv-unknown-unknown/release/deps/sky_shader.spv"

  error: internal compiler error: the following error was constructed but not emitted

  warning: internal error
    |
    = note: spirv-opt failed, leaving as unoptimized
    = note: module "/home/eddy/Projects/rust-gpu/target/spirv-builder/spirv-unknown-unknown/release/deps/sky_shader.spv"

  thread 'rustc' panicked at 'explicit panic', compiler/rustc_errors/src/diagnostic_builder.rs:460:13
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

  error: internal compiler error: unexpected panic

  note: the compiler unexpectedly panicked. this is a bug.

  note: we would appreciate a bug report: https://github.com/EmbarkStudios/rust-gpu/issues/new

  note: rustc 1.51.0-nightly (257becbfe 2020-12-27) running on x86_64-unknown-linux-gnu

  note: compiler flags: -Z unstable-options -Z codegen-backend=/home/eddy/Projects/rust-gpu/target/debug/deps/librustc_codegen_spirv.so -Z symbol-mangling-version=v0 -C prefer-dynamic -C opt-level=3 -C embed-bitcode=no -C target-feature=+spirv1.0 --crate-type dylib

  note: some of the compiler flags provided by cargo are hidden

  query stack during panic:
  end of query stack
  note: `rust-gpu` version 0.2.0

  error: aborting due to 2 previous errors; 1 warning emitted
```
</details>

However, the worst part is that the file path being shown is never written to, which was really confusing (since the file didn't seem to have any issues - that's because it was a week old, from a different branch!).