### PR TITLE
Revert const generics

### DIFF
--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -564,29 +564,6 @@ OpFunctionEnd",
 }
 
 #[test]
-fn any() {
-    val(r#"
-
-#[spirv(fragment)]
-pub fn main() {
-    let vector = glam::BVec2::new(true, false);
-    assert!(arch::any(vector));
-}
-"#);
-}
-
-#[test]
-fn all() {
-    val(r#"
-#[spirv(fragment)]
-pub fn main() {
-    let vector = glam::BVec2::new(true, true);
-    assert!(arch::all(vector));
-}
-"#);
-}
-
-#[test]
 fn image_read() {
     val(r#"
 #[spirv(fragment)]

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -10,6 +10,8 @@ use crate::{scalar::Scalar, vector::Vector};
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAny")]
 #[inline]
+// Remove after 25.03.2021 (Rust 1.51)
+#[cfg(any())]
 pub fn any<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
     let mut result = false;
 
@@ -43,6 +45,8 @@ pub fn any<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAll")]
 #[inline]
+// Remove after 25.03.2021 (Rust 1.51)
+#[cfg(any())]
 pub fn all<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
     let mut result = false;
 
@@ -79,10 +83,7 @@ pub fn all<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpVectorExtractDynamic")]
 #[inline]
-pub unsafe fn vector_extract_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
-    vector: V,
-    index: usize,
-) -> T {
+pub unsafe fn vector_extract_dynamic<T: Scalar, V: Vector<T>>(vector: V, index: usize) -> T {
     let mut result = T::default();
 
     asm! {
@@ -106,7 +107,7 @@ pub unsafe fn vector_extract_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpVectorInsertDynamic")]
 #[inline]
-pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
+pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T>>(
     vector: V,
     index: usize,
     element: T,

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -61,11 +61,11 @@ pub struct StorageImage2d {
 impl StorageImage2d {
     /// Read a texel from an image without a sampler.
     #[spirv_std_macros::gpu_only]
-    pub fn read<I, V, V2, const N: usize>(&self, coordinate: V) -> V2
+    pub fn read<I, V, V2>(&self, coordinate: V) -> V2
     where
         I: Integer,
-        V: Vector<I, 2>,
-        V2: Vector<f32, N>,
+        V: Vector<I>,
+        V2: Vector<f32>,
     {
         let mut result = V2::default();
 
@@ -86,11 +86,11 @@ impl StorageImage2d {
 
     /// Write a texel to an image without a sampler.
     #[spirv_std_macros::gpu_only]
-    pub unsafe fn write<I, V, V2, const N: usize>(&self, coordinate: V, texels: V2)
+    pub unsafe fn write<I, V, V2>(&self, coordinate: V, texels: V2)
     where
         I: Integer,
-        V: Vector<I, 2>,
-        V2: Vector<f32, N>,
+        V: Vector<I>,
+        V2: Vector<f32>,
     {
         asm! {
             "%image = OpLoad _ {this}",

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -1,19 +1,16 @@
 /// Abstract trait representing a SPIR-V vector type.
-pub trait Vector<T: crate::scalar::Scalar, const N: usize>:
-    crate::sealed::Sealed + Default
-{
-}
+pub trait Vector<T: crate::scalar::Scalar>: crate::sealed::Sealed + Default {}
 
-impl Vector<bool, 2> for glam::BVec2 {}
-impl Vector<bool, 3> for glam::BVec3 {}
-impl Vector<bool, 4> for glam::BVec4 {}
-impl Vector<f32, 2> for glam::Vec2 {}
-impl Vector<f32, 3> for glam::Vec3 {}
-impl Vector<f32, 3> for glam::Vec3A {}
-impl Vector<f32, 4> for glam::Vec4 {}
-impl Vector<u32, 2> for glam::UVec2 {}
-impl Vector<u32, 3> for glam::UVec3 {}
-impl Vector<u32, 4> for glam::UVec4 {}
-impl Vector<i32, 2> for glam::IVec2 {}
-impl Vector<i32, 3> for glam::IVec3 {}
-impl Vector<i32, 4> for glam::IVec4 {}
+impl Vector<bool> for glam::BVec2 {}
+impl Vector<bool> for glam::BVec3 {}
+impl Vector<bool> for glam::BVec4 {}
+impl Vector<f32> for glam::Vec2 {}
+impl Vector<f32> for glam::Vec3 {}
+impl Vector<f32> for glam::Vec3A {}
+impl Vector<f32> for glam::Vec4 {}
+impl Vector<u32> for glam::UVec2 {}
+impl Vector<u32> for glam::UVec3 {}
+impl Vector<u32> for glam::UVec4 {}
+impl Vector<i32> for glam::IVec2 {}
+impl Vector<i32> for glam::IVec3 {}
+impl Vector<i32> for glam::IVec4 {}


### PR DESCRIPTION
If we want to have ark use whatever commit we tag as `0.3` we need to revert the const generic part of `Vector` for now, as while it's stable for us, it won't be stable for Ark until the end of the month. 