### PR TITLE
Add a `#[spirv(...)]` attribute checking pass and remove `#[allow(unused_attributes)]`.

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -801,7 +801,7 @@ fn trans_image<'tcx>(
     attr: SpirvAttribute,
 ) -> Option<Word> {
     match attr {
-        SpirvAttribute::Image {
+        SpirvAttribute::ImageType {
             dim,
             depth,
             arrayed,

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -1,0 +1,312 @@
+//! `#[spirv(...)]` attribute support.
+//!
+//! The attribute-checking parts of this try to follow `rustc_passes::check_attr`.
+
+use crate::symbols::{SpirvAttribute, Symbols};
+use rustc_ast::Attribute;
+use rustc_hir as hir;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
+use rustc_hir::{HirId, MethodKind, Target, CRATE_HIR_ID};
+use rustc_middle::hir::map::Map;
+use rustc_middle::ty::query::Providers;
+use rustc_middle::ty::TyCtxt;
+use std::fmt;
+use std::rc::Rc;
+
+// FIXME(eddyb) make this reusable from somewhere in `rustc`.
+pub(crate) fn target_from_impl_item<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    impl_item: &hir::ImplItem<'_>,
+) -> Target {
+    match impl_item.kind {
+        hir::ImplItemKind::Const(..) => Target::AssocConst,
+        hir::ImplItemKind::Fn(..) => {
+            let parent_hir_id = tcx.hir().get_parent_item(impl_item.hir_id);
+            let containing_item = tcx.hir().expect_item(parent_hir_id);
+            let containing_impl_is_for_trait = match &containing_item.kind {
+                hir::ItemKind::Impl { of_trait, .. } => of_trait.is_some(),
+                _ => unreachable!("parent of an ImplItem must be an Impl"),
+            };
+            if containing_impl_is_for_trait {
+                Target::Method(MethodKind::Trait { body: true })
+            } else {
+                Target::Method(MethodKind::Inherent)
+            }
+        }
+        hir::ImplItemKind::TyAlias(..) => Target::AssocTy,
+    }
+}
+
+// HACK(eddyb) current `Target` (after rust-lang/rust#80641 + rust-lang/rust#80920),
+// emulated before we can rustup to that point and use the new variants directly.
+enum TargetNew {
+    Old(Target),
+
+    // Added by rust-lang/rust#80641.
+    Field,
+    Arm,
+    MacroDef,
+
+    // Added by rust-lang/rust#80920.
+    Param,
+}
+
+impl From<Target> for TargetNew {
+    fn from(target: Target) -> Self {
+        Self::Old(target)
+    }
+}
+
+impl fmt::Display for TargetNew {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = match self {
+            Self::Old(target) => return write!(f, "{}", target),
+
+            Self::Field => "struct field",
+            Self::Arm => "match arm",
+            Self::MacroDef => "macro def",
+
+            Self::Param => "function param",
+        };
+        f.write_str(description)
+    }
+}
+
+struct CheckSpirvAttrVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    sym: Rc<Symbols>,
+}
+
+impl CheckSpirvAttrVisitor<'_> {
+    fn check_spirv_attributes(
+        &self,
+        hir_id: HirId,
+        attrs: &[Attribute],
+        target: impl Into<TargetNew>,
+    ) {
+        let parse_attrs = |attrs| crate::symbols::parse_attrs_for_checking(&self.sym, attrs);
+
+        let target = target.into();
+        for parse_attr_result in parse_attrs(attrs) {
+            let (span, attr) = match parse_attr_result {
+                Ok(span_and_attr) => span_and_attr,
+                Err((span, msg)) => {
+                    self.tcx.sess.span_err(span, &msg);
+                    continue;
+                }
+            };
+
+            /// Error newtype marker used below for readability.
+            struct Expected<T>(T);
+
+            let valid_target = match attr {
+                SpirvAttribute::Builtin(_)
+                | SpirvAttribute::DescriptorSet(_)
+                | SpirvAttribute::Binding(_)
+                | SpirvAttribute::Flat => match target {
+                    TargetNew::Param => {
+                        let parent_hir_id = self.tcx.hir().get_parent_node(hir_id);
+                        let parent_is_entry_point =
+                            parse_attrs(self.tcx.hir().attrs(parent_hir_id))
+                                .filter_map(|r| r.ok())
+                                .any(|(_, attr)| matches!(attr, SpirvAttribute::Entry(_)));
+                        if !parent_is_entry_point {
+                            self.tcx.sess.span_err(
+                                span,
+                                "attribute is only valid on a parameter of an entry-point function",
+                            );
+                        }
+                        Ok(())
+                    }
+
+                    _ => Err(Expected("function parameter")),
+                },
+
+                SpirvAttribute::Entry(_) => match target {
+                    TargetNew::Old(Target::Fn)
+                    | TargetNew::Old(Target::Method(MethodKind::Trait { body: true }))
+                    | TargetNew::Old(Target::Method(MethodKind::Inherent)) => {
+                        // FIXME(eddyb) further check entry-point attribute validity,
+                        // e.g. signature, shouldn't have `#[inline]` or generics, etc.
+                        Ok(())
+                    }
+
+                    _ => Err(Expected("function")),
+                },
+
+                SpirvAttribute::UnrollLoops => match target {
+                    TargetNew::Old(Target::Fn)
+                    | TargetNew::Old(Target::Closure)
+                    | TargetNew::Old(Target::Method(MethodKind::Trait { body: true }))
+                    | TargetNew::Old(Target::Method(MethodKind::Inherent)) => Ok(()),
+
+                    _ => Err(Expected("function or closure")),
+                },
+
+                SpirvAttribute::StorageClass(_)
+                | SpirvAttribute::ImageType { .. }
+                | SpirvAttribute::Sampler
+                | SpirvAttribute::SampledImage
+                | SpirvAttribute::Block => match target {
+                    TargetNew::Old(Target::Struct) => {
+                        // FIXME(eddyb) further check type attribute validity,
+                        // e.g. layout, generics, other attributes, etc.
+                        Ok(())
+                    }
+
+                    _ => Err(Expected("struct")),
+                },
+            };
+            match valid_target {
+                Ok(()) => {}
+                Err(Expected(expected_target)) => self.tcx.sess.span_err(
+                    span,
+                    &format!(
+                        "attribute is only valid on a {}, not on a {}",
+                        expected_target, target
+                    ),
+                ),
+            }
+        }
+    }
+}
+
+// FIXME(eddyb) DRY this somehow and make it reusable from somewhere in `rustc`.
+impl<'tcx> Visitor<'tcx> for CheckSpirvAttrVisitor<'tcx> {
+    type Map = Map<'tcx>;
+
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
+        NestedVisitorMap::OnlyBodies(self.tcx.hir())
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
+        let target = Target::from_item(item);
+        self.check_spirv_attributes(item.hir_id, item.attrs, target);
+        intravisit::walk_item(self, item)
+    }
+
+    fn visit_generic_param(&mut self, generic_param: &'tcx hir::GenericParam<'tcx>) {
+        let target = Target::from_generic_param(generic_param);
+        self.check_spirv_attributes(generic_param.hir_id, generic_param.attrs, target);
+        intravisit::walk_generic_param(self, generic_param)
+    }
+
+    fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem<'tcx>) {
+        let target = Target::from_trait_item(trait_item);
+        self.check_spirv_attributes(trait_item.hir_id, trait_item.attrs, target);
+        intravisit::walk_trait_item(self, trait_item)
+    }
+
+    fn visit_struct_field(&mut self, struct_field: &'tcx hir::StructField<'tcx>) {
+        self.check_spirv_attributes(struct_field.hir_id, struct_field.attrs, TargetNew::Field);
+        intravisit::walk_struct_field(self, struct_field);
+    }
+
+    fn visit_arm(&mut self, arm: &'tcx hir::Arm<'tcx>) {
+        self.check_spirv_attributes(arm.hir_id, arm.attrs, TargetNew::Arm);
+        intravisit::walk_arm(self, arm);
+    }
+
+    fn visit_foreign_item(&mut self, f_item: &'tcx hir::ForeignItem<'tcx>) {
+        let target = Target::from_foreign_item(f_item);
+        self.check_spirv_attributes(f_item.hir_id, f_item.attrs, target);
+        intravisit::walk_foreign_item(self, f_item)
+    }
+
+    fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem<'tcx>) {
+        let target = target_from_impl_item(self.tcx, impl_item);
+        self.check_spirv_attributes(impl_item.hir_id, impl_item.attrs, target);
+        intravisit::walk_impl_item(self, impl_item)
+    }
+
+    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
+        // When checking statements ignore expressions, they will be checked later.
+        if let hir::StmtKind::Local(l) = stmt.kind {
+            self.check_spirv_attributes(l.hir_id, &l.attrs, Target::Statement);
+        }
+        intravisit::walk_stmt(self, stmt)
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        let target = match expr.kind {
+            hir::ExprKind::Closure(..) => Target::Closure,
+            _ => Target::Expression,
+        };
+
+        self.check_spirv_attributes(expr.hir_id, &expr.attrs, target);
+        intravisit::walk_expr(self, expr)
+    }
+
+    fn visit_variant(
+        &mut self,
+        variant: &'tcx hir::Variant<'tcx>,
+        generics: &'tcx hir::Generics<'tcx>,
+        item_id: HirId,
+    ) {
+        self.check_spirv_attributes(variant.id, variant.attrs, Target::Variant);
+        intravisit::walk_variant(self, variant, generics, item_id)
+    }
+
+    fn visit_macro_def(&mut self, macro_def: &'tcx hir::MacroDef<'tcx>) {
+        self.check_spirv_attributes(macro_def.hir_id, macro_def.attrs, TargetNew::MacroDef);
+        intravisit::walk_macro_def(self, macro_def);
+    }
+
+    fn visit_param(&mut self, param: &'tcx hir::Param<'tcx>) {
+        self.check_spirv_attributes(param.hir_id, param.attrs, TargetNew::Param);
+
+        intravisit::walk_param(self, param);
+    }
+}
+
+fn check_invalid_macro_level_spirv_attr(tcx: TyCtxt<'_>, sym: &Symbols, attrs: &[Attribute]) {
+    for attr in attrs {
+        if tcx.sess.check_name(attr, sym.spirv) {
+            tcx.sess
+                .span_err(attr.span, "#[spirv(..)] cannot be applied to a macro");
+        }
+    }
+}
+
+// FIXME(eddyb) DRY this somehow and make it reusable from somewhere in `rustc`.
+fn check_mod_attrs(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {
+    let check_spirv_attr_visitor = &mut CheckSpirvAttrVisitor {
+        tcx,
+        sym: Symbols::get(),
+    };
+    tcx.hir().visit_item_likes_in_module(
+        module_def_id,
+        &mut check_spirv_attr_visitor.as_deep_visitor(),
+    );
+    // FIXME(eddyb) use `tcx.hir().visit_exported_macros_in_krate(...)` after rustup.
+    for id in tcx.hir().krate().exported_macros {
+        check_spirv_attr_visitor.visit_macro_def(match tcx.hir().find(id.hir_id) {
+            Some(hir::Node::MacroDef(macro_def)) => macro_def,
+            _ => unreachable!(),
+        });
+    }
+    check_invalid_macro_level_spirv_attr(
+        tcx,
+        &check_spirv_attr_visitor.sym,
+        tcx.hir().krate().non_exported_macro_attrs,
+    );
+    if module_def_id.is_top_level_module() {
+        check_spirv_attr_visitor.check_spirv_attributes(
+            CRATE_HIR_ID,
+            tcx.hir().krate_attrs(),
+            Target::Mod,
+        );
+    }
+}
+
+pub(crate) fn provide(providers: &mut Providers) {
+    *providers = Providers {
+        check_mod_attrs: |tcx, def_id| {
+            // Run both the default checks, and our `#[spirv(...)]` ones.
+            (rustc_interface::DEFAULT_QUERY_PROVIDERS.check_mod_attrs)(tcx, def_id);
+            check_mod_attrs(tcx, def_id)
+        },
+        ..*providers
+    };
+}

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -32,6 +32,7 @@ use rustc_target::spec::{HasTargetSpec, Target};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::iter::once;
+use std::rc::Rc;
 
 pub struct CodegenCx<'tcx> {
     pub tcx: TyCtxt<'tcx>,
@@ -56,7 +57,7 @@ pub struct CodegenCx<'tcx> {
     unroll_loops_decorations: RefCell<HashMap<Word, UnrollLoopsDecoration>>,
     pub kernel_mode: bool,
     /// Cache of all the builtin symbols we need
-    pub sym: Box<Symbols>,
+    pub sym: Rc<Symbols>,
     pub instruction_table: InstructionTable,
     pub libm_intrinsics: RefCell<HashMap<Word, super::builder::libm_intrinsics::LibmIntrinsic>>,
 
@@ -72,7 +73,7 @@ pub struct CodegenCx<'tcx> {
 
 impl<'tcx> CodegenCx<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>, codegen_unit: &'tcx CodegenUnit<'tcx>) -> Self {
-        let sym = Box::new(Symbols::new());
+        let sym = Symbols::get();
         let mut spirv_version = None;
         let mut memory_model = None;
         let mut kernel_mode = false;

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -81,6 +81,7 @@ macro_rules! assert_ty_eq {
 }
 
 mod abi;
+mod attr;
 mod builder;
 mod builder_spirv;
 mod codegen_cx;
@@ -299,6 +300,9 @@ impl CodegenBackend for SpirvCodegenBackend {
                 inner
             })
         };
+
+        // Extra hooks provided by other parts of `rustc_codegen_spirv`.
+        crate::attr::provide(providers);
     }
 
     fn provide_extern(&self, providers: &mut query::Providers) {

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -480,7 +480,7 @@ pub fn parse_attrs<'a, 'tcx>(
     attrs: &'tcx [Attribute],
 ) -> impl Iterator<Item = SpirvAttribute> + Captures<'tcx> + 'a {
     parse_attrs_for_checking(&cx.sym, attrs)
-        .filter_map(move |parse_attr_result| {
+        .filter_map(move |(_, parse_attr_result)| {
             // NOTE(eddyb) `delay_span_bug` ensures that if attribute checking fails
             // to see an attribute error, it will cause an ICE instead.
             parse_attr_result
@@ -497,7 +497,12 @@ type ParseAttrError = (Span, String);
 pub(crate) fn parse_attrs_for_checking<'a>(
     sym: &'a Symbols,
     attrs: &'a [Attribute],
-) -> impl Iterator<Item = Result<(Span, SpirvAttribute), ParseAttrError>> + 'a {
+) -> impl Iterator<
+    Item = (
+        &'a Attribute,
+        Result<(Span, SpirvAttribute), ParseAttrError>,
+    ),
+> + 'a {
     attrs.iter().flat_map(move |attr| {
         let is_spirv = match attr.kind {
             AttrKind::Normal(ref item, _) => {
@@ -558,6 +563,7 @@ pub(crate) fn parse_attrs_for_checking<'a>(
                 };
                 Ok((span, parsed_attr))
             }))
+            .map(move |parse_attr_result| (attr, parse_attr_result))
     })
 }
 

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -22,7 +22,6 @@ impl<'a> Drop for SetEnvVar<'a> {
 #[test]
 fn hello_world() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
 }
@@ -35,7 +34,6 @@ pub fn main() {
 fn no_dce() {
     let _var = SetEnvVar::new(&"NO_DCE", "1");
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn no_dce() {
 }
@@ -49,7 +47,6 @@ fn add_two_ints() {
 fn add_two_ints(x: u32, y: u32) -> u32 {
     x + y
 }
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     add_two_ints(2, 3);
@@ -80,7 +77,6 @@ fn asm() {
         );
     }
 }
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     asm();
@@ -112,7 +108,6 @@ fn add_two_ints(x: u32, y: u32) -> u32 {
     }
     result
 }
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     add_two_ints(2, 3);
@@ -162,7 +157,6 @@ fn asm_op_decorate() {
                     );
             }
         }
-        #[allow(unused_attributes)]
         #[spirv(fragment)]
         pub fn main() {
             add_decorate();
@@ -208,7 +202,6 @@ fn asm() {
         );
     }
 }
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     asm();
@@ -222,7 +215,6 @@ fn logical_and() {
 fn f(x: bool, y: bool) -> bool {
     x && y
 }
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     f(false, true);
@@ -232,7 +224,6 @@ pub fn main() {
 #[test]
 fn panic() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     panic!("aaa");
@@ -247,7 +238,6 @@ fn int_div(x: usize) -> usize {
     1 / x
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     int_div(0);
@@ -262,7 +252,6 @@ fn array_bounds_check(x: [u32; 4], i: usize) -> u32 {
     x[i]
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     array_bounds_check([0, 1, 2, 3], 5);
@@ -282,7 +271,6 @@ pub struct ShaderConstants {
     pub time: f32,
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(constants: PushConstant<ShaderConstants>) {
     let _constants = *constants;
@@ -298,7 +286,6 @@ fn push_constant_vulkan() {
     val_vulkan(
         r#"
 #[derive(Copy, Clone)]
-#[allow(unused_attributes)]
 #[spirv(block)]
 pub struct ShaderConstants {
     pub width: u32,
@@ -306,7 +293,6 @@ pub struct ShaderConstants {
     pub time: f32,
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(constants: PushConstant<ShaderConstants>) {
     let _constants = *constants;
@@ -318,7 +304,6 @@ pub fn main(constants: PushConstant<ShaderConstants>) {
 #[test]
 fn infinite_loop() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     loop {}
@@ -330,7 +315,6 @@ fn unroll_loops() {
     dis_fn(
         // FIXME(eddyb) use `for _ in 0..10` here when that works.
         r#"
-#[allow(unused_attributes)]
 #[spirv(unroll_loops)]
 fn java_hash_ten_times(mut x: u32, y: u32) -> u32 {
     let mut i = 0;
@@ -340,7 +324,6 @@ fn java_hash_ten_times(mut x: u32, y: u32) -> u32 {
     }
     x
 }
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     java_hash_ten_times(7, 42);
@@ -390,7 +373,6 @@ OpFunctionEnd"#,
 #[test]
 fn signum() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<f32>, mut o: Output<f32>) {
     *o = i.signum();
@@ -406,7 +388,6 @@ fn allocate_const_scalar_pointer() {
 use core::ptr::Unique;
 const POINTER: Unique<[u8;4]> = Unique::<[u8; 4]>::dangling();
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     let _pointer = POINTER;
@@ -422,7 +403,6 @@ const VEC_LIKE: (Unique<usize>, usize, usize) = (Unique::<usize>::dangling(), 0,
 pub fn assign_vec_like() {
     let _vec_like = VEC_LIKE;
 }
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {}"#);
 }
@@ -433,7 +413,6 @@ fn allocate_null_pointer() {
 use core::ptr::null;
 const NULL_PTR: *const i32 = null();
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     let _null_ptr = NULL_PTR;
@@ -452,7 +431,6 @@ pub fn create_uninit_and_write() {
     let _maybei32 = unsafe { maybei32.assume_init() };
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {}"#);
 }
@@ -460,7 +438,6 @@ pub fn main() {}"#);
 #[test]
 fn vector_extract_dynamic() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     let vector = glam::Vec2::new(1.0, 2.0);
@@ -473,7 +450,6 @@ pub fn main() {
 #[test]
 fn vector_insert_dynamic() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     let vector = glam::Vec2::new(1.0, 2.0);
@@ -487,7 +463,6 @@ pub fn main() {
 #[test]
 fn mat3_vec3_multiply() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(input: Input<glam::Mat3>, mut output: Output<glam::Vec3>) {
     let input = *input;
@@ -548,7 +523,6 @@ fn complex_image_sample_inst() {
             result
         }
     }
-    #[allow(unused_attributes)]
     #[spirv(fragment)]
     pub fn main() {
         sample_proj_lod(glam::Vec4::zero(), glam::Vec2::zero(), glam::Vec2::zero(), 0, 0);
@@ -573,7 +547,6 @@ OpFunctionEnd",
 fn any() {
     val(r#"
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     let vector = glam::BVec2::new(true, false);
@@ -585,7 +558,6 @@ pub fn main() {
 #[test]
 fn all() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     let vector = glam::BVec2::new(true, true);
@@ -597,7 +569,6 @@ pub fn main() {
 #[test]
 fn image_read() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(image: UniformConstant<StorageImage2d>, mut output: Output<glam::Vec2>) {
     let coords = image.read(glam::IVec2::new(0, 1));
@@ -609,7 +580,6 @@ pub fn main(image: UniformConstant<StorageImage2d>, mut output: Output<glam::Vec
 #[test]
 fn image_write() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(input: Input<glam::Vec2>, image: UniformConstant<StorageImage2d>) {
     let texels = *input;

--- a/crates/spirv-builder/src/test/control_flow.rs
+++ b/crates/spirv-builder/src/test/control_flow.rs
@@ -3,7 +3,6 @@ use super::val;
 #[test]
 fn cf_while() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -15,7 +14,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_while() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 20 {
@@ -29,7 +27,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_while_break() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 20 {
@@ -44,7 +41,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_while_if_break() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 20 {
@@ -61,7 +57,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_break() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -74,7 +69,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_if_break() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -89,7 +83,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_if_break_else_break() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -106,7 +99,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_if_break_if_break() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -124,7 +116,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_while_continue() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 20 {
@@ -139,7 +130,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_while_if_continue() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 20 {
@@ -156,7 +146,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_continue() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -169,7 +158,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_if_continue() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -184,7 +172,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_if_continue_else_continue() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -201,7 +188,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_while_return() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 10 {
@@ -214,7 +200,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_if_return_else() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i < 10 {
@@ -228,7 +213,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_if_return_else_return() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i < 10 {
@@ -243,7 +227,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_if_while() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i == 0 {
@@ -257,7 +240,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_if() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i > 0 {
@@ -269,7 +251,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_ifx2() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i > 0 {
@@ -285,7 +266,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_if_else() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i > 0 {
@@ -300,7 +280,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_if_elseif_else() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i > 0 {
@@ -317,7 +296,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_if_if() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     if *i > 0 {
@@ -332,7 +310,6 @@ pub fn main(i: Input<i32>) {
 #[test]
 fn cf_defer() {
     val(r#"
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main(i: Input<i32>) {
     while *i < 32 {
@@ -393,7 +370,6 @@ fn render(eye: Vec3, dir: Vec3, start: f32, end: f32) -> f32 {
     end
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main() {
     let v = Vec3::new(1.0, 1.0, 1.0);

--- a/crates/spirv-std/src/storage_class.rs
+++ b/crates/spirv-std/src/storage_class.rs
@@ -12,7 +12,6 @@ use core::ops::{Deref, DerefMut};
 macro_rules! storage_class {
     ($(#[$($meta:meta)+])* storage_class $name:ident ; $($tt:tt)*) => {
         $(#[$($meta)+])*
-        #[allow(unused_attributes)]
         pub struct $name<'value, T: ?Sized> {
             reference: &'value mut T,
         }

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -2,14 +2,12 @@ use glam::{Vec2, Vec3A, Vec4};
 
 use crate::{integer::Integer, vector::Vector};
 
-#[allow(unused_attributes)]
 #[spirv(sampler)]
 #[derive(Copy, Clone)]
 pub struct Sampler {
     _x: u32,
 }
 
-#[allow(unused_attributes)]
 #[spirv(image_type(
     // sampled_type is hardcoded to f32 for now
     dim = "Dim2D",
@@ -46,7 +44,6 @@ impl Image2d {
     }
 }
 
-#[allow(unused_attributes)]
 #[spirv(image_type(
     // sampled_type is hardcoded to f32 for now
     dim = "Dim2D",
@@ -109,7 +106,6 @@ impl StorageImage2d {
     }
 }
 
-#[allow(unused_attributes)]
 #[spirv(image_type(
     // sampled_type is hardcoded to f32 for now
     dim = "Dim2D",
@@ -146,7 +142,6 @@ impl Image2dArray {
     }
 }
 
-#[allow(unused_attributes)]
 #[spirv(sampled_image)]
 #[derive(Copy, Clone)]
 pub struct SampledImage<I> {

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -10,7 +10,7 @@ pub struct Sampler {
 }
 
 #[allow(unused_attributes)]
-#[spirv(image(
+#[spirv(image_type(
     // sampled_type is hardcoded to f32 for now
     dim = "Dim2D",
     depth = 0,
@@ -47,7 +47,7 @@ impl Image2d {
 }
 
 #[allow(unused_attributes)]
-#[spirv(image(
+#[spirv(image_type(
     // sampled_type is hardcoded to f32 for now
     dim = "Dim2D",
     depth = 0,
@@ -110,7 +110,7 @@ impl StorageImage2d {
 }
 
 #[allow(unused_attributes)]
-#[spirv(image(
+#[spirv(image_type(
     // sampled_type is hardcoded to f32 for now
     dim = "Dim2D",
     depth = 0,

--- a/examples/shaders/compute-shader/src/lib.rs
+++ b/examples/shaders/compute-shader/src/lib.rs
@@ -13,6 +13,5 @@ extern crate spirv_std;
 #[macro_use]
 pub extern crate spirv_std_macros;
 
-#[allow(unused_attributes)]
 #[spirv(gl_compute)]
 pub fn main_cs() {}

--- a/examples/shaders/mouse-shader/src/lib.rs
+++ b/examples/shaders/mouse-shader/src/lib.rs
@@ -145,7 +145,6 @@ impl Painter {
     }
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main_fs(
     #[spirv(frag_coord)] in_frag_coord: Input<Vec4>,
@@ -258,7 +257,6 @@ pub fn main_fs(
     *output = painter.color.extend(1.0);
 }
 
-#[allow(unused_attributes)]
 #[spirv(vertex)]
 pub fn main_vs(
     #[spirv(vertex_index)] vert_idx: Input<i32>,

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -22,7 +22,6 @@ use spirv_std::num_traits::Float;
 #[spirv(block)]
 #[derive(Copy, Clone)]
 #[repr(C)]
-#[allow(unused_attributes)]
 pub struct ShaderConstants {
     pub width: u32,
     pub height: u32,

--- a/examples/shaders/simplest-shader/src/lib.rs
+++ b/examples/shaders/simplest-shader/src/lib.rs
@@ -13,13 +13,11 @@ pub extern crate spirv_std_macros;
 use spirv_std::glam::{vec4, Vec4};
 use spirv_std::storage_class::{Input, Output};
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main_fs(mut output: Output<Vec4>) {
     *output = vec4(1.0, 0.0, 0.0, 1.0);
 }
 
-#[allow(unused_attributes)]
 #[spirv(vertex)]
 pub fn main_vs(
     #[spirv(vertex_index)] vert_id: Input<i32>,

--- a/examples/shaders/sky-shader/src/lib.rs
+++ b/examples/shaders/sky-shader/src/lib.rs
@@ -158,7 +158,6 @@ pub fn fs(constants: &ShaderConstants, frag_coord: Vec2) -> Vec4 {
     tonemap(color).extend(1.0)
 }
 
-#[allow(unused_attributes)]
 #[spirv(fragment)]
 pub fn main_fs(
     #[spirv(frag_coord)] in_frag_coord: Input<Vec4>,
@@ -169,7 +168,6 @@ pub fn main_fs(
     *output = fs(&constants, frag_coord);
 }
 
-#[allow(unused_attributes)]
 #[spirv(vertex)]
 pub fn main_vs(
     #[spirv(vertex_index)] vert_idx: Input<i32>,


### PR DESCRIPTION
By hooking the `check_mod_attrs` query, we can effectively expand `rustc_passes::check_attr` to also check `#[spirv(...)]` attributes, which is an improvement over only validating attributes when they happen to be relevant.

In particular, this means that now we shouldn't have any latent "we allowed some attribute on an obviously wrong thing" bugs.

It also allows us to mark the attributes as used, and therefore remove the need for `#[allow(unused_attributes)]` altogether.

Fixes #386 (specifically as suggested in https://github.com/EmbarkStudios/rust-gpu/issues/386#issuecomment-763541989), to get `spirv_std::storage_class::Image` to compile again.

cc @XAMPPRocky It would be nice to get this in the next release, but I understand if we want to wait.