### PR TITLE
compiletest: allow specifying filters via `cargo compiletest ...`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ version = "0.0.0"
 dependencies = [
  "compiletest_rs",
  "rustc_codegen_spirv",
+ "structopt",
 ]
 
 [[package]]

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -25,5 +25,19 @@ normalised output, you can do this by passing a `--bless` flag to
 cargo compiletest --bless
 ```
 
+### Filtering Tests
+
+When working on tests, you may need to run `cargo compiletest` a few times,
+while changing only a small number of tests. You can avoid having to run all
+the other (unrelated) tests, by passing substrings of their paths, to
+`cargo compiletest`, for example:
+
+```bash
+cargo compiletest arch/u image
+```
+
+The above command will only test `ui/arch/u_*.rs` and `ui/image/*.rs`, and skip
+everything else. You can also add `--bless` to update expected outputs, as well.
+
 [`compiletest`]: https://github.com/laumann/compiletest-rs
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/tests/intro.html

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 [dependencies]
 compiletest = { version = "0.6.0", package = "compiletest_rs" }
 rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv" }
+structopt = "0.3.21"

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -10,12 +10,16 @@ use structopt::StructOpt;
     name = "cargo compiletest",
     no_version,
     // HACK(eddyb) avoid "USAGE:" saying "compiletests".
-    usage = "cargo compiletest [FLAGS]",
+    usage = "cargo compiletest [FLAGS] [FILTER]..."
 )]
 struct Opt {
     /// Automatically update stderr/stdout files
     #[structopt(long)]
     bless: bool,
+
+    /// Only run tests that match these filters
+    #[structopt(name = "FILTER")]
+    filters: Vec<String>,
 }
 
 const TARGET: &str = "spirv-unknown-unknown";
@@ -130,6 +134,7 @@ fn run_mode(
     config.src_base = tests_dir.join(mode);
     config.build_base = compiletest_build_dir;
     config.bless = opt.bless;
+    config.filters = opt.filters;
     config.clean_rmeta();
 
     compiletest::run_tests(&config);


### PR DESCRIPTION
See changed docs for example usage. Additionally, this is `cargo compiletest --help` after this PR:
```console
cargo compiletest 

USAGE:
    cargo compiletest [FLAGS] [FILTER]...

FLAGS:
        --bless      Automatically update stderr/stdout files
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <FILTER>...    Only run tests that match these filters
```