### PR TITLE
Don't auto-merge PRs with the `manual-merge` label set.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,7 @@ pull_request_rules:
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
       - base=main
+      - label!=manual-merge
     actions:
       merge:
         method: squash


### PR DESCRIPTION
This change has been made by @eddyb from https://mergify.io config editor.