### PR TITLE
Fix Location calculation for arrays in entrypoint interface

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -457,7 +457,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 std::iter::once(Operand::LiteralInt32(*location)),
             );
             // Arrays take up multiple locations
-            *location += if let SpirvType::Array { count, .. } = self.lookup_type(value_ty) {
+            *location += if let SpirvType::Array { count, .. } = self.lookup_type(value_spirv_type) {
                 self.builder
                     .lookup_const_u64(count)
                     .expect("Array type has invalid count value") as u32

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -400,7 +400,15 @@ impl<'tcx> CodegenCx<'tcx> {
                 Decoration::Location,
                 std::iter::once(Operand::LiteralInt32(*location)),
             );
-            *location += 1;
+            // Arrays take up multiple locations
+            *location +=
+                if let SpirvType::Array { count, .. } = self.lookup_type(var_spirv_type_pointee) {
+                    self.builder
+                        .lookup_const_u64(count)
+                        .expect("Array type has invalid count value") as u32
+                } else {
+                    1
+                }
         }
 
         // Emit the `OpVariable` with its *Result* ID set to `variable`.

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -401,14 +401,13 @@ impl<'tcx> CodegenCx<'tcx> {
                 std::iter::once(Operand::LiteralInt32(*location)),
             );
             // Arrays take up multiple locations
-            *location +=
-                if let SpirvType::Array { count, .. } = self.lookup_type(var_spirv_type_pointee) {
-                    self.builder
-                        .lookup_const_u64(count)
-                        .expect("Array type has invalid count value") as u32
-                } else {
-                    1
-                }
+            *location += if let SpirvType::Array { count, .. } = self.lookup_type(value_ty) {
+                self.builder
+                    .lookup_const_u64(count)
+                    .expect("Array type has invalid count value") as u32
+            } else {
+                1
+            }
         }
 
         // Emit the `OpVariable` with its *Result* ID set to `variable`.

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -505,3 +505,43 @@ OpUnreachable
 OpFunctionEnd"#,
     )
 }
+
+#[test]
+fn array_locations() {
+    dis_globals(
+        r#"
+#[allow(unused_variables)]
+#[spirv(fragment(entry_point_name="array_locations"))]
+pub fn main(one: [f32; 7], two: [f32; 3], three: f32) { }
+"#,
+        r#"OpCapability Shader
+OpCapability VulkanMemoryModel
+OpCapability VariablePointers
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint Fragment %1 "array_locations" %2 %3 %4
+OpExecutionMode %1 OriginUpperLeft
+OpName %2 "one"
+OpName %3 "two"
+OpName %4 "three"
+OpDecorate %5 ArrayStride 4
+OpDecorate %6 ArrayStride 4
+OpDecorate %2 Location 0
+OpDecorate %3 Location 7
+OpDecorate %4 Location 10
+%7 = OpTypeVoid
+%8 = OpTypeFloat 32
+%9 = OpTypeInt 32 0
+%10 = OpConstant %9 7
+%5 = OpTypeArray %8 %10
+%11 = OpTypePointer Input %5
+%12 = OpConstant %9 3
+%6 = OpTypeArray %8 %12
+%13 = OpTypePointer Input %6
+%14 = OpTypeFunction %7
+%2 = OpVariable %11 Input
+%3 = OpVariable %13 Input
+%15 = OpTypePointer Input %8
+%4 = OpVariable %15 Input"#,
+    );
+}


### PR DESCRIPTION
This PR fixes the calulation for Location decorations on array entrypoint parameters.

Both Vulkan ([spec][2]) and MLSL ([page 44 of the spec][3]) specify that array elements must take up consecutive locations, one for each element. Currently however, rust-gpu will always allocate 1 Location per entrypoint parameter, meaning that this code ([playground link][1]):
```rust
#[spirv(vertex)]
pub fn main_vs(
    data: Input<[f32; 4]>,
    more_data: Input<[f32; 4]>,
    mut out_data: Output<[f32; 4]>,
) {
```
will generate invalid SPIRV:
```
OpEntryPoint Vertex %1 "main_vs" %data %more_data %out_data
OpName %data "data"
OpName %more_data "more_data"
OpName %out_data "out_data"
OpDecorate %_arr_float_uint_4 ArrayStride 4
OpDecorate %data Location 0
OpDecorate %more_data Location 1
OpDecorate %out_data Location 0
```
since data and more_data have overlapping locations.

I'm not exactly that familiar with rustc and rustc_codegen_spirv, so there might be a better way to tell if an entrypoint parameter maps to a SPIRV array type than inspecting the generated type - please review :)

[1]: http://shader-playground.timjones.io/f15e88399b8c03dc131f7f758d53a1c2/vkspec.html#interfaces-iointerfaces-locations
[2]: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#interfaces-iointerfaces-locations
[3]: https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf