### PR TITLE
Move min-const-generics features out of const-generics flag

### DIFF
--- a/crates/spirv-std-macros/src/lib.rs
+++ b/crates/spirv-std-macros/src/lib.rs
@@ -137,7 +137,7 @@ pub fn vectorized(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 fn create_vectored_fn(
     ItemFn {
-        mut attrs,
+        attrs,
         vis,
         mut sig,
         block,
@@ -147,13 +147,6 @@ fn create_vectored_fn(
     let trait_bound_name = Ident::new("VECTOR", Span::mixed_site());
     let const_bound_name = Ident::new("LENGTH", Span::mixed_site());
 
-    attrs.push(syn::Attribute {
-        pound_token: Default::default(),
-        style: syn::AttrStyle::Outer,
-        bracket_token: Default::default(),
-        path: Ident::new("cfg", Span::mixed_site()).into(),
-        tokens: quote::quote![(feature = "const-generics")],
-    });
     sig.ident = Ident::new(&format!("{}_vector", sig.ident), Span::mixed_site());
     sig.output = syn::ReturnType::Type(
         Default::default(),

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -3,15 +3,12 @@
 //! This module is intended as a low level abstraction over SPIR-V instructions.
 //! These functions will typically map to a single instruction, and will perform
 //! no additional safety checks beyond type-checking.
-#[cfg(feature = "const-generics")]
 use crate::{scalar::Scalar, vector::Vector};
 
-#[cfg(feature = "const-generics")]
 mod arithmetic;
 mod derivative;
 mod primitive;
 
-#[cfg(feature = "const-generics")]
 pub use arithmetic::*;
 pub use derivative::*;
 pub use primitive::*;
@@ -21,7 +18,6 @@ pub use primitive::*;
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAny")]
 #[inline]
-#[cfg(feature = "const-generics")]
 pub fn any<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
     let mut result = false;
 
@@ -55,7 +51,6 @@ pub fn any<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAll")]
 #[inline]
-#[cfg(feature = "const-generics")]
 pub fn all<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
     let mut result = false;
 
@@ -92,7 +87,6 @@ pub fn all<V: Vector<bool, N>, const N: usize>(vector: V) -> bool {
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpVectorExtractDynamic")]
 #[inline]
-#[cfg(feature = "const-generics")]
 pub unsafe fn vector_extract_dynamic<T: Scalar, const N: usize>(
     vector: impl Vector<T, N>,
     index: usize,
@@ -120,7 +114,6 @@ pub unsafe fn vector_extract_dynamic<T: Scalar, const N: usize>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpVectorInsertDynamic")]
 #[inline]
-#[cfg(feature = "const-generics")]
 pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
     vector: V,
     index: usize,

--- a/crates/spirv-std/src/arch/arithmetic.rs
+++ b/crates/spirv-std/src/arch/arithmetic.rs
@@ -2,7 +2,6 @@
 // but the compiler/clippy hasn't caught up to that style yet, so we just
 // disable the lint.
 #![allow(unused_unsafe)]
-#![cfg(feature = "const-generics")]
 
 use crate::{
     float::Float,

--- a/crates/spirv-std/src/arch/primitive.rs
+++ b/crates/spirv-std/src/arch/primitive.rs
@@ -40,7 +40,6 @@ pub unsafe fn end_primitive() {
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpEmitStreamVertex")]
 #[inline]
-#[cfg(feature = "const-generics")]
 pub unsafe fn emit_stream_vertex<const STREAM: i64>() {
     asm! {
         "%i64 = OpTypeInt 64 1",
@@ -61,7 +60,6 @@ pub unsafe fn emit_stream_vertex<const STREAM: i64>() {
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpEndStreamPrimitive")]
 #[inline]
-#[cfg(feature = "const-generics")]
 pub unsafe fn end_stream_primitive<const STREAM: i64>() {
     asm! {
         "%i64 = OpTypeInt 64 1",

--- a/crates/spirv-std/src/textures.rs
+++ b/crates/spirv-std/src/textures.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "const-generics")]
 use crate::{integer::Integer, vector::Vector};
 
 #[spirv(sampler)]
@@ -23,7 +22,6 @@ pub struct Image2d {
 
 impl Image2d {
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     pub fn sample<V: Vector<f32, 4>>(
         &self,
         sampler: Sampler,
@@ -47,7 +45,6 @@ impl Image2d {
         }
     }
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     /// Sample the image at a coordinate by a lod
     pub fn sample_by_lod<V: Vector<f32, 4>>(
         &self,
@@ -75,7 +72,6 @@ impl Image2d {
         result
     }
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     /// Sample the image based on a gradient formed by (dx, dy). Specifically, ([du/dx, dv/dx], [du/dy, dv/dy])
     pub fn sample_by_gradient<V: Vector<f32, 4>>(
         &self,
@@ -107,7 +103,6 @@ impl Image2d {
     }
     /// Fetch a single texel with a sampler set at compile time
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     pub fn fetch<V, I, const N: usize>(&self, coordinate: impl Vector<I, N>) -> V
     where
         V: Vector<f32, 4>,
@@ -147,7 +142,6 @@ pub struct StorageImage2d {
 impl StorageImage2d {
     /// Read a texel from an image without a sampler.
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     pub fn read<I, V, const N: usize>(&self, coordinate: impl Vector<I, 2>) -> V
     where
         I: Integer,
@@ -172,7 +166,6 @@ impl StorageImage2d {
 
     /// Write a texel to an image without a sampler.
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     pub unsafe fn write<I, const N: usize>(
         &self,
         coordinate: impl Vector<I, 2>,
@@ -208,7 +201,6 @@ pub struct Image2dArray {
 
 impl Image2dArray {
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     pub fn sample<V: Vector<f32, 4>>(
         &self,
         sampler: Sampler,
@@ -232,7 +224,6 @@ impl Image2dArray {
         }
     }
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     /// Sample the image at a coordinate by a lod
     pub fn sample_by_lod<V: Vector<f32, 4>>(
         &self,
@@ -260,7 +251,6 @@ impl Image2dArray {
         result
     }
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     /// Sample the image based on a gradient formed by (dx, dy). Specifically, ([du/dx, dv/dx], [du/dy, dv/dy])
     pub fn sample_by_gradient<V: Vector<f32, 4>>(
         &self,
@@ -308,7 +298,6 @@ pub struct Cubemap {
 
 impl Cubemap {
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     pub fn sample<V: Vector<f32, 4>>(
         &self,
         sampler: Sampler,
@@ -332,7 +321,6 @@ impl Cubemap {
         }
     }
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     /// Sample the image at a coordinate by a lod
     pub fn sample_by_lod<V: Vector<f32, 4>>(
         &self,
@@ -360,7 +348,6 @@ impl Cubemap {
         result
     }
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     /// Sample the image based on a gradient formed by (dx, dy). Specifically, ([du/dx, dv/dx], [du/dy, dv/dy])
     pub fn sample_by_gradient<V: Vector<f32, 4>>(
         &self,
@@ -400,7 +387,6 @@ pub struct SampledImage<I> {
 
 impl SampledImage<Image2d> {
     #[spirv_std_macros::gpu_only]
-    #[cfg(feature = "const-generics")]
     pub fn sample<V: Vector<f32, 4>>(&self, coordinate: impl Vector<f32, 2>) -> V {
         unsafe {
             let mut result = Default::default();

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -1,3 +1,2 @@
 /// Abstract trait representing a SPIR-V vector type.
-#[cfg(feature = "const-generics")]
 pub unsafe trait Vector<T: crate::scalar::Scalar, const N: usize>: Default {}


### PR DESCRIPTION
This removes all `const-generics` feature flags for API features which only use `min-const-generics` in preparation of Rust 1.51 releasing this week.