### PR TITLE
Fix recover_access_chain_from_offset on unsized fields

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -405,7 +405,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             let field_ty_kind = self.lookup_type(field_ty);
 
                             let offset_in_field = offset - field_offset;
-                            if offset_in_field < field_ty_kind.sizeof(self)? {
+                            if field_ty_kind
+                                .sizeof(self)
+                                .map_or(true, |size| offset_in_field < size)
+                            {
                                 Some((i, field_ty, field_ty_kind, offset_in_field))
                             } else {
                                 None


### PR DESCRIPTION
Fixes the issue found in https://github.com/EmbarkStudios/rust-gpu/pull/504

I would add a test, but, the test case I came up with in 504 depends on that PR's content to compile. So, once 504 is in (or preferably in 504), we should add the test.