### PR TITLE
Add StorageImage with read/write

### DIFF
--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -430,3 +430,29 @@ pub fn main(input: Input<glam::Mat3>, mut output: Output<glam::Vec3>) {
 }
 "#);
 }
+
+#[test]
+fn image_read() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main(input: UniformConstant<StorageImage2d>, mut output: Output<glam::Vec2>) {
+    let image = input.load();
+    let coords = image.read(glam::IVec2::new(0, 1));
+    output.store(coords);
+}
+"#);
+}
+
+#[test]
+fn image_write() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main(input: Input<glam::Vec2>, image: UniformConstant<StorageImage2d>) {
+    let texels = input.load();
+    let image = image.load();
+    image.write(glam::UVec2::new(0, 1), texels);
+}
+"#);
+}

--- a/crates/spirv-std/src/integer.rs
+++ b/crates/spirv-std/src/integer.rs
@@ -1,0 +1,11 @@
+/// Abstract trait representing a SPIR-V integer type.
+pub trait Integer: num_traits::PrimInt + crate::scalar::Scalar {}
+
+impl Integer for u8 {}
+impl Integer for u16 {}
+impl Integer for u32 {}
+impl Integer for u64 {}
+impl Integer for i8 {}
+impl Integer for i16 {}
+impl Integer for i32 {}
+impl Integer for i64 {}

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -45,6 +45,7 @@ pub extern crate spirv_std_macros;
 
 pub mod arch;
 pub mod derivative;
+pub mod integer;
 pub mod scalar;
 pub(crate) mod sealed;
 pub mod storage_class;

--- a/crates/spirv-std/src/scalar.rs
+++ b/crates/spirv-std/src/scalar.rs
@@ -3,5 +3,11 @@ pub trait Scalar: Copy + Default + crate::sealed::Sealed {}
 
 impl Scalar for bool {}
 impl Scalar for f32 {}
+impl Scalar for u8 {}
+impl Scalar for u16 {}
 impl Scalar for u32 {}
+impl Scalar for u64 {}
+impl Scalar for i8 {}
+impl Scalar for i16 {}
 impl Scalar for i32 {}
+impl Scalar for i64 {}

--- a/crates/spirv-std/src/sealed.rs
+++ b/crates/spirv-std/src/sealed.rs
@@ -4,8 +4,14 @@ pub trait Sealed {}
 
 impl Sealed for bool {}
 impl Sealed for f32 {}
+impl Sealed for u8 {}
+impl Sealed for u16 {}
 impl Sealed for u32 {}
+impl Sealed for u64 {}
+impl Sealed for i8 {}
+impl Sealed for i16 {}
 impl Sealed for i32 {}
+impl Sealed for i64 {}
 impl Sealed for glam::BVec2 {}
 impl Sealed for glam::BVec3 {}
 impl Sealed for glam::BVec4 {}

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -1,5 +1,7 @@
 use glam::{Vec2, Vec3A, Vec4};
 
+use crate::{integer::Integer, vector::Vector};
+
 #[allow(unused_attributes)]
 #[spirv(sampler)]
 #[derive(Copy, Clone)]
@@ -40,6 +42,69 @@ impl Image2d {
                 in(reg) &coord
             );
             result
+        }
+    }
+}
+
+#[allow(unused_attributes)]
+#[spirv(image(
+    // sampled_type is hardcoded to f32 for now
+    dim = "Dim2D",
+    depth = 0,
+    arrayed = 0,
+    multisampled = 0,
+    sampled = 2,
+    image_format = "Unknown"
+))]
+#[derive(Copy, Clone)]
+pub struct StorageImage2d {
+    _x: u32,
+}
+
+impl StorageImage2d {
+    /// Read a texel from an image without a sampler.
+    #[spirv_std_macros::gpu_only]
+    pub fn read<I, V, V2>(&self, coordinate: V) -> V2
+    where
+        I: Integer,
+        V: Vector<I>,
+        V2: Vector<f32>,
+    {
+        let mut result = V2::default();
+
+        unsafe {
+            asm! {
+                "%image = OpLoad _ {this}",
+                "%coordinate = OpLoad _ {coordinate}",
+                "%result = OpImageRead typeof*{result} %image %coordinate",
+                "OpStore {result} %result",
+                this = in(reg) self,
+                coordinate = in(reg) &coordinate,
+                result = in(reg) &mut result,
+            }
+        }
+
+        result
+    }
+
+    /// Write a texel to an image without a sampler.
+    #[spirv_std_macros::gpu_only]
+    pub fn write<I, V, V2>(&self, coordinate: V, texels: V2)
+    where
+        I: Integer,
+        V: Vector<I>,
+        V2: Vector<f32>,
+    {
+        unsafe {
+            asm! {
+                "%image = OpLoad _ {this}",
+                "%coordinate = OpLoad _ {coordinate}",
+                "%texels = OpLoad _ {texels}",
+                "OpImageWrite %image %coordinate %texels",
+                this = in(reg) self,
+                coordinate = in(reg) &coordinate,
+                texels = in(reg) &texels,
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds a new `StorageImage2d` which doesn't use a sampler and allows you to use `OpImageRead` and `OpImageWrite` with the `read`  and `write` functions.