### PR TITLE
Add entry point attribute configuration.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -114,8 +114,8 @@ impl<'tcx> CodegenCx<'tcx> {
         for attr in parse_attrs(self, self.tcx.get_attrs(instance.def_id())) {
             match attr {
                 SpirvAttribute::Entry(entry) => {
-                    let crate_relative_name = instance.to_string();
-                    self.entry_stub(&instance, &fn_abi, declared, crate_relative_name, entry)
+                    let entry_name = entry.name.as_ref().map(ToString::to_string).unwrap_or_else(|| instance.to_string());
+                    self.entry_stub(&instance, &fn_abi, declared, entry_name, entry)
                 }
                 SpirvAttribute::UnrollLoops => {
                     self.unroll_loops_decorations

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -114,7 +114,11 @@ impl<'tcx> CodegenCx<'tcx> {
         for attr in parse_attrs(self, self.tcx.get_attrs(instance.def_id())) {
             match attr {
                 SpirvAttribute::Entry(entry) => {
-                    let entry_name = entry.name.as_ref().map(ToString::to_string).unwrap_or_else(|| instance.to_string());
+                    let entry_name = entry
+                        .name
+                        .as_ref()
+                        .map(ToString::to_string)
+                        .unwrap_or_else(|| instance.to_string());
                     self.entry_stub(&instance, &fn_abi, declared, entry_name, entry)
                 }
                 SpirvAttribute::UnrollLoops => {

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -802,12 +802,12 @@ fn parse_entry_attrs(
                         }
                         None => {
                             return Err((
-                                    attr_name.span,
-                                    format!(
-                                        "#[spirv({}(..))] unknown attribute argument {}",
-                                        name.name.to_ident_string(),
-                                        attr_name.name.to_ident_string()
-                                    ),
+                                attr_name.span,
+                                format!(
+                                    "#[spirv({}(..))] unknown attribute argument {}",
+                                    name.name.to_ident_string(),
+                                    attr_name.name.to_ident_string()
+                                ),
                             ))
                         }
                     }

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -33,7 +33,7 @@ pub struct Symbols {
     pub spirv13: Symbol,
     pub spirv14: Symbol,
     pub spirv15: Symbol,
-    pub entry_point: Symbol,
+    pub entry_point_name: Symbol,
     descriptor_set: Symbol,
     binding: Symbol,
     image_type: Symbol,
@@ -371,7 +371,7 @@ impl Symbols {
         Self {
             fmt_decimal: Symbol::intern("fmt_decimal"),
 
-            entry_point: Symbol::intern("entry_point"),
+            entry_point_name: Symbol::intern("entry_point_name"),
             spirv: Symbol::intern("spirv"),
             spirv_std: Symbol::intern("spirv_std"),
             libm: Symbol::intern("libm"),
@@ -795,7 +795,7 @@ fn parse_entry_attrs(
                             }
                         }
                     }
-                } else if attr_name.name == cx.sym.entry_point {
+                } else if attr_name.name == cx.sym.entry_point_name {
                     match attr.value_str() {
                         Some(sym) => {
                             entry.name = Some(sym);

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -33,6 +33,7 @@ pub struct Symbols {
     pub spirv13: Symbol,
     pub spirv14: Symbol,
     pub spirv15: Symbol,
+    pub entry_point: Symbol,
     descriptor_set: Symbol,
     binding: Symbol,
     image_type: Symbol,
@@ -370,6 +371,7 @@ impl Symbols {
         Self {
             fmt_decimal: Symbol::intern("fmt_decimal"),
 
+            entry_point: Symbol::intern("entry_point"),
             spirv: Symbol::intern("spirv"),
             spirv_std: Symbol::intern("spirv_std"),
             libm: Symbol::intern("libm"),
@@ -437,6 +439,7 @@ impl AsRef<[u32]> for ExecutionModeExtra {
 pub struct Entry {
     pub execution_model: ExecutionModel,
     pub execution_modes: Vec<(ExecutionMode, ExecutionModeExtra)>,
+    pub name: Option<Symbol>,
 }
 
 impl From<ExecutionModel> for Entry {
@@ -444,6 +447,7 @@ impl From<ExecutionModel> for Entry {
         Self {
             execution_model,
             execution_modes: Vec::new(),
+            name: None,
         }
     }
 }
@@ -789,6 +793,18 @@ fn parse_entry_attrs(
                                     .execution_modes
                                     .push((*execution_mode, ExecutionModeExtra::new([])));
                             }
+                        }
+                    }
+                } else if attr_name.name == cx.sym.entry_point {
+                    match attr.value_str() {
+                        Some(sym) => {
+                            entry.name = Some(sym);
+                        }
+                        None => {
+                            cx.tcx.sess.span_err(
+                                attr_name.span,
+                                r#"#[spirv(entrypoint = "...")] expects a valid str literal."#,
+                            );
                         }
                     }
                 } else {

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -795,16 +795,20 @@ fn parse_entry_attrs(
                             }
                         }
                     }
-                } else if attr_name.name == cx.sym.entry_point_name {
+                } else if attr_name.name == sym.entry_point_name {
                     match attr.value_str() {
                         Some(sym) => {
                             entry.name = Some(sym);
                         }
                         None => {
-                            cx.tcx.sess.span_err(
-                                attr_name.span,
-                                r#"#[spirv(entrypoint = "...")] expects a valid str literal."#,
-                            );
+                            return Err((
+                                    attr_name.span,
+                                    format!(
+                                        "#[spirv({}(..))] unknown attribute argument {}",
+                                        name.name.to_ident_string(),
+                                        attr_name.name.to_ident_string()
+                                    ),
+                            ))
                         }
                     }
                 } else {

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -30,12 +30,21 @@ pub fn main() {
 
 #[test]
 fn custom_entry_point() {
-    val(r#"
+    dis_globals(r#"
 #[allow(unused_attributes)]
-#[spirv(fragment(entry_point="hello_world"))]
-pub fn main() {
-}
-"#);
+#[spirv(fragment(entry_point_name="hello_world"))]
+pub fn main() { }
+"#,
+r#"OpCapability Shader
+OpCapability VulkanMemoryModel
+OpCapability VariablePointers
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint Fragment %1 "hello_world"
+OpExecutionMode %1 OriginUpperLeft
+OpName %2 "test_project::main"
+%3 = OpTypeVoid
+%4 = OpTypeFunction %3"#);
 }
 
 #[test]

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -29,6 +29,16 @@ pub fn main() {
 }
 
 #[test]
+fn custom_entry_point() {
+    val(r#"
+#[allow(unused_attributes)]
+#[spirv(fragment(entry_point="hello_world"))]
+pub fn main() {
+}
+"#);
+}
+
+#[test]
 // blocked on: https://github.com/EmbarkStudios/rust-gpu/issues/69
 #[ignore]
 fn no_dce() {

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -30,12 +30,13 @@ pub fn main() {
 
 #[test]
 fn custom_entry_point() {
-    dis_globals(r#"
+    dis_globals(
+        r#"
 #[allow(unused_attributes)]
 #[spirv(fragment(entry_point_name="hello_world"))]
 pub fn main() { }
 "#,
-r#"OpCapability Shader
+        r#"OpCapability Shader
 OpCapability VulkanMemoryModel
 OpCapability VariablePointers
 OpExtension "SPV_KHR_vulkan_memory_model"
@@ -44,7 +45,8 @@ OpEntryPoint Fragment %1 "hello_world"
 OpExecutionMode %1 OriginUpperLeft
 OpName %2 "test_project::main"
 %3 = OpTypeVoid
-%4 = OpTypeFunction %3"#);
+%4 = OpTypeFunction %3"#,
+    );
 }
 
 #[test]

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -32,7 +32,6 @@ pub fn main() {
 fn custom_entry_point() {
     dis_globals(
         r#"
-#[allow(unused_attributes)]
 #[spirv(fragment(entry_point_name="hello_world"))]
 pub fn main() { }
 "#,

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -17,6 +17,10 @@ fn main() { }
 
 Common values are `#[spirv(fragment)]` and `#[spirv(vertex)]`. A list of all supported names can be found in [spirv_headers](https://docs.rs/spirv_headers/1.5.0/spirv_headers/enum.ExecutionModel.html) - convert the enum name to snake_case for the rust-gpu attribute name.
 
+### Override entry point name
+
+You can override the default `OpEntryPoint` name for any entry point with the `entry_point_name` sub-attribute on any of the execution model attributes. (e.g. `#[spirv(vertex(entry_point_name="foo"))]`)
+
 ## Builtins
 
 When declaring inputs and outputs, sometimes you want to declare it as a "builtin". This means many things, but one example is `gl_Position` from glsl - the GPU assigns inherent meaning to the variable and uses it for placing the vertex in clip space. The equivalent in rust-gpu is called `position`.


### PR DESCRIPTION
Adds an nested `entry_point` attribute to all the execution models attributes. This allows you to override the `OpEntryPoint` for a given entry point with your own name.

### Example

```rust
#[allow(unused_attributes)]
#[spirv(fragment(entry_point_name="hello_world"))]
pub fn main() { }
```