### PR TITLE
Use [profile.release.build-override] to optimize build dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,9 @@ members = [
     "crates/spirv-builder",
     "crates/spirv-std",
 ]
+
+# Compile build-dependencies in release mode with
+# the same settings as regular dependencies.
+[profile.release.build-override]
+opt-level = 3
+codegen-units = 16


### PR DESCRIPTION
Based on these parts of the Cargo docs on Profiles:
* https://doc.rust-lang.org/cargo/reference/profiles.html#build-dependencies
* https://doc.rust-lang.org/cargo/reference/profiles.html#overrides
* https://doc.rust-lang.org/cargo/reference/profiles.html#release

I'm pretty sure that adding this to the workspace `Cargo.toml` will cause `[build-dependencies]` (and build scripts and proc macros) to be compiled the same way as regular dependencies, but *only* when building with `--release` (so debug mode isn't affected):
```toml
[profile.release.build-override]
opt-level = 3
codegen-units = 16
```

Sadly, everyone using Rust-GPU would need to replicate this, so we might want to document this somewhere.
(We should probably also document that passing `--release` makes building the shaders themselves faster)

In our case, the relevant "build dependencies" are `rustc_codegen_spirv` and its dependencies (e.g. `rspirv`), where having them optimized makes some linker passes up to 20x faster (including the new one in #414, which is why I looked into this).

The overall results from this are also pretty compelling:
* Debug mode
```console
$ cat target/debug/build/example-runner-wgpu-*/stderr
   Compiling compiler_builtins v0.1.36
   Compiling proc-macro2 v1.0.24
   Compiling core v0.0.0 (/home/eddy/.rustup/toolchains/nightly-2020-12-28-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
   Compiling autocfg v1.0.1
   Compiling unicode-xid v0.2.1
   Compiling libm v0.2.1
   Compiling syn v1.0.60
   Compiling num-traits v0.2.14
   Compiling quote v1.0.9
   Compiling rustc-std-workspace-core v1.99.0 (/home/eddy/.rustup/toolchains/nightly-2020-12-28-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling glam v0.12.0
   Compiling spirv-std-macros v0.3.0-alpha.0 (/home/eddy/Projects/rust-gpu/crates/spirv-std-macros)
   Compiling spirv-std v0.3.0-alpha.0 (/home/eddy/Projects/rust-gpu/crates/spirv-std)
   Compiling shared v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/shared)
   Compiling sky-shader v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/sky-shader)
    Finished release [optimized] target(s) in 58.27s
   Compiling simplest-shader v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/simplest-shader)
    Finished release [optimized] target(s) in 11.36s
   Compiling compute-shader v0.3.0-alpha.0 (/home/eddy/Projects/rust-gpu/examples/shaders/compute-shader)
    Finished release [optimized] target(s) in 11.37s
   Compiling mouse-shader v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/mouse-shader)
    Finished release [optimized] target(s) in 25.49s
```
* Release mode
```console
$ cat target/release/build/example-runner-wgpu-*/stderr
   Compiling compiler_builtins v0.1.36
   Compiling core v0.0.0 (/home/eddy/.rustup/toolchains/nightly-2020-12-28-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
   Compiling proc-macro2 v1.0.24
   Compiling unicode-xid v0.2.1
   Compiling libm v0.2.1
   Compiling autocfg v1.0.1
   Compiling syn v1.0.60
   Compiling num-traits v0.2.14
   Compiling quote v1.0.9
   Compiling rustc-std-workspace-core v1.99.0 (/home/eddy/.rustup/toolchains/nightly-2020-12-28-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling glam v0.12.0
   Compiling spirv-std-macros v0.3.0-alpha.0 (/home/eddy/Projects/rust-gpu/crates/spirv-std-macros)
   Compiling spirv-std v0.3.0-alpha.0 (/home/eddy/Projects/rust-gpu/crates/spirv-std)
   Compiling shared v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/shared)
   Compiling sky-shader v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/sky-shader)
    Finished release [optimized] target(s) in 23.41s
   Compiling simplest-shader v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/simplest-shader)
    Finished release [optimized] target(s) in 1.06s
   Compiling compute-shader v0.3.0-alpha.0 (/home/eddy/Projects/rust-gpu/examples/shaders/compute-shader)
    Finished release [optimized] target(s) in 1.05s
   Compiling mouse-shader v0.1.0 (/home/eddy/Projects/rust-gpu/examples/shaders/mouse-shader)
    Finished release [optimized] target(s) in 1.91s
```

Assuming `sky-shader` takes somewhere between `simplest-shader` and `mouse-shader`, we can see that the speedup for the final shader crate (i.e. when a lot of SPIR-V codegen and linking is involved) is around 10x, whereas `core` itself doesn't get a big speedup (as most of the work is in `rustc` itself, which is optimized either way).