### PR TITLE
Use Embark standard lints v0.3

### DIFF
--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -4,7 +4,7 @@
     feature(asm, register_attr, repr_simd, core_intrinsics, lang_items),
     register_attr(spirv)
 )]
-// BEGIN - Embark standard lints v0.2.
+// BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -23,13 +23,16 @@
     clippy::if_let_mutex,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
+    clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
     clippy::lossy_float_literal,
     clippy::macro_use_imports,
+    clippy::map_err_ignore,
     clippy::map_flatten,
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
+    clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,
@@ -39,9 +42,12 @@
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
+    clippy::string_add_assign,
+    clippy::string_add,
     clippy::string_to_string,
     clippy::suboptimal_flops,
     clippy::todo,
+    clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::verbose_file_reads,
@@ -49,9 +55,15 @@
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.2
+// END - Embark standard lints v0.3
 // crate-specific exceptions:
-#![allow(unsafe_code)] // still quite a bit needed
+#![allow(
+    // Needed for `asm!`.
+    unsafe_code,
+    // We deblierately provide an unimplemented version of our API on CPU
+    // platforms so that code completion still works.
+    clippy::unimplemented,
+)]
 
 #[cfg(not(target_arch = "spirv"))]
 #[macro_use]


### PR DESCRIPTION
Fixes up our code to support the additional lints in the draft v0.3 of our standard set: https://github.com/EmbarkStudios/rust-ecosystem/issues/60. This is not final yet, but getting close there. Probably be quite a while until the next version after this, now we have most of the main lints we've been testing with.

The main change was with the [`match_same_arms`](https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms) lint, many match cases worked nicely and got merged together which do find easier to read, but some would require larger ordering changes & merges which looked like it could reduce readability in the complex backend code so left it with `allow´ in those few cases.

Leaving this as draft until  https://github.com/EmbarkStudios/rust-ecosystem/issues/60 is merged and v0.3 finalized. If you have any issues with any of these changes/lints, please do comment here and/or in the PR if we should not enable one of the lints.