### PR TITLE
Add capability attribute

### DIFF
--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -5,8 +5,8 @@
 use crate::codegen_cx::CodegenCx;
 use crate::symbols::Symbols;
 use rspirv::spirv::{
-    AccessQualifier, BuiltIn, Dim, ExecutionMode, ExecutionModel, ImageFormat, StorageClass,
-    Capability
+    AccessQualifier, BuiltIn, Capability, Dim, ExecutionMode, ExecutionModel, ImageFormat,
+    StorageClass,
 };
 use rustc_ast::Attribute;
 use rustc_hir as hir;
@@ -198,7 +198,9 @@ impl AggregatedSpirvAttributes {
             StorageClass(value) => {
                 try_insert(&mut self.storage_class, value, span, "storage class")
             }
-            Capability(value) => try_insert(&mut self.capability, value, span, "#[spirv(capability)]"),
+            Capability(value) => {
+                try_insert(&mut self.capability, value, span, "#[spirv(capability)]")
+            }
             Builtin(value) => try_insert(&mut self.builtin, value, span, "builtin"),
             DescriptorSet(value) => try_insert(
                 &mut self.descriptor_set,
@@ -371,8 +373,10 @@ impl CheckSpirvAttrVisitor<'_> {
 
         match aggregated_attrs.capability {
             Some(spanned) if aggregated_attrs.entry.is_none() => {
-                self.tcx.sess.span_err(spanned.span, "`#[spirv(capability)]` can only be used with entry point functions.");
-
+                self.tcx.sess.span_err(
+                    spanned.span,
+                    "`#[spirv(capability)]` can only be used with entry point functions.",
+                );
             }
             _ => {}
         }

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -85,7 +85,7 @@ pub enum SpirvAttribute {
 
     // `fn` attributes:
     Entry(Entry),
-    Capabilities(Vec<Capability>),
+    Capability(Vec<Capability>),
 
     // (entry) `fn` parameter attributes:
     StorageClass(StorageClass),
@@ -117,7 +117,7 @@ pub struct AggregatedSpirvAttributes {
 
     // `fn` attributes:
     pub entry: Option<Spanned<Entry>>,
-    pub capabilities: Option<Spanned<Vec<Capability>>>,
+    pub capability: Option<Spanned<Vec<Capability>>>,
 
     // (entry) `fn` parameter attributes:
     pub storage_class: Option<Spanned<StorageClass>>,
@@ -198,7 +198,7 @@ impl AggregatedSpirvAttributes {
             StorageClass(value) => {
                 try_insert(&mut self.storage_class, value, span, "storage class")
             }
-            Capabilities(value) => try_insert(&mut self.capabilities, value, span, "#[spirv(capabilities)]"),
+            Capability(value) => try_insert(&mut self.capability, value, span, "#[spirv(capability)]"),
             Builtin(value) => try_insert(&mut self.builtin, value, span, "builtin"),
             DescriptorSet(value) => try_insert(
                 &mut self.descriptor_set,
@@ -273,7 +273,7 @@ impl CheckSpirvAttrVisitor<'_> {
                     _ => Err(Expected("struct")),
                 },
 
-                SpirvAttribute::Capabilities(_) | SpirvAttribute::Entry(_) => match target {
+                SpirvAttribute::Capability(_) | SpirvAttribute::Entry(_) => match target {
                     Target::Fn
                     | Target::Method(MethodKind::Trait { body: true })
                     | Target::Method(MethodKind::Inherent) => {
@@ -369,9 +369,9 @@ impl CheckSpirvAttrVisitor<'_> {
             }
         }
 
-        match aggregated_attrs.capabilities {
+        match aggregated_attrs.capability {
             Some(spanned) if aggregated_attrs.entry.is_none() => {
-                self.tcx.sess.span_err(spanned.span, "`#[spirv(capabilities)]` can only be used with entry point functions.");
+                self.tcx.sess.span_err(spanned.span, "`#[spirv(capability)]` can only be used with entry point functions.");
 
             }
             _ => {}

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -112,6 +112,13 @@ impl<'tcx> CodegenCx<'tcx> {
         let declared = fn_id.with_type(function_type);
 
         let attrs = AggregatedSpirvAttributes::parse(self, self.tcx.get_attrs(instance.def_id()));
+
+        let mut emit  = self.emit_global();
+        for capability in attrs.capabilities.map(|x| x.value).unwrap_or_default() {
+            emit.capability(capability);
+        }
+        drop(emit);
+
         if let Some(entry) = attrs.entry.map(|attr| attr.value) {
             let entry_name = entry
                 .name

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -113,7 +113,7 @@ impl<'tcx> CodegenCx<'tcx> {
 
         let attrs = AggregatedSpirvAttributes::parse(self, self.tcx.get_attrs(instance.def_id()));
 
-        let mut emit  = self.emit_global();
+        let mut emit = self.emit_global();
         for capability in attrs.capability.map(|x| x.value).unwrap_or_default() {
             emit.capability(capability);
         }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -114,7 +114,7 @@ impl<'tcx> CodegenCx<'tcx> {
         let attrs = AggregatedSpirvAttributes::parse(self, self.tcx.get_attrs(instance.def_id()));
 
         let mut emit  = self.emit_global();
-        for capability in attrs.capabilities.map(|x| x.value).unwrap_or_default() {
+        for capability in attrs.capability.map(|x| x.value).unwrap_or_default() {
             emit.capability(capability);
         }
         drop(emit);

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -603,15 +603,24 @@ fn parse_image_type(
 fn parse_capability_list(arg: &NestedMetaItem) -> Result<Vec<Capability>, ParseAttrError> {
     let list = match arg.meta_item_list() {
         Some(list) => list,
-        None => return Err((arg.span(), "`#[spirv(capability())]` requires a list.".to_string())),
+        None => {
+            return Err((
+                arg.span(),
+                "`#[spirv(capability())]` requires a list.".to_string(),
+            ))
+        }
     };
 
-    Ok(
-        list.iter()
-            .filter_map(NestedMetaItem::ident)
-            .filter_map(|i| CAPABILITIES.iter().find(|x| Symbol::intern(x.0) == i.name).map(|x| x.1))
-            .collect()
-    )
+    Ok(list
+        .iter()
+        .filter_map(NestedMetaItem::ident)
+        .filter_map(|i| {
+            CAPABILITIES
+                .iter()
+                .find(|x| Symbol::intern(x.0) == i.name)
+                .map(|x| x.1)
+        })
+        .collect())
 }
 
 const CAPABILITIES: &[(&str, Capability)] = {
@@ -644,10 +653,22 @@ const CAPABILITIES: &[(&str, Capability)] = {
         ("geometry_point_size", GeometryPointSize),
         ("image_gather_extended", ImageGatherExtended),
         ("storage_image_multisample", StorageImageMultisample),
-        ("uniform_buffer_array_dynamic_indexing", UniformBufferArrayDynamicIndexing),
-        ("sampled_image_array_dynamic_indexing", SampledImageArrayDynamicIndexing),
-        ("storage_buffer_array_dynamic_indexing", StorageBufferArrayDynamicIndexing),
-        ("storage_image_array_dynamic_indexing", StorageImageArrayDynamicIndexing),
+        (
+            "uniform_buffer_array_dynamic_indexing",
+            UniformBufferArrayDynamicIndexing,
+        ),
+        (
+            "sampled_image_array_dynamic_indexing",
+            SampledImageArrayDynamicIndexing,
+        ),
+        (
+            "storage_buffer_array_dynamic_indexing",
+            StorageBufferArrayDynamicIndexing,
+        ),
+        (
+            "storage_image_array_dynamic_indexing",
+            StorageImageArrayDynamicIndexing,
+        ),
         ("clip_distance", ClipDistance),
         ("cull_distance", CullDistance),
         ("image_cube_array", ImageCubeArray),
@@ -665,14 +686,23 @@ const CAPABILITIES: &[(&str, Capability)] = {
         ("sampled_buffer", SampledBuffer),
         ("image_buffer", ImageBuffer),
         ("image_ms_array", ImageMSArray),
-        ("storage_image_extended_formats", StorageImageExtendedFormats),
+        (
+            "storage_image_extended_formats",
+            StorageImageExtendedFormats,
+        ),
         ("image_query", ImageQuery),
         ("derivative_control", DerivativeControl),
         ("interpolation_function", InterpolationFunction),
         ("transform_feedback", TransformFeedback),
         ("geometry_streams", GeometryStreams),
-        ("storage_image_read_without_format", StorageImageReadWithoutFormat),
-        ("storage_image_write_without_format", StorageImageWriteWithoutFormat),
+        (
+            "storage_image_read_without_format",
+            StorageImageReadWithoutFormat,
+        ),
+        (
+            "storage_image_write_without_format",
+            StorageImageWriteWithoutFormat,
+        ),
         ("multi_viewport", MultiViewport),
         ("subgroup_dispatch", SubgroupDispatch),
         ("named_barrier", NamedBarrier),
@@ -682,7 +712,10 @@ const CAPABILITIES: &[(&str, Capability)] = {
         ("group_non_uniform_arithmetic", GroupNonUniformArithmetic),
         ("group_non_uniform_ballot", GroupNonUniformBallot),
         ("group_non_uniform_shuffle", GroupNonUniformShuffle),
-        ("group_non_uniform_shuffleRelative", GroupNonUniformShuffleRelative),
+        (
+            "group_non_uniform_shuffleRelative",
+            GroupNonUniformShuffleRelative,
+        ),
         ("group_non_uniform_clustered", GroupNonUniformClustered),
         ("group_non_uniform_quad", GroupNonUniformQuad),
         ("shader_layer", ShaderLayer),
@@ -691,17 +724,29 @@ const CAPABILITIES: &[(&str, Capability)] = {
         ("draw_parameters", DrawParameters),
         ("subgroup_vote_khr", SubgroupVoteKHR),
         ("storage_buffer_16bit_access", StorageBuffer16BitAccess),
-        ("uniform_and_storage_buffer_16bit_access", UniformAndStorageBuffer16BitAccess),
+        (
+            "uniform_and_storage_buffer_16bit_access",
+            UniformAndStorageBuffer16BitAccess,
+        ),
         ("storage_push_constant16", StoragePushConstant16),
         ("storage_input_output16", StorageInputOutput16),
         ("device_group", DeviceGroup),
         ("multi_view", MultiView),
-        ("variable_pointers_storage_buffer", VariablePointersStorageBuffer),
+        (
+            "variable_pointers_storage_buffer",
+            VariablePointersStorageBuffer,
+        ),
         ("variable_pointers", VariablePointers),
         ("atomic_storage_ops", AtomicStorageOps),
-        ("sample_mask_post_depth_coverage", SampleMaskPostDepthCoverage),
+        (
+            "sample_mask_post_depth_coverage",
+            SampleMaskPostDepthCoverage,
+        ),
         ("storage_buffer_8bit_access", StorageBuffer8BitAccess),
-        ("uniform_and_storage_buffer_8bit_access", UniformAndStorageBuffer8BitAccess),
+        (
+            "uniform_and_storage_buffer_8bit_access",
+            UniformAndStorageBuffer8BitAccess,
+        ),
         ("storage_push_constant8", StoragePushConstant8),
         ("denorm_preserve", DenormPreserve),
         ("denorm_flush_to_zero", DenormFlushToZero),
@@ -715,9 +760,18 @@ const CAPABILITIES: &[(&str, Capability)] = {
         ("stencil_export_ext", StencilExportEXT),
         ("image_read_write_lod_amd", ImageReadWriteLodAMD),
         ("shader_clock_khr", ShaderClockKHR),
-        ("sample_mask_overridecoverage_nv", SampleMaskOverrideCoverageNV),
-        ("geometry_shader_passthrough_nv", GeometryShaderPassthroughNV),
-        ("shader_viewport_index_layer_ext", ShaderViewportIndexLayerEXT),
+        (
+            "sample_mask_overridecoverage_nv",
+            SampleMaskOverrideCoverageNV,
+        ),
+        (
+            "geometry_shader_passthrough_nv",
+            GeometryShaderPassthroughNV,
+        ),
+        (
+            "shader_viewport_index_layer_ext",
+            ShaderViewportIndexLayerEXT,
+        ),
         ("shader_viewport_mask_nv", ShaderViewportMaskNV),
         ("shader_stereo_view_nv", ShaderStereoViewNV),
         ("per_view_attributes_nv", PerViewAttributesNV),
@@ -725,25 +779,67 @@ const CAPABILITIES: &[(&str, Capability)] = {
         ("mesh_shading_nv", MeshShadingNV),
         ("image_footprint_nv", ImageFootprintNV),
         ("fragment_barycentric_nv", FragmentBarycentricNV),
-        ("compute_derivative_group_quads_nv", ComputeDerivativeGroupQuadsNV),
+        (
+            "compute_derivative_group_quads_nv",
+            ComputeDerivativeGroupQuadsNV,
+        ),
         ("fragment_density_ext", FragmentDensityEXT),
-        ("group_non_uniform_partitioned_nv", GroupNonUniformPartitionedNV),
+        (
+            "group_non_uniform_partitioned_nv",
+            GroupNonUniformPartitionedNV,
+        ),
         ("shader_non_uniform", ShaderNonUniform),
         ("runtime_descriptor_array", RuntimeDescriptorArray),
-        ("input_attachment_array_dynamic_indexing", InputAttachmentArrayDynamicIndexing),
-        ("uniform_texel_bufferarray_dynamic_indexing", UniformTexelBufferArrayDynamicIndexing),
-        ("storage_texel_buffer_array_dynamic_indexing", StorageTexelBufferArrayDynamicIndexing),
-        ("uniform_buffer_array_non_uniform_indexing", UniformBufferArrayNonUniformIndexing),
-        ("sampled_image_array_non_uniform_indexing", SampledImageArrayNonUniformIndexing),
-        ("storage_buffer_array_non_uniform_indexing", StorageBufferArrayNonUniformIndexing),
-        ("storage_image_array_non_uniform_indexing", StorageImageArrayNonUniformIndexing),
-        ("input_attachment_array_non_uniform_indexing", InputAttachmentArrayNonUniformIndexing),
-        ("uniform_texel_buffer_array_non_uniform_indexing", UniformTexelBufferArrayNonUniformIndexing),
-        ("storage_texel_buffer_array_non_uniform_indexing", StorageTexelBufferArrayNonUniformIndexing),
+        (
+            "input_attachment_array_dynamic_indexing",
+            InputAttachmentArrayDynamicIndexing,
+        ),
+        (
+            "uniform_texel_bufferarray_dynamic_indexing",
+            UniformTexelBufferArrayDynamicIndexing,
+        ),
+        (
+            "storage_texel_buffer_array_dynamic_indexing",
+            StorageTexelBufferArrayDynamicIndexing,
+        ),
+        (
+            "uniform_buffer_array_non_uniform_indexing",
+            UniformBufferArrayNonUniformIndexing,
+        ),
+        (
+            "sampled_image_array_non_uniform_indexing",
+            SampledImageArrayNonUniformIndexing,
+        ),
+        (
+            "storage_buffer_array_non_uniform_indexing",
+            StorageBufferArrayNonUniformIndexing,
+        ),
+        (
+            "storage_image_array_non_uniform_indexing",
+            StorageImageArrayNonUniformIndexing,
+        ),
+        (
+            "input_attachment_array_non_uniform_indexing",
+            InputAttachmentArrayNonUniformIndexing,
+        ),
+        (
+            "uniform_texel_buffer_array_non_uniform_indexing",
+            UniformTexelBufferArrayNonUniformIndexing,
+        ),
+        (
+            "storage_texel_buffer_array_non_uniform_indexing",
+            StorageTexelBufferArrayNonUniformIndexing,
+        ),
         ("ray_tracing_nv", RayTracingNV),
         ("vulkan_memory_model", VulkanMemoryModel),
-        ("vulkan_memory_model_device_scope", VulkanMemoryModelDeviceScope),
-        ("physical_storage_buffer_addresses", PhysicalStorageBufferAddresses),
+        (
+            "vulkan_memory_model_device_scope",
+            VulkanMemoryModelDeviceScope,
+        ),
+        (
+            "physical_storage_buffer_addresses",
+            PhysicalStorageBufferAddresses,
+        ),
     ]
 };
 

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -31,7 +31,7 @@ pub struct Symbols {
     pub spirv14: Symbol,
     pub spirv15: Symbol,
     pub entry_point_name: Symbol,
-    capabilities: Symbol,
+    capability: Symbol,
     descriptor_set: Symbol,
     binding: Symbol,
     image_type: Symbol,
@@ -386,7 +386,7 @@ impl Symbols {
             spirv13: Symbol::intern("spirv1.3"),
             spirv14: Symbol::intern("spirv1.4"),
             spirv15: Symbol::intern("spirv1.5"),
-            capabilities: Symbol::intern("capabilities"),
+            capability: Symbol::intern("capability"),
             descriptor_set: Symbol::intern("descriptor_set"),
             binding: Symbol::intern("binding"),
             image_type: Symbol::intern("image_type"),
@@ -460,8 +460,8 @@ pub(crate) fn parse_attrs_for_checking<'a>(
                     SpirvAttribute::DescriptorSet(parse_attr_int_value(arg)?)
                 } else if arg.has_name(sym.binding) {
                     SpirvAttribute::Binding(parse_attr_int_value(arg)?)
-                } else if arg.has_name(sym.capabilities) {
-                    SpirvAttribute::Capabilities(parse_capability_list(arg)?)
+                } else if arg.has_name(sym.capability) {
+                    SpirvAttribute::Capability(parse_capability_list(arg)?)
                 } else {
                     let name = match arg.ident() {
                         Some(i) => i,
@@ -603,7 +603,7 @@ fn parse_image_type(
 fn parse_capability_list(arg: &NestedMetaItem) -> Result<Vec<Capability>, ParseAttrError> {
     let list = match arg.meta_item_list() {
         Some(list) => list,
-        None => return Err((arg.span(), "`#[spirv(capabilities())]` requires a list.".to_string())),
+        None => return Err((arg.span(), "`#[spirv(capability())]` requires a list.".to_string())),
     };
 
     Ok(

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -44,7 +44,7 @@ fn capability_attribute() {
     dis_globals(
         r#"
 #[spirv(fragment)]
-#[spirv(capabilities(multi_view))]
+#[spirv(capability(multi_view))]
 pub fn main() { }
 "#,
         r#"OpCapability Shader

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -40,6 +40,28 @@ OpName %2 "test_project::main"
 }
 
 #[test]
+fn capability_attribute() {
+    dis_globals(
+        r#"
+#[spirv(fragment)]
+#[spirv(capabilities(multi_view))]
+pub fn main() { }
+"#,
+        r#"OpCapability Shader
+OpCapability VulkanMemoryModel
+OpCapability VariablePointers
+OpCapability MultiView
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+OpName %2 "test_project::main"
+%3 = OpTypeVoid
+%4 = OpTypeFunction %3"#,
+    );
+}
+
+#[test]
 // blocked on: https://github.com/EmbarkStudios/rust-gpu/issues/69
 #[ignore]
 fn no_dce() {

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -86,6 +86,18 @@ struct Thing {
 fn main(#[spirv(push_constant)] obj: &ShaderConstants) { }
 ```
 
+## Capabilities
+
+The `#[spirv(capability)]` attribute allows you to specify what SPIR-V capabilities your module requires on your entry point function. `#[spirv(capability)]` accepts one or more camel-case identifiers of the [SPIR-V Capabilities].
+
+```
+#[spirv(fragment)]
+#[spirv(capability(multi_view))] // Enables `OpCapability MultiView`
+fn main () {}
+```
+
+[spir-v capabilities]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#Capability
+
 ## Flat
 
 The flat attribute corresponds to the flat keyword in glsl - in other words, the data is not interpolated across the triangle when invoking the fragment shader.

--- a/tests/ui/spirv-attr/capabilities/no_items.rs
+++ b/tests/ui/spirv-attr/capabilities/no_items.rs
@@ -1,7 +1,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-#[spirv(capabilities)]
-//~^ ERROR `#[spirv(capabilities())]` requires a list.
+#[spirv(capability)]
+//~^ ERROR `#[spirv(capability())]` requires a list.
 pub fn main() { }
 

--- a/tests/ui/spirv-attr/capabilities/no_items.rs
+++ b/tests/ui/spirv-attr/capabilities/no_items.rs
@@ -1,0 +1,7 @@
+use spirv_std as _;
+
+#[spirv(fragment)]
+#[spirv(capabilities)]
+//~^ ERROR `#[spirv(capabilities())]` requires a list.
+pub fn main() { }
+

--- a/tests/ui/spirv-attr/capabilities/no_items.stderr
+++ b/tests/ui/spirv-attr/capabilities/no_items.stderr
@@ -1,0 +1,8 @@
+error: `#[spirv(capabilities())]` requires a list.
+ --> $DIR/no_items.rs:4:9
+  |
+4 | #[spirv(capabilities)]
+  |         ^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/spirv-attr/capabilities/no_items.stderr
+++ b/tests/ui/spirv-attr/capabilities/no_items.stderr
@@ -1,8 +1,8 @@
-error: `#[spirv(capabilities())]` requires a list.
+error: `#[spirv(capability())]` requires a list.
  --> $DIR/no_items.rs:4:9
   |
-4 | #[spirv(capabilities)]
-  |         ^^^^^^^^^^^^
+4 | #[spirv(capability)]
+  |         ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/spirv-attr/capabilities/not_entry_point.rs
+++ b/tests/ui/spirv-attr/capabilities/not_entry_point.rs
@@ -1,0 +1,9 @@
+use spirv_std as _;
+
+#[spirv(capabilities(multi_view))]
+//~^ ERROR `#[spirv(capabilities)]` can only be used with entry point functions.
+pub fn main() { }
+
+#[spirv(fragment)]
+pub fn real_main() { }
+

--- a/tests/ui/spirv-attr/capabilities/not_entry_point.rs
+++ b/tests/ui/spirv-attr/capabilities/not_entry_point.rs
@@ -1,7 +1,7 @@
 use spirv_std as _;
 
-#[spirv(capabilities(multi_view))]
-//~^ ERROR `#[spirv(capabilities)]` can only be used with entry point functions.
+#[spirv(capability(multi_view))]
+//~^ ERROR `#[spirv(capability)]` can only be used with entry point functions.
 pub fn main() { }
 
 #[spirv(fragment)]

--- a/tests/ui/spirv-attr/capabilities/not_entry_point.stderr
+++ b/tests/ui/spirv-attr/capabilities/not_entry_point.stderr
@@ -1,0 +1,8 @@
+error: `#[spirv(capabilities)]` can only be used with entry point functions.
+ --> $DIR/not_entry_point.rs:3:9
+  |
+3 | #[spirv(capabilities(multi_view))]
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/spirv-attr/capabilities/not_entry_point.stderr
+++ b/tests/ui/spirv-attr/capabilities/not_entry_point.stderr
@@ -1,8 +1,8 @@
-error: `#[spirv(capabilities)]` can only be used with entry point functions.
+error: `#[spirv(capability)]` can only be used with entry point functions.
  --> $DIR/not_entry_point.rs:3:9
   |
-3 | #[spirv(capabilities(multi_view))]
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^
+3 | #[spirv(capability(multi_view))]
+  |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR adds the `#[spirv(capabilities)]` attribute, which accepts a list of capabilities on an entrypoint function and emits those capabilities.


### To Do

- [x] Documentation
- [x] Ensure you can only use `#[spirv(capabilities)]` with entry point functions.