### PR TITLE
Safeness bug in StorageImage2d::write

### DIFF
--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -613,7 +613,9 @@ fn image_write() {
 #[spirv(fragment)]
 pub fn main(input: Input<glam::Vec2>, image: UniformConstant<StorageImage2d>) {
     let texels = *input;
-    image.write(glam::UVec2::new(0, 1), texels);
+    unsafe {
+        image.write(glam::UVec2::new(0, 1), texels);
+    }
 }
 "#);
 }

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -89,7 +89,7 @@ impl StorageImage2d {
 
     /// Write a texel to an image without a sampler.
     #[spirv_std_macros::gpu_only]
-    pub fn write<I, V, V2, const N: usize>(&self, coordinate: V, texels: V2)
+    pub unsafe fn write<I, V, V2, const N: usize>(&self, coordinate: V, texels: V2)
     where
         I: Integer,
         V: Vector<I, N>,

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -95,16 +95,14 @@ impl StorageImage2d {
         V: Vector<I, N>,
         V2: Vector<f32, N>,
     {
-        unsafe {
-            asm! {
-                "%image = OpLoad _ {this}",
-                "%coordinate = OpLoad _ {coordinate}",
-                "%texels = OpLoad _ {texels}",
-                "OpImageWrite %image %coordinate %texels",
-                this = in(reg) self,
-                coordinate = in(reg) &coordinate,
-                texels = in(reg) &texels,
-            }
+        asm! {
+            "%image = OpLoad _ {this}",
+            "%coordinate = OpLoad _ {coordinate}",
+            "%texels = OpLoad _ {texels}",
+            "OpImageWrite %image %coordinate %texels",
+            this = in(reg) self,
+            coordinate = in(reg) &coordinate,
+            texels = in(reg) &texels,
         }
     }
 }


### PR DESCRIPTION
It's pretty easy to see why this is unsafe, if multiple threads write to the same coordinate race-conditions happen (for example calling this with Coord(0, 0) in a pixel shader that covers more then one pixel would trample data).

Ultimately this should be addressed through something like #216 and some higher level abstractions on top of our buffer types, but since we don't have those for now, marking this as unsafe seems to be the only thing we can do for now.