### PR TITLE
Work around linker error by isolating spirv_tools usage to rustc_codegen_spirv.

### DIFF
--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -121,7 +121,6 @@ use rustc_session::Session;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_target::spec::abi::Abi;
 use rustc_target::spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetTriple};
-pub use spirv_tools;
 use std::any::Any;
 use std::env;
 use std::fs::{create_dir_all, File};
@@ -608,4 +607,18 @@ pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
     }));
 
     Box::new(SpirvCodegenBackend)
+}
+
+// HACK(eddyb) this allows `spirv-builder` to use `spirv-tools::val` without
+// risking linker errors (especially when compiled with optimizations) - this
+// also means the function can't be generic or `#[inline]`.
+pub use spirv_tools::TargetEnv as SpirvToolsTargetEnv;
+#[inline(never)]
+pub fn spirv_tools_validate(
+    target_env: Option<spirv_tools::TargetEnv>,
+    bytes: &[u8],
+    options: Option<spirv_tools::val::ValidatorOptions>,
+) -> Result<(), spirv_tools::error::Error> {
+    use spirv_tools::val::Validator as _;
+    spirv_tools::val::create(target_env).validate(spirv_tools::binary::to_binary(bytes)?, options)
 }

--- a/crates/spirv-builder/src/test/mod.rs
+++ b/crates/spirv-builder/src/test/mod.rs
@@ -100,17 +100,11 @@ fn val(src: &str) {
 /// stricter Vulkan validation (`vulkan1.2` specifically), which may produce
 /// additional errors (such as missing Vulkan-specific decorations).
 fn val_vulkan(src: &str) {
-    use rustc_codegen_spirv::spirv_tools::{
-        binary::to_binary,
-        val::{self, Validator},
-        TargetEnv,
-    };
-
-    let validator = val::create(Some(TargetEnv::Vulkan_1_2));
+    use rustc_codegen_spirv::{spirv_tools_validate as validate, SpirvToolsTargetEnv as TargetEnv};
 
     let _lock = global_lock();
     let bytes = std::fs::read(build(src)).unwrap();
-    if let Err(e) = validator.validate(to_binary(&bytes).unwrap(), None) {
+    if let Err(e) = validate(Some(TargetEnv::Vulkan_1_2), &bytes, None) {
         panic!("Vulkan validation failed:\n{}", e.to_string());
     }
 }


### PR DESCRIPTION
For a while now I haven't been able to run `cargo test --release -p spirv-builder`, as I would get this link error:
```
  = note: ld: /home/eddy/Projects/rust-gpu/target/release/deps/spirv_builder-e8692b806589bb2b.spirv_builder.3lx9jx37-cgu.15.rcgu.o: in function `<spirv_tools::val::compiled::CompiledValidator as spirv_tools::val::Validator>::validate':
          spirv_builder.3lx9jx37-cgu.15:(.text._ZN93_$LT$spirv_tools..val..compiled..CompiledValidator$u20$as$u20$spirv_tools..val..Validator$GT$8validate17h79ecbb1961cc80b1E+0xce):
              undefined reference to `spvValidateWithOptions'
          ld: spirv_builder.3lx9jx37-cgu.15:(.text._ZN93_$LT$spirv_tools..val..compiled..CompiledValidator$u20$as$u20$spirv_tools..val..Validator$GT$8validate17h79ecbb1961cc80b1E+0xf6):
              undefined reference to `spvValidate'
          collect2: error: ld returned 1 exit status
```

This would be confined to `--release` (i.e. debug mode would still work fine), but I really wanted that for the additional speed.

Investigation turned up nothing weird regarding those symbols, but `spirv-builder` does use `spirv-tools` in a weird way (via a reexport through `rustc_codegen_spirv`, which is a dylib), so I tried removing any direct uses of `spirv-tools(-sys)` symbols from `spirv-builder`, by introducing a helper in `rustc_codegen_spirv`, and that worked.