### PR TITLE
Reenable clippy's `use_self` lint (disabled during last rustup) and remove now-unneeded `#[allow]`s for it.

### DIFF
--- a/crates/rustc_codegen_spirv/src/decorations.rs
+++ b/crates/rustc_codegen_spirv/src/decorations.rs
@@ -1,6 +1,10 @@
 //! SPIR-V decorations specific to `rustc_codegen_spirv`, produced during
 //! the original codegen of a crate, and consumed by the `linker`.
 
+// FIXME(eddyb) Remove when a fix for clippy warning in `serde` derives
+// (https://github.com/rust-lang/rust-clippy/issues/6818) lands in nightly.
+#![allow(clippy::use_self)]
+
 use rspirv::dr::{Instruction, Module, Operand};
 use rspirv::spirv::{Decoration, Op, Word};
 use rustc_span::{source_map::SourceMap, FileName, Pos, Span};

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -28,8 +28,7 @@
     //clippy::enum_glob_use,
     clippy::pub_enum_variant_names,
     clippy::mem_forget,
-    // See: https://github.com/EmbarkStudios/rust-gpu/issues/459
-    // clippy::use_self,
+    clippy::use_self,
     clippy::filter_map_next,
     clippy::needless_continue,
     clippy::needless_borrow,

--- a/crates/rustc_codegen_spirv/src/linker/specializer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/specializer.rs
@@ -325,8 +325,6 @@ enum Value<T> {
     SameAs(T),
 }
 
-// FIXME(eddyb) clippy bug suggests `Self` even when it'd be a type mismatch.
-#[allow(clippy::use_self)]
 impl<T> Value<T> {
     fn map_var<U>(self, f: impl FnOnce(T) -> U) -> Value<U> {
         match self {
@@ -363,8 +361,6 @@ struct Instance<GA> {
     generic_args: GA,
 }
 
-// FIXME(eddyb) clippy bug suggests `Self` even when it'd be a type mismatch.
-#[allow(clippy::use_self)]
 impl<GA> Instance<GA> {
     fn as_ref(&self) -> Instance<&GA> {
         Instance {

--- a/crates/rustc_codegen_spirv/src/linker/specializer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/specializer.rs
@@ -290,7 +290,7 @@ impl TryFrom<&Operand> for CopyOperand {
 }
 
 impl From<CopyOperand> for Operand {
-    fn from(op: CopyOperand) -> Operand {
+    fn from(op: CopyOperand) -> Self {
         match op {
             CopyOperand::IdRef(id) => Self::IdRef(id),
             CopyOperand::StorageClass(s) => Self::StorageClass(s),

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -323,8 +323,6 @@ const EXECUTION_MODES: &[(&str, ExecutionMode, ExecutionModeExtraDim)] = {
     ]
 };
 
-// FIXME(eddyb) clippy bug suggests `Self` even when it couldn't possibly work.
-#[allow(clippy::use_self)]
 impl Symbols {
     fn new() -> Self {
         let builtins = BUILTINS


### PR DESCRIPTION
Fixes #459 (clippy's `use_self` has a correct implementation now).

Sadly, I had to add one new `#[allow(clippy::use_self)]`, because of https://github.com/rust-lang/rust-clippy/issues/6818, but it's still an overall improvement.