### PR TITLE
Clean up some of the cases of duplication found by `clippy::match_same_arms`.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -271,8 +271,7 @@ impl<'tcx> StaticMethods for CodegenCx<'tcx> {
         if self.lookup_type(v.ty) == SpirvType::Bool {
             let val = self.builder.lookup_const(v).unwrap();
             let val_int = match val {
-                SpirvConst::Bool(_, false) => 0,
-                SpirvConst::Bool(_, true) => 0,
+                SpirvConst::Bool(_, val) => val as u8,
                 _ => bug!(),
             };
             v = self.constant_u8(span, val_int);

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -156,7 +156,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
     fn type_kind(&self, ty: Self::Type) -> TypeKind {
         match self.lookup_type(ty) {
             SpirvType::Void => TypeKind::Void,
-            SpirvType::Bool => TypeKind::Integer, // thanks llvm
+            SpirvType::Bool | // thanks llvm
             SpirvType::Integer(_, _) => TypeKind::Integer,
             SpirvType::Float(width) => match width {
                 16 => TypeKind::Half,

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -305,21 +305,23 @@ impl SpirvType {
 
     pub fn sizeof<'tcx>(&self, cx: &CodegenCx<'tcx>) -> Option<Size> {
         let result = match *self {
-            Self::Void => Size::ZERO,
+            // Types that have a dynamic size, or no concept of size at all.
+            Self::Void
+            | Self::Opaque { .. }
+            | Self::RuntimeArray { .. }
+            | Self::Function { .. } => return None,
+
             Self::Bool => Size::from_bytes(1),
             Self::Integer(width, _) => Size::from_bits(width),
             Self::Float(width) => Size::from_bits(width),
             Self::Adt { size, .. } => size?,
-            Self::Opaque { .. } => Size::ZERO,
             Self::Vector { element, count } => {
                 cx.lookup_type(element).sizeof(cx)? * count.next_power_of_two() as u64
             }
             Self::Array { element, count } => {
                 cx.lookup_type(element).sizeof(cx)? * cx.builder.lookup_const_u64(count).unwrap()
             }
-            Self::RuntimeArray { .. } => return None,
             Self::Pointer { .. } => cx.tcx.data_layout.pointer_size,
-            Self::Function { .. } => cx.tcx.data_layout.pointer_size,
             Self::Image { .. } => Size::from_bytes(4),
             Self::Sampler => Size::from_bytes(4),
             Self::SampledImage { .. } => Size::from_bytes(4),
@@ -329,12 +331,15 @@ impl SpirvType {
 
     pub fn alignof<'tcx>(&self, cx: &CodegenCx<'tcx>) -> Align {
         match *self {
-            Self::Void => Align::from_bytes(0).unwrap(),
+            // Types that have no concept of size or alignment.
+            Self::Void | Self::Opaque { .. } | Self::Function { .. } => {
+                Align::from_bytes(0).unwrap()
+            }
+
             Self::Bool => Align::from_bytes(1).unwrap(),
             Self::Integer(width, _) => Align::from_bits(width as u64).unwrap(),
             Self::Float(width) => Align::from_bits(width as u64).unwrap(),
             Self::Adt { align, .. } => align,
-            Self::Opaque { .. } => Align::from_bytes(0).unwrap(),
             // Vectors have size==align
             Self::Vector { .. } => Align::from_bytes(
                 self.sizeof(cx)
@@ -345,7 +350,6 @@ impl SpirvType {
             Self::Array { element, .. } => cx.lookup_type(element).alignof(cx),
             Self::RuntimeArray { element } => cx.lookup_type(element).alignof(cx),
             Self::Pointer { .. } => cx.tcx.data_layout.pointer_align.abi,
-            Self::Function { .. } => cx.tcx.data_layout.pointer_align.abi,
             Self::Image { .. } => Align::from_bytes(4).unwrap(),
             Self::Sampler => Align::from_bytes(4).unwrap(),
             Self::SampledImage { .. } => Align::from_bytes(4).unwrap(),


### PR DESCRIPTION
After these changes, examples still run and the tests seem to pass, but I'm not sure they're all great.
At the very least, they're conservative, in that we might now error/ICE in cases that were allowed before.

They all originated as comments on #482, and I made this PR because @repi (understandably) didn't want to do functional changes in a lint cleanup PR.