### PR TITLE
simd_types_indirect: false

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -409,7 +409,7 @@ fn trans_type_impl<'tcx>(
             .def_with_name(cx, span, TyLayoutNameKey::from(ty))
         }
         Abi::Vector { ref element, count } => {
-            let elem_spirv = trans_scalar(cx, span, ty, element, None, is_immediate);
+            let elem_spirv = trans_scalar(cx, span, ty, element, None, false);
             SpirvType::Vector {
                 element: elem_spirv,
                 count: count as u32,

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -193,6 +193,7 @@ fn target_options() -> Target {
         data_layout: "e-m:e-p:32:32:32-i64:64-n8:16:32:64".to_string(),
         arch: "spirv".to_string(),
         options: TargetOptions {
+            simd_types_indirect: false,
             allows_weak_linkage: false,
             crt_static_allows_dylibs: true,
             dll_prefix: "".to_string(),


### PR DESCRIPTION
also fix bug in abi.rs - vectors are always memory, never immediate