### PR TITLE
Access the original type's fields through a `pointercast`, under the Logical addressing model.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -13,6 +13,7 @@ use std::{fs::File, io::Write, path::Path};
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum SpirvValueKind {
     Def(Word),
+
     /// There are a fair number of places where `rustc_codegen_ssa` creates a pointer to something
     /// that cannot be pointed to in SPIR-V. For example, constant values are frequently emitted as
     /// a pointer to constant memory, and then dereferenced where they're used. Functions are the
@@ -27,6 +28,24 @@ pub enum SpirvValueKind {
         /// The global (module-scoped) `OpVariable` (with `initializer` set as
         /// its initializer) to attach zombies to.
         global_var: Word,
+    },
+
+    /// Deferred pointer cast, for the `Logical` addressing model (which doesn't
+    /// really support raw pointers in the way Rust expects to be able to use).
+    ///
+    /// The cast's target pointer type is the `ty` of the `SpirvValue` that has
+    /// `LogicalPtrCast` as its `kind`, as it would be redundant to have it here.
+    LogicalPtrCast {
+        /// Pointer value being cast.
+        original_ptr: Word,
+
+        /// Pointee type of `original_ptr`.
+        original_pointee_ty: Word,
+
+        /// `OpUndef` of the right target pointer type, to attach zombies to.
+        // FIXME(eddyb) we should be using a real `OpBitcast` here, but we can't
+        // emit that on the fly during `SpirvValue::def`, due to builder locking.
+        zombie_target_undef: Word,
     },
 }
 
@@ -49,7 +68,8 @@ impl SpirvValue {
                 };
                 Some(initializer.with_type(ty))
             }
-            SpirvValueKind::Def(_) => None,
+
+            SpirvValueKind::Def(_) | SpirvValueKind::LogicalPtrCast { .. } => None,
         }
     }
 
@@ -69,6 +89,7 @@ impl SpirvValue {
     pub fn def_with_span(self, cx: &CodegenCx<'_>, span: Span) -> Word {
         match self.kind {
             SpirvValueKind::Def(word) => word,
+
             SpirvValueKind::ConstantPointer {
                 initializer: _,
                 global_var,
@@ -82,6 +103,29 @@ impl SpirvValue {
                 );
 
                 global_var
+            }
+
+            SpirvValueKind::LogicalPtrCast {
+                original_ptr: _,
+                original_pointee_ty,
+                zombie_target_undef,
+            } => {
+                if cx.is_system_crate() {
+                    cx.zombie_with_span(
+                        zombie_target_undef,
+                        span,
+                        "OpBitcast on ptr without AddressingModel != Logical",
+                    )
+                } else {
+                    cx.tcx
+                        .sess
+                        .struct_span_err(span, "Cannot cast between pointer types")
+                        .note(&format!("from: *{}", cx.debug_type(original_pointee_ty)))
+                        .note(&format!("to: {}", cx.debug_type(self.ty)))
+                        .emit()
+                }
+
+                zombie_target_undef
             }
         }
     }

--- a/crates/spirv-builder/src/test/control_flow.rs
+++ b/crates/spirv-builder/src/test/control_flow.rs
@@ -376,3 +376,35 @@ pub fn main() {
     render(v, v, 1.0, 2.0);
 }"#);
 }
+
+// HACK(eddyb) test that `for` loop desugaring (with its call to `Iterator::next`
+// and matching on the resulting `Option`) works, without a working `Range`
+// iterator (due to the use of `mem::swap` and its block-wise implementation).
+#[test]
+fn cf_for_with_custom_range_iter() {
+    val(r#"
+use num_traits::Num;
+use core::ops::Range;
+
+struct RangeIter<T>(Range<T>);
+
+impl<T: Num + Ord + Copy> Iterator for RangeIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        let x = self.0.start;
+        if x >= self.0.end {
+            None
+        } else {
+            self.0.start = x + T::one();
+            Some(x)
+        }
+    }
+}
+
+#[spirv(fragment)]
+pub fn main(i: Input<i32>) {
+    for _ in RangeIter(0..*i) {
+    }
+}
+"#);
+}


### PR DESCRIPTION
This allows simple `enum`s, like `Option<u32>`, to work, since they already have the variant fields in the `enum` itself
(thanks to `ScalarPair` ABI - but this could easily be extended to at least all `Option<T>` without much effort).

`for` loops that rely on those `Option` types also work, except `Range`'s implementation of `Iterator` uses `mem::swap`, and that happens to have a [pretty severe case of microoptimization](https://github.com/rust-lang/rust/blob/7f32f62aa5ceba1b795f3702e502d8473238be6b/library/core/src/ptr/mod.rs#L490-L550), that we'll have to turn off upstream (frankly, given that this kind of library optimization blocks MIR optimizations, generating that SIMD loop should probably be done in the backend, not in a library).

You can see a working example of a `for` loop with a custom `Range`-like iterator, in the third commit.