### PR TITLE
Add arch functions for all non-Matrix arithmetic instructions

### DIFF
--- a/crates/spirv-builder/src/test/arch.rs
+++ b/crates/spirv-builder/src/test/arch.rs
@@ -1,0 +1,304 @@
+use super::val;
+
+#[test]
+fn any() {
+    val(r#"
+
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let vector = glam::BVec2::new(true, false);
+    assert!(arch::any(vector));
+}
+"#);
+}
+
+#[test]
+fn all() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let vector = glam::BVec2::new(true, true);
+    assert!(spirv_std::arch::all(vector));
+}
+"#);
+}
+
+#[test]
+fn s_negate() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let operand: i32 = -5;
+    let vector = glam::IVec2::new(-5, -0);
+    assert!(arch::s_negate_vector(vector) == glam::IVec2::new(5, 0));
+}
+"#);
+}
+
+#[test]
+fn f_negate() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let operand: f32 = -5.0;
+    let vector = glam::Vec2::new(-5.0, -0.0);
+    assert!(arch::f_negate_vector(vector) == glam::Vec2::new(5.0, 0.0));
+}
+"#);
+}
+
+#[test]
+fn i_add() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 5;
+    let y = 2;
+    let vx = glam::IVec2::new(2, 5);
+    let vy = glam::IVec2::new(5, 2);
+    assert!(arch::i_add_vector(vx, vy) == glam::IVec2::new(7, 7));
+}
+"#);
+}
+
+#[test]
+fn f_add() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 5.0;
+    let y = 2.0;
+    let vx = glam::Vec2::new(2.0, 5.0);
+    let vy = glam::Vec2::new(5.0, 2.0);
+    assert!(arch::f_add_vector(vx, vy) == glam::Vec2::new(7.0, 7.0));
+}
+"#);
+}
+
+#[test]
+fn i_sub() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 5;
+    let y = 5;
+    let vx = glam::IVec2::new(5, 7);
+    let vy = glam::IVec2::new(5, 7);
+    assert!(arch::i_sub_vector(vx, vy) == glam::IVec2::new(0, 0));
+}
+"#);
+}
+
+#[test]
+fn f_sub() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 5.0;
+    let y = 5.0;
+    let vx = glam::Vec2::new(5.0, 7.0);
+    let vy = glam::Vec2::new(5.0, 7.0);
+    assert!(arch::f_sub_vector(vx, vy) == glam::Vec2::new(0.0, 0.0));
+}
+"#);
+}
+
+#[test]
+fn i_mul() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 5;
+    let y = 2;
+    let vx = glam::IVec2::new(5, 2);
+    let vy = glam::IVec2::new(2, 5);
+    assert!(arch::i_mul_vector(vx, vy) == glam::IVec2::new(10, 10));
+}
+"#);
+}
+
+#[test]
+fn f_mul() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 5.0;
+    let y = 2.0;
+    let vx = glam::Vec2::new(5.0, 2.0);
+    let vy = glam::Vec2::new(2.0, 5.0);
+    assert!(arch::f_mul_vector(vx, vy) == glam::Vec2::new(10.0, 10.0));
+}
+"#);
+}
+
+#[test]
+fn s_div() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 10;
+    let y = 2;
+    let vx = glam::IVec2::new(10, 10);
+    let vy = glam::IVec2::new(2, 2);
+    assert!(arch::s_div_vector(vx, vy) == glam::IVec2::new(5, 5));
+}
+"#);
+}
+
+#[test]
+fn u_div() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x: u32 = 10;
+    let y = 2;
+    let vx = glam::UVec2::new(10, 10);
+    let vy = glam::UVec2::new(2, 2);
+    assert!(arch::u_div_vector(vx, vy) == glam::UVec2::new(5, 5));
+}
+"#);
+}
+
+#[test]
+fn f_div() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 10.0;
+    let y = 2.0;
+    let vx = glam::Vec2::new(10.0, 10.0);
+    let vy = glam::Vec2::new(2.0, 2.0);
+    assert!(arch::f_div_vector(vx, vy) == glam::Vec2::new(5.0, 5.0));
+}
+"#);
+}
+
+#[test]
+fn u_mod() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x: u32 = 10;
+    let y = 2;
+    let vx = glam::UVec2::new(10, 10);
+    let vy = glam::UVec2::new(2, 2);
+    assert!(arch::u_mod_vector(vx, vy) == glam::UVec2::new(0, 0));
+}
+"#);
+}
+
+#[test]
+fn s_mod() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 10;
+    let y = 2;
+    let vx = glam::IVec2::new(10, 10);
+    let vy = glam::IVec2::new(2, 2);
+    assert!(arch::s_mod_vector(vx, vy) == glam::IVec2::new(0, 0));
+}
+"#);
+}
+
+#[test]
+fn s_rem() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = -10;
+    let y = -2;
+    let vx = glam::IVec2::new(-10, -10);
+    let vy = glam::IVec2::new(-2, -2);
+    assert!(arch::s_rem_vector(vx, vy) == glam::IVec2::new(-0, -0));
+}
+"#);
+}
+
+#[test]
+fn f_mod() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = 10.0;
+    let y = 2.0;
+    let vx = glam::Vec2::new(10.0, 10.0);
+    let vy = glam::Vec2::new(2.0, 2.0);
+    assert!(arch::f_mod_vector(vx, vy) == glam::Vec2::new(0.0, 0.0));
+}
+"#);
+}
+
+#[test]
+fn f_rem() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let x = -10.0;
+    let y = -2.0;
+    let vx = glam::Vec2::new(-10.0, -10.0);
+    let vy = glam::Vec2::new(-2.0, -2.0);
+    assert!(arch::f_mod_vector(vx, vy) == glam::Vec2::new(-0.0, -0.0));
+}
+"#);
+}
+
+#[test]
+fn vector_times_scalar() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let vector = glam::Vec2::new(10.0, 10.0);
+    let scalar = 2.0;
+    assert!(arch::vector_times_scalar(vector, scalar) == glam::Vec2::new(20.0, 20.0));
+}
+"#);
+}
+
+#[test]
+fn vector_extract_dynamic() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let vector = glam::Vec2::new(1.0, 2.0);
+    let element = unsafe { spirv_std::arch::vector_extract_dynamic(vector, 1) };
+    assert!(2.0 == element);
+}
+"#);
+}
+
+#[test]
+fn vector_insert_dynamic() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment)]
+pub fn main() {
+    let vector = glam::Vec2::new(1.0, 2.0);
+    let expected = glam::Vec2::new(1.0, 3.0);
+    let new_vector = unsafe { spirv_std::arch::vector_insert_dynamic(vector, 1, 3.0) };
+    assert!(new_vector == expected);
+}
+"#);
+}
+
+

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -6,8 +6,12 @@
 #[cfg(feature = "const-generics")]
 use crate::{scalar::Scalar, vector::Vector};
 
+#[cfg(feature = "const-generics")]
+mod arithmetic;
 mod derivative;
 
+#[cfg(feature = "const-generics")]
+pub use arithmetic::*;
 pub use derivative::*;
 
 /// Result is true if any component of `vector` is true, otherwise result is

--- a/crates/spirv-std/src/arch/arithmetic.rs
+++ b/crates/spirv-std/src/arch/arithmetic.rs
@@ -1,0 +1,574 @@
+// The new preferred style is still to use `unsafe` blocks in `unsafe` functions
+// but the compiler/clippy hasn't caught up to that style yet, so we just
+// disable the lint.
+#![allow(unused_unsafe)]
+#![cfg(feature = "const-generics")]
+
+use crate::{
+    float::Float,
+    integer::{Integer, SignedInteger, UnsignedInteger},
+    vector::Vector,
+};
+
+/// Signed-integer subtract of `operand` from zero. Results are computed
+/// per component.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpSNegate")]
+#[inline]
+pub fn s_negate_vector<S, V, const N: usize>(operand: V) -> V
+where
+    S: SignedInteger,
+    V: Vector<S, N>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} 1",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%operand = OpLoad %vec_type {operand}",
+            "%result = OpSNegate %vec_type %operand",
+            "OpStore {result} %result",
+            operand = in(reg) &operand,
+            width = const S::WIDTH,
+            length = const N,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Floating-point subtract of `operand` from zero. Results are computed
+/// per component.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpFNegate")]
+#[inline]
+pub fn f_negate_vector<F, V, const N: usize>(operand: V) -> V
+where
+    F: Float,
+    V: Vector<F, N>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%operand = OpLoad %vec_type {operand}",
+            "%result = OpFNegate %vec_type %operand",
+            "OpStore {result} %result",
+            operand = in(reg) &operand,
+            width = const F::WIDTH,
+            length = const N,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Integer addition of `x` and `y`. Results are computed per component.
+///
+/// # Safety
+/// The resulting value is undefined if the computation would result
+/// in overflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpIAdd")]
+#[inline]
+pub unsafe fn i_add_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: Integer,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} {sign}",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpIAdd %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            sign = const I::SIGNED as u8,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Floating-point addition of `x` and `y`. Results are computed per component.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpFAdd")]
+#[inline]
+pub fn f_add_vector<F, V, const LEN: usize>(x: V, y: V) -> V
+where
+    F: Float,
+    V: Vector<F, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpFAdd %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const F::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Signed-integer subtract of `x` from `y`. Results are computed per component.
+///
+/// # Safety
+/// The resulting value is undefined if the computation would result
+/// in underflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpISub")]
+#[inline]
+pub fn i_sub_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: Integer,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} {sign}",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpISub %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            sign = const I::SIGNED as u8,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Floating-point subtract of `x` from `y`. Results are computed per component.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpFSub")]
+#[inline]
+pub fn f_sub_vector<F, V, const LEN: usize>(x: V, y: V) -> V
+where
+    F: Float,
+    V: Vector<F, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpFSub %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const F::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Integer multiplication of `x` and `y`. Results are computed per component.
+///
+/// # Safety
+/// The resulting value is undefined if the computation would result
+/// in underflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpIMul")]
+#[inline]
+pub fn i_mul_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: Integer,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} {sign}",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpIMul %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            sign = const I::SIGNED as u8,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Floating-point multiplication of `x` and `y`. Results are computed
+/// per component.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpFMul")]
+#[inline]
+pub fn f_mul_vector<F, V, const LEN: usize>(x: V, y: V) -> V
+where
+    F: Float,
+    V: Vector<F, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpFMul %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const F::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Unsigned-integer division of `x` from `y`.  Results are computed
+/// per component.
+///
+/// # Safety
+/// The resulting value is undefined if any component of `y` is `0`.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpUDiv")]
+#[inline]
+pub unsafe fn u_div_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: UnsignedInteger,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} 0",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpUDiv %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Signed-integer division of `x` from `y`. Results are computed
+/// per component.
+///
+/// # Safety
+/// The resulting value is undefined if any component of `y` is `0`, or if a
+/// component of `y` is `-1` and the dividing component of `x` is
+/// minimum representable value for its type, causing signed overflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpSDiv")]
+#[inline]
+pub unsafe fn s_div_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: SignedInteger,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} 1",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpSDiv %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Floating-point division of `x` from `y`. Results are computed
+/// per component.
+///
+/// # Safety
+/// The resulting value is undefined if any component of `y` is `0.0`.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpFDiv")]
+#[inline]
+pub fn f_div_vector<F, V, const LEN: usize>(x: V, y: V) -> V
+where
+    F: Float,
+    V: Vector<F, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpFDiv %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const F::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Unsigned modulo operation of `x` modulo `y`. Results are computed
+/// per component.
+///
+/// # Safety
+/// The resulting value is undefined if `y` is `0`.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpUMod")]
+#[inline]
+pub fn u_mod_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: UnsignedInteger,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} 0",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpUMod %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Signed-integer remainder operation for getting the remainder from `x / y`
+/// whose sign matches the sign of `x`.
+///
+/// # Safety
+/// Behavior is undefined if `y` is 0, or if `y` is -1 and `x` is the minimum
+/// representable value for the type, causing signed overflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpSRem")]
+#[inline]
+pub fn s_rem_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: SignedInteger,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} 1",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpSRem %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Signed-integer modulo operation from `x` modulo `y`, whose sign matches the
+/// sign of `y`. Results are computed per component.
+///
+/// # Safety
+/// Behavior is undefined if `y` is 0, or if `y` is -1 and `x` is the minimum
+/// representable value for the type, causing signed overflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpSMod")]
+#[inline]
+pub fn s_mod_vector<I, V, const LEN: usize>(x: V, y: V) -> V
+where
+    I: SignedInteger,
+    V: Vector<I, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%int_type = OpTypeInt {width} 1",
+            "%vec_type = OpTypeVector %int_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpSMod %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const I::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Floating-point remainder operation for getting the remainder from `x / y`
+/// whose sign matches the sign of `x`. Results are computed per component.
+///
+/// # Safety
+/// Behavior is undefined if `y` is 0, or if `y` is -1 and `x` is the minimum
+/// representable value for the type, causing signed overflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpFRem")]
+#[inline]
+pub fn f_rem_vector<F, V, const LEN: usize>(x: V, y: V) -> V
+where
+    F: Float,
+    V: Vector<F, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpFRem %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const F::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Floating-point modulo operation from `x` modulo `y`, whose sign matches the
+/// sign of `y`. Results are computed per component.
+///
+/// # Safety
+/// Behavior is undefined if `y` is 0, or if `y` is -1 and `x` is the minimum
+/// representable value for the type, causing signed overflow.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpFMod")]
+#[inline]
+pub fn f_mod_vector<F, V, const LEN: usize>(x: V, y: V) -> V
+where
+    F: Float,
+    V: Vector<F, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%x = OpLoad %vec_type {x}",
+            "%y = OpLoad %vec_type {y}",
+            "%result = OpFMod %vec_type %x %y",
+            "OpStore {result} %result",
+            x = in(reg) &x,
+            y = in(reg) &y,
+            width = const F::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}
+
+/// Scale a floating-point `vector` by `scalar`. Each component of `vector` is
+/// multiplied by `scalar`.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpVectorTimesScalar")]
+#[inline]
+pub fn vector_times_scalar<F, V, const LEN: usize>(vector: V, scalar: F) -> V
+where
+    F: Float,
+    V: Vector<F, LEN>,
+{
+    let mut result = V::default();
+
+    unsafe {
+        asm! {
+            "%float_type = OpTypeFloat {width}",
+            "%vec_type = OpTypeVector %float_type {length}",
+            "%vector = OpLoad %vec_type {vector}",
+            "%scalar = OpLoad %float_type {scalar}",
+            "%result = OpVectorTimesScalar %vec_type %vector %scalar",
+            "OpStore {result} %result",
+            vector = in(reg) &vector,
+            scalar = in(reg) &scalar,
+            width = const F::WIDTH,
+            length = const LEN,
+            result = in(reg) &mut result,
+        }
+    }
+
+    result
+}

--- a/crates/spirv-std/src/integer.rs
+++ b/crates/spirv-std/src/integer.rs
@@ -1,11 +1,44 @@
-/// Abstract trait representing a SPIR-V integer type.
-pub unsafe trait Integer: num_traits::PrimInt + crate::scalar::Scalar {}
+/// Abstract trait representing any SPIR-V integer type.
+pub unsafe trait Integer: num_traits::PrimInt + crate::scalar::Scalar {
+    const WIDTH: usize;
+    const SIGNED: bool;
+}
 
-unsafe impl Integer for u8 {}
-unsafe impl Integer for u16 {}
-unsafe impl Integer for u32 {}
-unsafe impl Integer for u64 {}
-unsafe impl Integer for i8 {}
-unsafe impl Integer for i16 {}
-unsafe impl Integer for i32 {}
-unsafe impl Integer for i64 {}
+/// A trait for being generic over signed integer types.
+pub trait SignedInteger: Integer {}
+/// A trait for being generic over unsigned integer types.
+pub trait UnsignedInteger: Integer {}
+
+macro_rules! impl_numbers {
+    (impl UnsignedInteger for $typ:ty;) => {
+        unsafe impl Integer for $typ {
+            const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+            const SIGNED: bool = false;
+        }
+
+        impl UnsignedInteger for $typ {}
+    };
+    (impl SignedInteger for $typ:ty;) => {
+        unsafe impl Integer for $typ {
+            const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+            const SIGNED: bool = true;
+        }
+
+        impl SignedInteger for $typ {}
+    };
+    ($(impl $trait:ident for $typ:ty;)+) => {
+        $(impl_numbers!(impl $trait for $typ;);)+
+    };
+
+}
+
+impl_numbers! {
+    impl UnsignedInteger for u8;
+    impl UnsignedInteger for u16;
+    impl UnsignedInteger for u32;
+    impl UnsignedInteger for u64;
+    impl SignedInteger for i8;
+    impl SignedInteger for i16;
+    impl SignedInteger for i32;
+    impl SignedInteger for i64;
+}


### PR DESCRIPTION
This PR adds every arithmetic instruction in SPIR-V, except anything related to Matrixes, as I wanted to make a separate PR for that.

There's two functions for every instruction (e.g. `i_add`/`i_add_vector`), as I couldn't really find a way to make a function generic over a vector *or* a scalar, so I just split the implementation into two functions.

Depends on #441 for the const generic in vectors.