### PR TITLE
Unlock `for i in 0..n` loops! (by bumping rust-toolchain to nightly-2021-03-17)

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -504,7 +504,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
         cond
     }
 
-    fn sideeffect(&mut self, _: bool) {
+    fn sideeffect(&mut self) {
         // TODO: This is currently ignored.
         // It corresponds to the llvm.sideeffect intrinsic - does spir-v have an equivalent?
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -166,7 +166,7 @@ impl<'tcx> CodegenCx<'tcx> {
         if let hir::PatKind::Binding(_, _, ident, _) = &hir_param.pat.kind {
             self.emit_global().name(variable, ident.to_string());
         }
-        for attr in parse_attrs(self, hir_param.attrs) {
+        for attr in parse_attrs(self, self.tcx.hir().attrs(hir_param.hir_id)) {
             match attr {
                 SpirvAttribute::Builtin(builtin) => {
                     self.emit_global().decorate(

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -313,7 +313,7 @@ impl CodegenBackend for SpirvCodegenBackend {
             // capture variables. Fortunately, the defaults are exposed (thanks rustdoc), so use that instead.
             let result = (rustc_interface::DEFAULT_QUERY_PROVIDERS.fn_sig)(tcx, def_id);
             result.map_bound(|mut inner| {
-                if inner.abi == Abi::C {
+                if let Abi::C { .. } = inner.abi {
                     inner.abi = Abi::Rust;
                 }
                 inner
@@ -329,7 +329,7 @@ impl CodegenBackend for SpirvCodegenBackend {
         providers.fn_sig = |tcx, def_id| {
             let result = (rustc_interface::DEFAULT_EXTERN_QUERY_PROVIDERS.fn_sig)(tcx, def_id);
             result.map_bound(|mut inner| {
-                if inner.abi == Abi::C {
+                if let Abi::C { .. } = inner.abi {
                     inner.abi = Abi::Rust;
                 }
                 inner

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -78,6 +78,7 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, String> {
         diagnostic_output: DiagnosticOutput::Raw(Box::new(write_diags)),
         stderr: None,
         lint_caps: Default::default(),
+        parse_sess_created: None,
         register_lints: None,
         override_queries: None,
         make_codegen_backend: None,

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -1217,15 +1217,15 @@ impl PipelineDescriptor {
             .build();
 
         Self {
+            color_blend_attachments,
+            dynamic_state,
             shader_stages,
             vertex_input,
             input_assembly,
             rasterization,
             multisample,
             depth_stencil,
-            color_blend_attachments,
             color_blend,
-            dynamic_state,
             dynamic_state_info,
         }
     }

--- a/examples/shaders/mouse-shader/src/lib.rs
+++ b/examples/shaders/mouse-shader/src/lib.rs
@@ -226,9 +226,7 @@ pub fn main_fs(
         .intersect(mouse_circle)
     };
 
-    // FIXME(eddyb) use a `for i in 0..3` loop when that works.
-    let mut i = 0;
-    while i < 3 {
+    for i in 0..3 {
         painter.fill(
             mouse_button(i),
             RED.lerp(
@@ -242,7 +240,6 @@ pub fn main_fs(
                 ),
             ),
         );
-        i += 1;
     }
 
     painter.fill_with_contrast_border(

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-03-11"
+channel = "nightly-2021-03-17"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-03-04"
+channel = "nightly-2021-03-11"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
Most of the changes are uninteresting (and in their own commit), and were already part of #490.

What's new is @m-ou-se landed https://github.com/rust-lang/rust/pull/83022 in nightly, decoupling `mem::replace` from `mem::swap`.
So while `mem::swap` still doesn't work for us (as https://github.com/rust-lang/rust/pull/83019 wasn't approved), most things only use `mem::replace`, and that's in fact the case for `Range`'s `Iterator` impl, which was the last thing that had been blocking `for i in 0..n`.

And after this nightly bump, we now have e.g. this loop in `mouse-shader`:
```rust
    for i in 0..3 {
        painter.fill(
            mouse_button(i),
            // ...
        );
    }
```

However, we/I haven't had a chance to test more complicated patterns of iterators, and it would be great if everyone started experimenting with all kinds of iterators (either base ones or combinators etc.), to get a feel for what works and what doesn't.