### PR TITLE
compiletest: don't require `--` to pass our specific flags.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,4 +4,4 @@
 rustflags = "-C prefer-dynamic"
 
 [alias]
-compiletest = "run --release -p compiletests"
+compiletest = "run --release -p compiletests --"

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -25,15 +25,5 @@ normalised output, you can do this by passing a `--bless` flag to
 cargo compiletest -- --bless
 ``
 
-### Caching Tests
-
-`cargo compiletest` by default caches the build output for dependencies of test
-cases such as `spirv-std` and `glam`. If you need to compile from a fresh source
-you can pass the `--clean` flag to build from scratch.
-
-``
-cargo compiletest -- --clean
-``
-
 [`compiletest`]: https://github.com/laumann/compiletest-rs
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/tests/intro.html

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -21,9 +21,9 @@ You will occassionally need to "bless" the output from UI tests to update the
 normalised output, you can do this by passing a `--bless` flag to
 `cargo compiletest`.
 
-``
-cargo compiletest -- --bless
-``
+```bash
+cargo compiletest --bless
+```
 
 [`compiletest`]: https://github.com/laumann/compiletest-rs
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/tests/intro.html


### PR DESCRIPTION
I found myself running `cargo compiletest -- --bless` a bunch, and IMO it looks better after this PR, which changes it to `cargo compiletest --bless`.

If someone needs to pass Cargo flags specifically, they can still manually run `cargo run -p compiletest`.

(Also there's a drive-by removal of some docs that weren't applicable by the time the compiletest PR landed)