### PR TITLE
Use Embark standard lints v0.3 (redux)

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -143,9 +143,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     fn ordering_to_semantics_def(&self, ordering: AtomicOrdering) -> SpirvValue {
         let mut invalid_seq_cst = false;
         let semantics = match ordering {
-            AtomicOrdering::NotAtomic => MemorySemantics::NONE,
-            AtomicOrdering::Unordered => MemorySemantics::NONE,
-            AtomicOrdering::Monotonic => MemorySemantics::NONE,
+            AtomicOrdering::NotAtomic | AtomicOrdering::Unordered | AtomicOrdering::Monotonic => {
+                MemorySemantics::NONE
+            }
             // Note: rustc currently has AtomicOrdering::Consume commented out, if it ever becomes
             // uncommented, it should be MakeVisible | Acquire.
             AtomicOrdering::Acquire => MemorySemantics::MAKE_VISIBLE | MemorySemantics::ACQUIRE,

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -356,9 +356,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
         let out_register = if match first_token {
             Token::Placeholder(_, _) => true,
             Token::Word(id_str) if id_str.starts_with('%') => true,
-            Token::Word(_) => false,
-            Token::String(_) => false,
-            Token::Typeof(_, _, _) => false,
+            Token::Word(_) | Token::String(_) | Token::Typeof(_, _, _) => false,
         } {
             let result_id = match self.parse_id_out(id_map, defined_ids, first_token) {
                 Some(result_id) => result_id,
@@ -921,9 +919,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
         };
         let word = match token {
             Token::Word(word) => Some(word),
-            Token::String(_) => None,
-            Token::Placeholder(_, _) => None,
-            Token::Typeof(_, _, _) => None,
+            Token::String(_) | Token::Placeholder(_, _) | Token::Typeof(_, _, _) => None,
         };
         match (kind, word) {
             (OperandKind::IdResultType, _) | (OperandKind::IdResult, _) => {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -21,8 +21,7 @@ fn attrs_to_spirv(attrs: &CodegenFnAttrs) -> FunctionControl {
     let mut control = FunctionControl::NONE;
     match attrs.inline {
         InlineAttr::None => (),
-        InlineAttr::Hint => control.insert(FunctionControl::INLINE),
-        InlineAttr::Always => control.insert(FunctionControl::INLINE),
+        InlineAttr::Hint | InlineAttr::Always => control.insert(FunctionControl::INLINE),
         InlineAttr::Never => control.insert(FunctionControl::DONT_INLINE),
     }
     if attrs.flags.contains(CodegenFnAttrFlags::FFI_PURE) {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -172,9 +172,11 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             SpirvType::Array { .. } | SpirvType::RuntimeArray { .. } => TypeKind::Array,
             SpirvType::Pointer { .. } => TypeKind::Pointer,
             SpirvType::Function { .. } => TypeKind::Function,
+            // HACK(eddyb) this is probably the closest `TypeKind` (which is still
+            // very much LLVM-specific, sadly) has to offer to "resource handle".
             SpirvType::Image { .. } |
             SpirvType::Sampler |
-            SpirvType::SampledImage { .. } => TypeKind::Integer,
+            SpirvType::SampledImage { .. } => TypeKind::Token,
         }
     }
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -167,15 +167,13 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
                     .sess
                     .fatal(&format!("Invalid float width in type_kind: {}", other)),
             },
-            SpirvType::Adt { .. } => TypeKind::Struct,
-            SpirvType::Opaque { .. } => TypeKind::Struct,
+            SpirvType::Adt { .. } | SpirvType::Opaque { .. } => TypeKind::Struct,
             SpirvType::Vector { .. } => TypeKind::Vector,
-            SpirvType::Array { .. } => TypeKind::Array,
-            SpirvType::RuntimeArray { .. } => TypeKind::Array,
+            SpirvType::Array { .. } | SpirvType::RuntimeArray { .. } => TypeKind::Array,
             SpirvType::Pointer { .. } => TypeKind::Pointer,
             SpirvType::Function { .. } => TypeKind::Function,
-            SpirvType::Image { .. } => TypeKind::Integer,
-            SpirvType::Sampler => TypeKind::Integer,
+            SpirvType::Image { .. } |
+            SpirvType::Sampler |
             SpirvType::SampledImage { .. } => TypeKind::Integer,
         }
     }

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -17,7 +17,7 @@
 //! [`spirv-tools-sys`]: https://embarkstudios.github.io/rust-gpu/api/spirv_tools_sys
 #![feature(rustc_private)]
 #![feature(once_cell)]
-// BEGIN - Embark standard lints v0.2.
+// BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -36,13 +36,16 @@
     clippy::if_let_mutex,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
+    clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
     clippy::lossy_float_literal,
     clippy::macro_use_imports,
+    clippy::map_err_ignore,
     clippy::map_flatten,
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
+    clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,
@@ -52,9 +55,12 @@
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
+    clippy::string_add_assign,
+    clippy::string_add,
     clippy::string_to_string,
     clippy::suboptimal_flops,
     clippy::todo,
+    clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::verbose_file_reads,
@@ -62,7 +68,7 @@
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.2
+// END - Embark standard lints v0.3
 // crate-specific exceptions:
 #![allow(
     unsafe_code,                // still quite a bit of unsafe

--- a/crates/rustc_codegen_spirv/src/linker/specializer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/specializer.rs
@@ -1665,6 +1665,7 @@ impl<'a, S: Specialization> InferCx<'a, S> {
             return Ok(a);
         }
 
+        #[allow(clippy::match_same_arms)]
         Ok(match (a.clone(), b.clone()) {
             // Instances of "generic" globals/functions must be of the same ID,
             // and their `generic_args` inference variables must be unified.

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -84,7 +84,7 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, String> {
         make_codegen_backend: None,
         registry: Registry::new(&[]),
     };
-    let res = rustc_interface::interface::run_compiler(config, |compiler| {
+    rustc_interface::interface::run_compiler(config, |compiler| {
         let res = link(
             compiler.session(),
             modules,
@@ -99,8 +99,8 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, String> {
         );
         assert_eq!(compiler.session().has_errors(), res.is_err());
         res
-    });
-    res.map_err(|_| thread.join().unwrap())
+    })
+    .map_err(|_e| thread.join().unwrap())
 }
 
 fn without_header_eq(mut result: Module, expected: &str) {

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -312,8 +312,7 @@ impl SpirvType {
             | Self::Function { .. } => return None,
 
             Self::Bool => Size::from_bytes(1),
-            Self::Integer(width, _) => Size::from_bits(width),
-            Self::Float(width) => Size::from_bits(width),
+            Self::Integer(width, _) | Self::Float(width) => Size::from_bits(width),
             Self::Adt { size, .. } => size?,
             Self::Vector { element, count } => {
                 cx.lookup_type(element).sizeof(cx)? * count.next_power_of_two() as u64
@@ -322,9 +321,7 @@ impl SpirvType {
                 cx.lookup_type(element).sizeof(cx)? * cx.builder.lookup_const_u64(count).unwrap()
             }
             Self::Pointer { .. } => cx.tcx.data_layout.pointer_size,
-            Self::Image { .. } => Size::from_bytes(4),
-            Self::Sampler => Size::from_bytes(4),
-            Self::SampledImage { .. } => Size::from_bytes(4),
+            Self::Image { .. } | Self::Sampler | Self::SampledImage { .. } => Size::from_bytes(4),
         };
         Some(result)
     }
@@ -337,8 +334,7 @@ impl SpirvType {
             }
 
             Self::Bool => Align::from_bytes(1).unwrap(),
-            Self::Integer(width, _) => Align::from_bits(width as u64).unwrap(),
-            Self::Float(width) => Align::from_bits(width as u64).unwrap(),
+            Self::Integer(width, _) | Self::Float(width) => Align::from_bits(width as u64).unwrap(),
             Self::Adt { align, .. } => align,
             // Vectors have size==align
             Self::Vector { .. } => Align::from_bytes(
@@ -347,12 +343,13 @@ impl SpirvType {
                     .bytes(),
             )
             .expect("alignof: Vectors must have power-of-2 size"),
-            Self::Array { element, .. } => cx.lookup_type(element).alignof(cx),
-            Self::RuntimeArray { element } => cx.lookup_type(element).alignof(cx),
+            Self::Array { element, .. } | Self::RuntimeArray { element } => {
+                cx.lookup_type(element).alignof(cx)
+            }
             Self::Pointer { .. } => cx.tcx.data_layout.pointer_align.abi,
-            Self::Image { .. } => Align::from_bytes(4).unwrap(),
-            Self::Sampler => Align::from_bytes(4).unwrap(),
-            Self::SampledImage { .. } => Align::from_bytes(4).unwrap(),
+            Self::Image { .. } | Self::Sampler | Self::SampledImage { .. } => {
+                Align::from_bytes(4).unwrap()
+            }
         }
     }
 }

--- a/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
@@ -238,6 +238,7 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         };
     }
 
+    #[allow(clippy::match_same_arms)]
     match op {
         // 3.37.1. Miscellaneous Instructions
         Op::Nop | Op::Undef => {}

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -1,4 +1,4 @@
-// BEGIN - Embark standard lints v0.2.
+// BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -17,13 +17,16 @@
     clippy::if_let_mutex,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
+    clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
     clippy::lossy_float_literal,
     clippy::macro_use_imports,
+    clippy::map_err_ignore,
     clippy::map_flatten,
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
+    clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,
@@ -33,9 +36,12 @@
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
+    clippy::string_add_assign,
+    clippy::string_add,
     clippy::string_to_string,
     clippy::suboptimal_flops,
     clippy::todo,
+    clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::verbose_file_reads,
@@ -43,7 +49,7 @@
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.2
+// END - Embark standard lints v0.3
 // crate-specific exceptions:
 #![allow()]
 

--- a/crates/spirv-std-macros/src/lib.rs
+++ b/crates/spirv-std-macros/src/lib.rs
@@ -1,4 +1,4 @@
-// BEGIN - Embark standard lints v0.2.
+// BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -17,13 +17,16 @@
     clippy::if_let_mutex,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
+    clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
     clippy::lossy_float_literal,
     clippy::macro_use_imports,
+    clippy::map_err_ignore,
     clippy::map_flatten,
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
+    clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,
@@ -33,9 +36,12 @@
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
+    clippy::string_add_assign,
+    clippy::string_add,
     clippy::string_to_string,
     clippy::suboptimal_flops,
     clippy::todo,
+    clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::verbose_file_reads,
@@ -43,7 +49,7 @@
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.2
+// END - Embark standard lints v0.3
 // crate-specific exceptions:
 #![allow()]
 


### PR DESCRIPTION
This is a re-land of #482, most of which (other than the `spirv-std` changes) got lost after a rebase.