### PR TITLE
Bump rust-toolchain to nightly-2021-03-11.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -504,7 +504,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
         cond
     }
 
-    fn sideeffect(&mut self, _: bool) {
+    fn sideeffect(&mut self) {
         // TODO: This is currently ignored.
         // It corresponds to the llvm.sideeffect intrinsic - does spir-v have an equivalent?
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -166,7 +166,7 @@ impl<'tcx> CodegenCx<'tcx> {
         if let hir::PatKind::Binding(_, _, ident, _) = &hir_param.pat.kind {
             self.emit_global().name(variable, ident.to_string());
         }
-        for attr in parse_attrs(self, hir_param.attrs) {
+        for attr in parse_attrs(self, self.tcx.hir().attrs(hir_param.hir_id)) {
             match attr {
                 SpirvAttribute::Builtin(builtin) => {
                     self.emit_global().decorate(

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -313,7 +313,7 @@ impl CodegenBackend for SpirvCodegenBackend {
             // capture variables. Fortunately, the defaults are exposed (thanks rustdoc), so use that instead.
             let result = (rustc_interface::DEFAULT_QUERY_PROVIDERS.fn_sig)(tcx, def_id);
             result.map_bound(|mut inner| {
-                if inner.abi == Abi::C {
+                if let Abi::C { .. } = inner.abi {
                     inner.abi = Abi::Rust;
                 }
                 inner
@@ -329,7 +329,7 @@ impl CodegenBackend for SpirvCodegenBackend {
         providers.fn_sig = |tcx, def_id| {
             let result = (rustc_interface::DEFAULT_EXTERN_QUERY_PROVIDERS.fn_sig)(tcx, def_id);
             result.map_bound(|mut inner| {
-                if inner.abi == Abi::C {
+                if let Abi::C { .. } = inner.abi {
                     inner.abi = Abi::Rust;
                 }
                 inner

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-03-04"
+channel = "nightly-2021-03-11"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
Opened this as a draft, as this specific bump might be a bad idea because [this nightly lacks `rls`](https://rust-lang.github.io/rustup-components-history/) (which I still rely on).

I mostly did this to be able to test https://github.com/rust-lang/rust/pull/83019, and the fixes here can be reused when updating to an even newer nightly.
(and yes, with https://github.com/rust-lang/rust/pull/83019 we can finally use `for i in 0..n` loops in shaders!)

cc @XAMPPRocky for visibility