### PR TITLE
builder: constant-fold `bx.mul(a, b)` in order to support `ptr::{read,write}`.

### DIFF
--- a/crates/spirv-builder/src/test/mod.rs
+++ b/crates/spirv-builder/src/test/mod.rs
@@ -136,7 +136,13 @@ fn dis_fn(src: &str, func: &str, expect: &str) {
             inst.class.opcode == rspirv::spirv::Op::Name
                 && inst.operands[1].unwrap_literal_string() == abs_func_path
         })
-        .expect("No function with that name found")
+        .unwrap_or_else(|| {
+            panic!(
+                "no function with the name `{}` found in:\n{}\n",
+                abs_func_path,
+                module.disassemble()
+            )
+        })
         .operands[0]
         .unwrap_id_ref();
     let mut func = module


### PR DESCRIPTION
`rustc_codegen_ssa` uses `bx.mul(count, size_of_pointee)` to implement e.g. `ptr::copy`, and functions like `ptr::read`, `ptr::write`, and some abstractions, rely on calling `ptr::copy(src, dst, 1)`, instead of having a separate intrinsic for the `count == 1` case.

Under `rustc_codegen_llvm`, this obviously works for arbitrary `count` values, but also it gets constant-folded, so by the time the `memcpy` call is created, the number of bytes to copy is a constant. I've replicated the constant-folding behavior in `rustc_codegen_spirv`, which gets rid of these kinds of errors (i.e. in the cases `OpCopyMemorySized` isn't *actually* needed):
```
error: OpCopyMemorySized without OpCapability Addresses
   --> core/src/ptr/mod.rs:894:9
    |
894 |         copy_nonoverlapping(&src as *const T, dst, 1);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Sadly, this doesn't work through the `copy_from`/`copy_to` pointer methods (see comments on tests for a more in-depth explanation and potential solutions), but it looks like a lot of low-level library code avoids using the methods itself.

Fixes #462 by un-`#[ignore]`-ing the `create_uninitialized_memory` test.