### PR TITLE
Use installed SPIR-V tools for compiletest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8b450c59e36984d9b8fc26b08a650f447ae156b1c60be17c8bca2d8458942a"
+checksum = "75ac9aad1f66b780f6db297cb69e08303898175df898319678618b810e7de950"
 dependencies = [
  "memchr",
  "spirv-tools-sys",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -34,7 +34,7 @@ rustc-demangle = "0.1.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"
-spirv-tools = { version = "0.5.0", default-features = false }
+spirv-tools = { version = "0.6.0", default-features = false }
 tar = "0.4.30"
 topological-sort = "0.1"
 

--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[[bin]]
+name = "example-runner-ash"
+test = false
+
 # See rustc_codegen_spirv/Cargo.toml for details on these features
 [features]
 default = ["use-compiled-tools"]

--- a/examples/runners/cpu/Cargo.toml
+++ b/examples/runners/cpu/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[[bin]]
+name = "example-runner-cpu"
+test = false
+
 [dependencies]
 minifb = "0.19.2"
 # bring in the shader as natively compiled code

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -6,8 +6,14 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[[bin]]
+name = "example-runner-wgpu"
+test = false
+
 [lib]
 crate-type = ["lib", "cdylib"]
+test = false
+doctest = false
 
 # See rustc_codegen_spirv/Cargo.toml for details on these features
 [features]

--- a/examples/shaders/compute-shader/Cargo.toml
+++ b/examples/shaders/compute-shader/Cargo.toml
@@ -7,6 +7,8 @@ license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["dylib"]
+test = false
+doctest = false
 
 [dependencies]
 spirv-std-macros = { path = "../../../crates/spirv-std-macros" }

--- a/examples/shaders/mouse-shader/Cargo.toml
+++ b/examples/shaders/mouse-shader/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 
 [lib]
 crate-type = ["dylib"]
+test = false
+doctest = false
 
 [dependencies]
 shared = { path = "../../shaders/shared" }

--- a/examples/shaders/shared/Cargo.toml
+++ b/examples/shaders/shared/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[lib]
+test = false
+doctest = false
+
 [dependencies]
 spirv-std-macros = { path = "../../../crates/spirv-std-macros" }
 spirv-std = { path = "../../../crates/spirv-std" }

--- a/examples/shaders/simplest-shader/Cargo.toml
+++ b/examples/shaders/simplest-shader/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 
 [lib]
 crate-type = ["dylib"]
+test = false
+doctest = false
 
 [dependencies]
 spirv-std-macros = { path = "../../../crates/spirv-std-macros" }

--- a/examples/shaders/sky-shader/Cargo.toml
+++ b/examples/shaders/sky-shader/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 
 [lib]
 crate-type = ["dylib"]
+test = false
+doctest = false
 
 [dependencies]
 shared = { path = "../../shaders/shared" }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-03-21"
+channel = "nightly-2021-03-25"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,12 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[features]
+default = ["use-compiled-tools"]
+use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
+use-installed-tools = ["rustc_codegen_spirv/use-installed-tools"]
+
 [dependencies]
 compiletest = { version = "0.6.0", package = "compiletest_rs" }
-rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv" }
+rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", default-features = false }
 structopt = "0.3.21"

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -4,7 +4,7 @@ error: pointer has non-null integer address
           allocate_const_scalar::main
           Unnamed function ID %4
 
-error: invalid binary:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
+error: error:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |
   = note: spirv-val failed
   = note: module `$TEST_BUILD_DIR/lang/core/ptr/allocate_const_scalar.stage-id.spv`


### PR DESCRIPTION
This PR changes the default to require installed tools and to disable compiling examples for tests, both of which help reduce compile times. We don't currently have any tests for these examples but they are always compiled when changes in the compiler happen which makes tests run longer.