### PR TITLE
Allow running `cargo compiletest` from any sub-directory in the workspace.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,4 +4,4 @@
 rustflags = "-C prefer-dynamic"
 
 [alias]
-compiletest = "run --release --manifest-path=tests/Cargo.toml"
+compiletest = "run --release -p compiletests"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 name = "compiletest_rs"
 version = "0.6.0"
-source = "git+https://github.com/Manishearth/compiletest-rs.git?rev=1f4a4c4#1f4a4c40e06ba36fef63909ddfaa76edcb2ac620"
+source = "git+https://github.com/Manishearth/compiletest-rs.git?rev=9257f6d#9257f6dd0a9687dd36897684ae18a124ac34016b"
 dependencies = [
  "diff",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ codegen-units = 16
 spirv-std = { path = "./crates/spirv-std" }
 spirv-std-macros = { path = "./crates/spirv-std-macros" }
 glam = { git = "https://github.com/bitshifter/glam-rs.git", rev ="b3e94fb" }
-# TODO: Needed for handling SPIR-V extension across platforms. Remove once
-# next version is released.
-compiletest_rs= { git = "https://github.com/Manishearth/compiletest-rs.git", rev = "1f4a4c4" }
+# TODO: Remove once next version is released - needed to include these two PRs:
+# * Manishearth/compiletest-rs#240 (for handling SPIR-V extension across platforms)
+# * Manishearth/compiletest-rs#241 (for the `$TEST_BUILD_DIR` path normalization)
+compiletest_rs = { git = "https://github.com/Manishearth/compiletest-rs.git", rev = "9257f6d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-exclude = ["target/"]
 members = [
     "examples/runners/cpu",
     "examples/runners/ash",

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -148,7 +148,7 @@ fn link_exe(
         if let Err(e) = std::fs::write(out_filename, spirv_tools::binary::from_binary(&spv_binary))
         {
             let mut err = sess.struct_err("failed to serialize spirv-binary to disk");
-            err.note(&format!("module {:?}", out_filename));
+            err.note(&format!("module `{}`", out_filename.display()));
             err.note(&format!("I/O error: {:#}", e));
             err.emit();
         }
@@ -195,7 +195,7 @@ fn do_spirv_opt(sess: &Session, spv_binary: Vec<u32>, filename: &Path) -> Vec<u3
                 Level::Info | Level::Debug => sess.struct_note_without_error(&msg.message),
             };
 
-            err.note(&format!("module {:?}", filename));
+            err.note(&format!("module `{}`", filename.display()));
             err.emit();
         },
         // We currently run the validator separately after optimization or even
@@ -208,7 +208,7 @@ fn do_spirv_opt(sess: &Session, spv_binary: Vec<u32>, filename: &Path) -> Vec<u3
         Err(e) => {
             let mut err = sess.struct_warn(&e.to_string());
             err.note("spirv-opt failed, leaving as unoptimized");
-            err.note(&format!("module {:?}", filename));
+            err.note(&format!("module `{}`", filename.display()));
             err.emit();
             spv_binary
         }
@@ -223,7 +223,7 @@ fn do_spirv_val(sess: &Session, spv_binary: &[u32], filename: &Path) {
     if let Err(e) = validator.validate(spv_binary, None) {
         let mut err = sess.struct_err(&e.to_string());
         err.note("spirv-val failed");
-        err.note(&format!("module {:?}", filename));
+        err.note(&format!("module `{}`", filename.display()));
         err.emit();
     }
 }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -30,7 +30,7 @@ impl DepKind {
 
 fn main() {
     let original_target_dir = Path::new("./target");
-    let deps_target_dir = original_target_dir.join("compiletest/spirv-std");
+    let deps_target_dir = original_target_dir.join("compiletest-deps");
     let compiletest_build_dir = original_target_dir.join("compiletest-results");
 
     // Pull in rustc_codegen_spirv as a dynamic library in the same way

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -7,7 +7,7 @@ error: pointer has non-null integer address
 error: invalid binary:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |
   = note: spirv-val failed
-  = note: module "$TEST_BUILD_DIR/lang/core/ptr/allocate_const_scalar.stage-id.spv"
+  = note: module `$TEST_BUILD_DIR/lang/core/ptr/allocate_const_scalar.stage-id.spv`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -7,7 +7,7 @@ error: pointer has non-null integer address
 error: invalid binary:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |
   = note: spirv-val failed
-  = note: module "./target/compiletest-results/lang/core/ptr/allocate_const_scalar.stage-id.spv"
+  = note: module "$TEST_BUILD_DIR/lang/core/ptr/allocate_const_scalar.stage-id.spv"
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This PR lets you run `cargo compiletest` while being e.g. nested in `crates/rustc_codegen_spirv` (which I often am because that's what I open in VSCode, to avoid overzealous building of code outside it).

Ideally each commit can be reviewed individually - only the last one significantly changes behavior.

~~The reason this is WIP is that we have to wait for https://github.com/Manishearth/compiletest-rs/pull/241 to land before merging (as that's how absolute paths to the `compiletest-results` directory get normalized to `$TEST_BUILD_DIR`).~~

There's also a workaround for not having `resolver = "2"` yet - I wonder when we can switch the workspace to that, and stop having weird issues with featuresets (IIRC @khyperia ran into some bugs with it, so we can't yet?).