### PR TITLE
Add atomic arch instructions

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -201,7 +201,7 @@ fn invoke_rustc(builder: &SpirvBuilder, multimodule: bool) -> Result<PathBuf, Sp
         .unwrap_or_default();
 
     let rustflags = format!(
-        "-Z codegen-backend={} -Zsymbol-mangling-version=v0{}",
+        "-Z codegen-backend={}{}",
         rustc_codegen_spirv.display(),
         llvm_args,
     );

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -7,12 +7,16 @@ use crate::{scalar::Scalar, vector::Vector};
 
 mod arithmetic;
 #[cfg(feature = "const-generics")]
+mod atomics;
+#[cfg(feature = "const-generics")]
 mod barrier;
 mod derivative;
 mod primitive;
 mod ray_tracing;
 
 pub use arithmetic::*;
+#[cfg(feature = "const-generics")]
+pub use atomics::*;
 #[cfg(feature = "const-generics")]
 pub use barrier::*;
 pub use derivative::*;

--- a/crates/spirv-std/src/arch/atomics.rs
+++ b/crates/spirv-std/src/arch/atomics.rs
@@ -1,0 +1,504 @@
+use crate::{
+    integer::{Integer, SignedInteger, UnsignedInteger},
+    memory::{Scope, Semantics},
+    number::Number,
+};
+
+/// Atomically load through `ptr` using the given `SEMANTICS`. All subparts of
+/// the value that is loaded are read atomically with respect to all other
+/// atomic accesses to it within `SCOPE`.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicLoad")]
+#[inline]
+pub unsafe fn atomic_load<N: Number, const SCOPE: Scope, const SEMANTICS: Semantics>(ptr: &N) -> N {
+    let mut result = N::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%result = OpAtomicLoad _ {ptr} %scope %semantics",
+        "OpStore {result} %result",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        result = in(reg) &mut result
+    }
+
+    result
+}
+
+/// Atomically store through `ptr` using the given `SEMANTICS`. All subparts of
+/// `value` are written atomically with respect to all other atomic accesses to
+/// it within `SCOPE`.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicStore")]
+#[inline]
+pub unsafe fn atomic_store<N: Number, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut N,
+    value: N,
+) {
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "OpAtomicStore {ptr} %scope %semantics %value",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        value = in(reg) &value,
+    }
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within `SCOPE` to the same location:
+///
+/// 1. Load through `ptr` to get the original value,
+/// 2. Get a new value from copying `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicExchange")]
+#[inline]
+pub unsafe fn atomic_exchange<N: Number, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut N,
+    value: N,
+) -> N {
+    let mut old = N::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicExchange _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        value = in(reg) &value,
+        old = in(reg) &mut old,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within `SCOPE` to the same location:
+///
+/// 1. Load through `ptr` to get the original value
+/// 2. Get a new value from `value` only if the original value equals
+///    `comparator`, and
+/// 3. Store the new value back through `ptr`, only if the original value
+///    equaled `comparator`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicCompareExchange")]
+#[inline]
+pub unsafe fn atomic_compare_exchange<
+    I: Integer,
+    const SCOPE: Scope,
+    const EQUAL: Semantics,
+    const UNEQUAL: Semantics,
+>(
+    ptr: &mut I,
+    value: I,
+    comparator: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%equal = OpConstant %u32 {equal}",
+        "%unequal = OpConstant %u32 {unequal}",
+        "%value = OpLoad _ {value}",
+        "%comparator = OpLoad _ {comparator}",
+        "%old = OpAtomicCompareExchange _ {ptr} %scope %equal %unequal %value %comparator",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        equal = const EQUAL as u8,
+        unequal = const UNEQUAL as u8,
+        ptr = in(reg) ptr,
+        value = in(reg) &value,
+        comparator = in(reg) &comparator,
+        old = in(reg) &mut old,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within `SCOPE` to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value through integer addition of 1 to original value, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicIIncrement")]
+#[inline]
+pub unsafe fn atomic_i_increment<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%old = OpAtomicIIncrement _ {ptr} %scope %semantics",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within `SCOPE` to the same location:
+///
+/// 1) load through `ptr` to get an original value,
+/// 2) get a new value through integer subtraction of 1 from original value, and
+/// 3) store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicIDecrement")]
+#[inline]
+pub unsafe fn atomic_i_decrement<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%old = OpAtomicIIncrement _ {ptr} %scope %semantics",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within `SCOPE` to the same location:
+///
+/// 1) load through `ptr` to get an original value,
+/// 2) get a new value by integer addition of original value and `value`, and
+/// 3) store the new value back through `ptr`.
+///
+/// The result is the Original Value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicIAdd")]
+#[inline]
+pub unsafe fn atomic_i_add<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicIAdd _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within `SCOPE` to the same location:
+///
+/// 1) load through `ptr` to get an original value,
+/// 2) get a new value by integer subtraction of original value and `value`, and
+/// 3) store the new value back through `ptr`.
+///
+/// The result is the Original Value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicISub")]
+#[inline]
+pub unsafe fn atomic_i_sub<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicISub _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within Scope to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value by finding the smallest signed integer of original value
+///    and `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicSMin")]
+#[inline]
+pub unsafe fn atomic_s_min<I: SignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicSMin _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within Scope to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value by finding the smallest unsigned integer of original
+///    value and `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicUMin")]
+#[inline]
+pub unsafe fn atomic_u_min<I: UnsignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicUMin _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within Scope to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value by finding the largest signed integer of original value
+///    and `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicSMax")]
+#[inline]
+pub unsafe fn atomic_s_max<I: SignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicSMax _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within Scope to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value by finding the largest unsigned integer of original
+///    value and `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicUMax")]
+#[inline]
+pub unsafe fn atomic_u_max<I: UnsignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicUMax _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within Scope to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value by the bitwise AND of the original value and `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicAnd")]
+#[inline]
+pub unsafe fn atomic_and<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicAnd _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within Scope to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value by the bitwise OR of the original value and `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicOr")]
+#[inline]
+pub unsafe fn atomic_or<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicOr _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}
+
+/// Perform the following steps atomically with respect to any other atomic
+/// accesses within Scope to the same location:
+///
+/// 1. Load through `ptr` to get an original value,
+/// 2. Get a new value by the bitwise XOR of the original value and `value`, and
+/// 3. Store the new value back through `ptr`.
+///
+/// The result is the original value.
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpAtomicXor")]
+#[inline]
+pub unsafe fn atomic_xor<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
+    ptr: &mut I,
+    value: I,
+) -> I {
+    let mut old = I::default();
+
+    asm! {
+        "%u32 = OpTypeInt 32 0",
+        "%scope = OpConstant %u32 {scope}",
+        "%semantics = OpConstant %u32 {semantics}",
+        "%value = OpLoad _ {value}",
+        "%old = OpAtomicXor _ {ptr} %scope %semantics %value",
+        "OpStore {old} %old",
+        scope = const SCOPE as u8,
+        semantics = const SEMANTICS as u8,
+        ptr = in(reg) ptr,
+        old = in(reg) &mut old,
+        value = in(reg) &value,
+    }
+
+    old
+}

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -83,6 +83,7 @@ pub mod integer;
 pub mod memory;
 pub mod ray_tracing;
 mod sampler;
+pub mod number;
 pub mod scalar;
 pub(crate) mod sealed;
 mod textures;

--- a/crates/spirv-std/src/number.rs
+++ b/crates/spirv-std/src/number.rs
@@ -1,0 +1,13 @@
+/// Abstract trait representing a SPIR-V integer type.
+pub trait Number: crate::scalar::Scalar {}
+
+impl Number for u8 {}
+impl Number for u16 {}
+impl Number for u32 {}
+impl Number for u64 {}
+impl Number for i8 {}
+impl Number for i16 {}
+impl Number for i32 {}
+impl Number for i64 {}
+impl Number for f32 {}
+impl Number for f64 {}

--- a/tests/ui/arch/atomic_and.rs
+++ b/tests/ui/arch/atomic_and.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_and::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_compare_exchange.rs
+++ b/tests/ui/arch/atomic_compare_exchange.rs
@@ -1,0 +1,18 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_compare_exchange::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+            { Semantics::ImageMemory },
+        >(&mut *output, 5, 10);
+    }
+}

--- a/tests/ui/arch/atomic_exchange.rs
+++ b/tests/ui/arch/atomic_exchange.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<f32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_exchange::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory }
+        >(&mut *output, 5.0);
+    }
+}

--- a/tests/ui/arch/atomic_i_add.rs
+++ b/tests/ui/arch/atomic_i_add.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_i_add::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_i_decrement.rs
+++ b/tests/ui/arch/atomic_i_decrement.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_i_decrement::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output);
+    }
+}

--- a/tests/ui/arch/atomic_i_increment.rs
+++ b/tests/ui/arch/atomic_i_increment.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_i_increment::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output);
+    }
+}

--- a/tests/ui/arch/atomic_i_sub.rs
+++ b/tests/ui/arch/atomic_i_sub.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_i_sub::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_load.rs
+++ b/tests/ui/arch/atomic_load.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(output: Image<f32>) {
+    unsafe {
+        let output = spirv_std::arch::atomic_load::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory }
+        >(&*output);
+    }
+}

--- a/tests/ui/arch/atomic_or.rs
+++ b/tests/ui/arch/atomic_or.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_or::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_s_max.rs
+++ b/tests/ui/arch/atomic_s_max.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_s_max::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_s_min.rs
+++ b/tests/ui/arch/atomic_s_min.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_s_min::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_store.rs
+++ b/tests/ui/arch/atomic_store.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<f32>) {
+    unsafe {
+        spirv_std::arch::atomic_store::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory }
+        >(&mut *output, 5.0);
+    }
+}

--- a/tests/ui/arch/atomic_u_max.rs
+++ b/tests/ui/arch/atomic_u_max.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<u32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_u_min::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_u_min.rs
+++ b/tests/ui/arch/atomic_u_min.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<u32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_u_max::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}

--- a/tests/ui/arch/atomic_xor.rs
+++ b/tests/ui/arch/atomic_xor.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::{memory::{Scope, Semantics}, storage_class::Image};
+
+#[spirv(fragment)]
+pub fn main(mut output: Image<i32>) {
+    unsafe {
+        let old = spirv_std::arch::atomic_xor::<
+            _,
+            { Scope::CrossDevice },
+            { Semantics::ImageMemory },
+        >(&mut *output, 10);
+    }
+}


### PR DESCRIPTION
This PR adds nearly all of the SPIR-V atomic instructions, the only ones not implemented are the ones around atomic flags as we don't have a type for them at the moment.

Depends on #519 