### PR TITLE
Remove accidentally-commited `test = false` from rustc_codegen_spirv/Cargo.toml.

### DIFF
--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/EmbarkStudios/rust-gpu"
 
 [lib]
 crate-type = ["dylib"]
-test = false
 
 [features]
 # By default, the use-compiled-tools is enabled, as doesn't require additional


### PR DESCRIPTION
See https://github.com/EmbarkStudios/rust-gpu/pull/414#discussion_r580158992.