### PR TITLE
Add #[spirv(invariant)]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,8 @@ jobs:
         run: cargo fetch --locked
       - name: Rustfmt
         run: cargo fmt --all -- --check
+      - name: Rustfmt tests
+        run: rustfmt --check tests/ui/**/*.rs
       - name: Clippy
         run: .github/workflows/clippy.sh
 

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -91,6 +91,7 @@ pub enum SpirvAttribute {
     DescriptorSet(u32),
     Binding(u32),
     Flat,
+    Invariant,
 
     // `fn`/closure attributes:
     UnrollLoops,
@@ -122,6 +123,7 @@ pub struct AggregatedSpirvAttributes {
     pub descriptor_set: Option<Spanned<u32>>,
     pub binding: Option<Spanned<u32>>,
     pub flat: Option<Spanned<()>>,
+    pub invariant: Option<Spanned<()>>,
 
     // `fn`/closure attributes:
     pub unroll_loops: Option<Spanned<()>>,
@@ -204,6 +206,7 @@ impl AggregatedSpirvAttributes {
             ),
             Binding(value) => try_insert(&mut self.binding, value, span, "#[spirv(binding)]"),
             Flat => try_insert(&mut self.flat, (), span, "#[spirv(flat)]"),
+            Invariant => try_insert(&mut self.invariant, (), span, "#[spirv(invariant)]"),
             UnrollLoops => try_insert(&mut self.unroll_loops, (), span, "#[spirv(unroll_loops)]"),
         }
     }
@@ -285,7 +288,8 @@ impl CheckSpirvAttrVisitor<'_> {
                 | SpirvAttribute::Builtin(_)
                 | SpirvAttribute::DescriptorSet(_)
                 | SpirvAttribute::Binding(_)
-                | SpirvAttribute::Flat => match target {
+                | SpirvAttribute::Flat
+                | SpirvAttribute::Invariant => match target {
                     Target::Param => {
                         let parent_hir_id = self.tcx.hir().get_parent_node(hir_id);
                         let parent_is_entry_point =

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -261,6 +261,16 @@ impl<'tcx> CodegenCx<'tcx> {
             self.emit_global()
                 .decorate(variable, Decoration::Flat, std::iter::empty());
         }
+        if let Some(invariant) = attrs.invariant {
+            self.emit_global()
+                .decorate(variable, Decoration::Invariant, std::iter::empty());
+            if storage_class != StorageClass::Output {
+                self.tcx.sess.span_err(
+                    invariant.span,
+                    "#[spirv(invariant)] is only valid on Output variables",
+                );
+            }
+        }
 
         // FIXME(eddyb) check whether the storage class is compatible with the
         // specific shader stage of this entry-point, and any decorations

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -336,6 +336,7 @@ impl Symbols {
             ),
             ("block", SpirvAttribute::Block),
             ("flat", SpirvAttribute::Flat),
+            ("invariant", SpirvAttribute::Invariant),
             (
                 "sampled_image",
                 SpirvAttribute::IntrinsicType(IntrinsicType::SampledImage),

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -94,5 +94,16 @@ Example:
 
 ```rust
 #[spirv(fragment)]
-fn main(#[spirv(flat)] obj: &u32) { }
+fn main(#[spirv(flat)] obj: u32) { }
+```
+
+## Invariant
+
+The invariant attribute corresponds to the invariant keyword in glsl. It can only be applied to output variables.
+
+Example:
+
+```rust
+#[spirv(vertex)]
+fn main(#[spirv(invariant)] var: &mut f32) { }
 ```

--- a/tests/ui/hello_world.rs
+++ b/tests/ui/hello_world.rs
@@ -4,5 +4,4 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main() {
-}
+pub fn main() {}

--- a/tests/ui/lang/control_flow/for_range.rs
+++ b/tests/ui/lang/control_flow/for_range.rs
@@ -4,6 +4,5 @@ use spirv_std as _;
 
 #[spirv(fragment)]
 pub fn main(i: i32) {
-    for _ in 0..i {
-    }
+    for _ in 0..i {}
 }

--- a/tests/ui/lang/control_flow/for_with_custom_range_iter.rs
+++ b/tests/ui/lang/control_flow/for_with_custom_range_iter.rs
@@ -6,8 +6,8 @@
 
 // build-pass
 
-use spirv_std::num_traits::Num;
 use core::ops::Range;
+use spirv_std::num_traits::Num;
 
 struct RangeIter<T>(Range<T>);
 
@@ -26,7 +26,5 @@ impl<T: Num + Ord + Copy> Iterator for RangeIter<T> {
 
 #[spirv(fragment)]
 pub fn main(i: i32) {
-    for _ in RangeIter(0..i) {
-    }
+    for _ in RangeIter(0..i) {}
 }
-

--- a/tests/ui/lang/control_flow/if.rs
+++ b/tests/ui/lang/control_flow/if.rs
@@ -4,7 +4,5 @@ use spirv_std as _;
 
 #[spirv(fragment)]
 pub fn main(i: i32) {
-    if i > 0 {
-
-    }
+    if i > 0 {}
 }

--- a/tests/ui/lang/control_flow/if_else.rs
+++ b/tests/ui/lang/control_flow/if_else.rs
@@ -5,8 +5,6 @@ use spirv_std as _;
 #[spirv(fragment)]
 pub fn main(i: i32) {
     if i > 0 {
-
     } else {
-
     }
 }

--- a/tests/ui/lang/control_flow/if_else_if_else.rs
+++ b/tests/ui/lang/control_flow/if_else_if_else.rs
@@ -5,10 +5,7 @@ use spirv_std as _;
 #[spirv(fragment)]
 pub fn main(i: i32) {
     if i > 0 {
-
     } else if i < 0 {
-
     } else {
-
     }
 }

--- a/tests/ui/lang/control_flow/if_if.rs
+++ b/tests/ui/lang/control_flow/if_if.rs
@@ -5,8 +5,6 @@ use spirv_std as _;
 #[spirv(fragment)]
 pub fn main(i: i32) {
     if i > 0 {
-        if i < 10 {
-
-        }
+        if i < 10 {}
     }
 }

--- a/tests/ui/lang/control_flow/if_while.rs
+++ b/tests/ui/lang/control_flow/if_while.rs
@@ -5,7 +5,6 @@ use spirv_std as _;
 #[spirv(fragment)]
 pub fn main(i: i32) {
     if i == 0 {
-        while i < 10 {
-        }
+        while i < 10 {}
     }
 }

--- a/tests/ui/lang/control_flow/ifx2.rs
+++ b/tests/ui/lang/control_flow/ifx2.rs
@@ -4,10 +4,6 @@ use spirv_std as _;
 
 #[spirv(fragment)]
 pub fn main(i: i32) {
-    if i > 0 {
-
-    }
-    if i > 1 {
-
-    }
+    if i > 0 {}
+    if i > 1 {}
 }

--- a/tests/ui/lang/control_flow/while.rs
+++ b/tests/ui/lang/control_flow/while.rs
@@ -4,6 +4,5 @@ use spirv_std as _;
 
 #[spirv(fragment)]
 pub fn main(i: i32) {
-    while i < 10 {
-    }
+    while i < 10 {}
 }

--- a/tests/ui/lang/control_flow/while_while.rs
+++ b/tests/ui/lang/control_flow/while_while.rs
@@ -5,7 +5,6 @@ use spirv_std as _;
 #[spirv(fragment)]
 pub fn main(i: i32) {
     while i < 20 {
-        while i < 10 {
-        }
+        while i < 10 {}
     }
 }

--- a/tests/ui/lang/core/mem/create_unitialized_memory.rs
+++ b/tests/ui/lang/core/mem/create_unitialized_memory.rs
@@ -8,7 +8,9 @@ const MAYBEI32: MaybeUninit<&i32> = MaybeUninit::<&i32>::uninit();
 
 pub fn create_uninit_and_write() {
     let mut maybei32 = MAYBEI32;
-    unsafe { maybei32.as_mut_ptr().write(&0); }
+    unsafe {
+        maybei32.as_mut_ptr().write(&0);
+    }
     let _maybei32 = unsafe { maybei32.assume_init() };
 }
 

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.rs
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.rs
@@ -8,7 +8,7 @@
 use spirv_std as _;
 
 use core::ptr::Unique;
-const POINTER: Unique<[u8;4]> = Unique::<[u8; 4]>::dangling();
+const POINTER: Unique<[u8; 4]> = Unique::<[u8; 4]>::dangling();
 
 #[spirv(fragment)]
 pub fn main() {

--- a/tests/ui/spirv-attr/invalid-storage-class.rs
+++ b/tests/ui/spirv-attr/invalid-storage-class.rs
@@ -9,4 +9,5 @@ fn _entry(
     #[spirv(private)] _: (),
     #[spirv(function)] _: (),
     #[spirv(generic)] _: (),
-) {}
+) {
+}

--- a/tests/ui/spirv-attr/invalid-target.rs
+++ b/tests/ui/spirv-attr/invalid-target.rs
@@ -3,7 +3,12 @@
 
 // build-fail
 
-#![feature(extern_types, min_type_alias_impl_trait, stmt_expr_attributes, trait_alias)]
+#![feature(
+    extern_types,
+    min_type_alias_impl_trait,
+    stmt_expr_attributes,
+    trait_alias
+)]
 
 // NOTE(eddyb) in the interest of keeping this test manageable, only one of
 // each of the following categories of `#[spirv(...)]` attributes is used:
@@ -135,7 +140,9 @@ type _TyAlias = ();
 )]
 type _OpaqueTy = impl Copy;
 
-fn _opaque_ty_definer() -> _OpaqueTy { () }
+fn _opaque_ty_definer() -> _OpaqueTy {
+    ()
+}
 
 #[spirv(
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
@@ -332,14 +339,13 @@ fn _fn(
     )]
     let _statement = ();
 
-    let _closure =
-        #[spirv(
+    let _closure = #[spirv(
             sampler, block, sampled_image, // struct-only (incl. `image_type`)
             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
             vertex, // fn-only
             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         )]
-        || {};
+    || {};
 
     (
         #[spirv(
@@ -371,24 +377,20 @@ fn _fn_with_generics<
         vertex, // fn-only
         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
-    )]
-    '_lifetime_param,
-
+    )] '_lifetime_param,
     #[spirv(
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
-    )]
-    _TyParam,
-
+    )] _TyParam,
     #[spirv(
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
-    )]
-    const _CONST_PARAM: usize
->() {}
+    )] const _CONST_PARAM: usize,
+>() {
+}

--- a/tests/ui/spirv-attr/invalid-target.rs
+++ b/tests/ui/spirv-attr/invalid-target.rs
@@ -29,18 +29,18 @@
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 macro_rules! _macro {
-    () => {}
+    () => {};
 }
 
 #[spirv(
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 extern crate spirv_std as _;
@@ -49,7 +49,7 @@ extern crate spirv_std as _;
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 use spirv_std as _;
@@ -58,7 +58,7 @@ use spirv_std as _;
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 mod _mod {}
@@ -67,7 +67,7 @@ mod _mod {}
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 extern "C" {
@@ -75,7 +75,7 @@ extern "C" {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     type _ForeignTy;
@@ -84,7 +84,7 @@ extern "C" {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     static _FOREIGN_STATIC: ();
@@ -93,7 +93,7 @@ extern "C" {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     fn _foreign_fn();
@@ -103,7 +103,7 @@ extern "C" {
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 static _STATIC: () = ();
@@ -112,7 +112,7 @@ static _STATIC: () = ();
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 const _CONST: () = ();
@@ -121,7 +121,7 @@ const _CONST: () = ();
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 type _TyAlias = ();
@@ -130,7 +130,7 @@ type _TyAlias = ();
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 type _OpaqueTy = impl Copy;
@@ -141,7 +141,7 @@ fn _opaque_ty_definer() -> _OpaqueTy { () }
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 enum _Enum {
@@ -149,7 +149,7 @@ enum _Enum {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     _Variant {
@@ -157,18 +157,18 @@ enum _Enum {
             sampler, block, sampled_image, // struct-only (incl. `image_type`)
             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
             vertex, // fn-only
-            uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+            uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
             unroll_loops, // fn/closure-only
         )]
-        _field: ()
-    }
+        _field: (),
+    },
 }
 
 #[spirv(
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 union _Union {
@@ -176,15 +176,15 @@ union _Union {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
-    _field: ()
+    _field: (),
 }
 
 #[spirv(
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 struct _Struct {
@@ -192,17 +192,17 @@ struct _Struct {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
-    _field: ()
+    _field: (),
 }
 
 #[spirv(
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 impl _Struct {
@@ -210,7 +210,7 @@ impl _Struct {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     const _INHERENT_ASSOC_CONST: () = ();
@@ -218,7 +218,7 @@ impl _Struct {
     #[spirv(
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     )]
     fn _inherent_method() {}
 }
@@ -227,7 +227,7 @@ impl _Struct {
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 trait _TraitAlias = Copy;
@@ -236,7 +236,7 @@ trait _TraitAlias = Copy;
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 trait _Trait {
@@ -244,7 +244,7 @@ trait _Trait {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     type _AssocTy;
@@ -253,7 +253,7 @@ trait _Trait {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     const _TRAIT_ASSOC_CONST: ();
@@ -262,7 +262,7 @@ trait _Trait {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     fn _trait_method();
@@ -270,7 +270,7 @@ trait _Trait {
     #[spirv(
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     )]
     fn _trait_method_with_default() {}
 }
@@ -279,7 +279,7 @@ trait _Trait {
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     vertex, // fn-only
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     unroll_loops, // fn/closure-only
 )]
 impl _Trait for () {
@@ -287,7 +287,7 @@ impl _Trait for () {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     type _AssocTy = ();
@@ -296,7 +296,7 @@ impl _Trait for () {
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     const _TRAIT_ASSOC_CONST: () = ();
@@ -304,7 +304,7 @@ impl _Trait for () {
     #[spirv(
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     )]
     fn _trait_method() {}
 }
@@ -312,7 +312,7 @@ impl _Trait for () {
 #[spirv(
     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
-    uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+    uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
 )]
 fn _fn(
     #[spirv(
@@ -321,13 +321,13 @@ fn _fn(
         vertex, // fn-only
         unroll_loops, // fn/closure-only
     )]
-    _entry_param: ()
+    _entry_param: (),
 ) {
     #[spirv(
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     let _statement = ();
@@ -337,7 +337,7 @@ fn _fn(
             sampler, block, sampled_image, // struct-only (incl. `image_type`)
             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
             vertex, // fn-only
-            uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+            uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         )]
         || {};
 
@@ -346,7 +346,7 @@ fn _fn(
             sampler, block, sampled_image, // struct-only (incl. `image_type`)
             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
             vertex, // fn-only
-            uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+            uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
             unroll_loops, // fn/closure-only
         )]
         (1, 2, 3) // expression
@@ -357,7 +357,7 @@ fn _fn(
             sampler, block, sampled_image, // struct-only (incl. `image_type`)
             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
             vertex, // fn-only
-            uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+            uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
             unroll_loops, // fn/closure-only
         )]
         _arm => {}
@@ -369,7 +369,7 @@ fn _fn_with_generics<
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     '_lifetime_param,
@@ -378,7 +378,7 @@ fn _fn_with_generics<
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     _TyParam,
@@ -387,7 +387,7 @@ fn _fn_with_generics<
         sampler, block, sampled_image, // struct-only (incl. `image_type`)
         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
         vertex, // fn-only
-        uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+        uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         unroll_loops, // fn/closure-only
     )]
     const _CONST_PARAM: usize

--- a/tests/ui/spirv-attr/invalid-target.stderr
+++ b/tests/ui/spirv-attr/invalid-target.stderr
@@ -1,2779 +1,2779 @@
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:369:9
+   --> $DIR/invalid-target.rs:375:9
     |
-369 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+375 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:369:18
+   --> $DIR/invalid-target.rs:375:18
     |
-369 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+375 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:369:25
+   --> $DIR/invalid-target.rs:375:25
     |
-369 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+375 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:370:9
+   --> $DIR/invalid-target.rs:376:9
     |
-370 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+376 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:371:9
+   --> $DIR/invalid-target.rs:377:9
     |
-371 |         vertex, // fn-only
+377 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:372:9
+   --> $DIR/invalid-target.rs:378:9
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+378 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:372:18
+   --> $DIR/invalid-target.rs:378:18
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+378 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:372:28
+   --> $DIR/invalid-target.rs:378:28
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+378 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:372:48
+   --> $DIR/invalid-target.rs:378:48
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+378 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:372:61
+   --> $DIR/invalid-target.rs:378:61
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+378 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:372:67
+   --> $DIR/invalid-target.rs:378:67
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+378 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:373:9
+   --> $DIR/invalid-target.rs:379:9
     |
-373 |         unroll_loops, // fn/closure-only
+379 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:378:9
+   --> $DIR/invalid-target.rs:382:9
     |
-378 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+382 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:378:18
+   --> $DIR/invalid-target.rs:382:18
     |
-378 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+382 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:378:25
+   --> $DIR/invalid-target.rs:382:25
     |
-378 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+382 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:379:9
+   --> $DIR/invalid-target.rs:383:9
     |
-379 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+383 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a type parameter
-   --> $DIR/invalid-target.rs:380:9
+   --> $DIR/invalid-target.rs:384:9
     |
-380 |         vertex, // fn-only
+384 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:381:9
+   --> $DIR/invalid-target.rs:385:9
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+385 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:381:18
+   --> $DIR/invalid-target.rs:385:18
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+385 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:381:28
+   --> $DIR/invalid-target.rs:385:28
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+385 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:381:48
+   --> $DIR/invalid-target.rs:385:48
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+385 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:381:61
+   --> $DIR/invalid-target.rs:385:61
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+385 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:381:67
+   --> $DIR/invalid-target.rs:385:67
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+385 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a type parameter
-   --> $DIR/invalid-target.rs:382:9
+   --> $DIR/invalid-target.rs:386:9
     |
-382 |         unroll_loops, // fn/closure-only
+386 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:387:9
+   --> $DIR/invalid-target.rs:389:9
     |
-387 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+389 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:387:18
+   --> $DIR/invalid-target.rs:389:18
     |
-387 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+389 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:387:25
+   --> $DIR/invalid-target.rs:389:25
     |
-387 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+389 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:388:9
+   --> $DIR/invalid-target.rs:390:9
     |
-388 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+390 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a const parameter
-   --> $DIR/invalid-target.rs:389:9
+   --> $DIR/invalid-target.rs:391:9
     |
-389 |         vertex, // fn-only
+391 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:390:9
+   --> $DIR/invalid-target.rs:392:9
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+392 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:390:18
+   --> $DIR/invalid-target.rs:392:18
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+392 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:390:28
+   --> $DIR/invalid-target.rs:392:28
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+392 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:390:48
+   --> $DIR/invalid-target.rs:392:48
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+392 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:390:61
+   --> $DIR/invalid-target.rs:392:61
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+392 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:390:67
+   --> $DIR/invalid-target.rs:392:67
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+392 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a const parameter
-   --> $DIR/invalid-target.rs:391:9
+   --> $DIR/invalid-target.rs:393:9
     |
-391 |         unroll_loops, // fn/closure-only
+393 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:40:5
+  --> $DIR/invalid-target.rs:45:5
    |
-40 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+45 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:40:14
+  --> $DIR/invalid-target.rs:45:14
    |
-40 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+45 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:40:21
+  --> $DIR/invalid-target.rs:45:21
    |
-40 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+45 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:41:5
+  --> $DIR/invalid-target.rs:46:5
    |
-41 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+46 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a extern crate
-  --> $DIR/invalid-target.rs:42:5
+  --> $DIR/invalid-target.rs:47:5
    |
-42 |     vertex, // fn-only
+47 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:43:5
+  --> $DIR/invalid-target.rs:48:5
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:43:14
+  --> $DIR/invalid-target.rs:48:14
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:43:24
+  --> $DIR/invalid-target.rs:48:24
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:43:44
+  --> $DIR/invalid-target.rs:48:44
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:43:57
+  --> $DIR/invalid-target.rs:48:57
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:43:63
+  --> $DIR/invalid-target.rs:48:63
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a extern crate
-  --> $DIR/invalid-target.rs:44:5
+  --> $DIR/invalid-target.rs:49:5
    |
-44 |     unroll_loops, // fn/closure-only
+49 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:49:5
+  --> $DIR/invalid-target.rs:54:5
    |
-49 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+54 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:49:14
+  --> $DIR/invalid-target.rs:54:14
    |
-49 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+54 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:49:21
+  --> $DIR/invalid-target.rs:54:21
    |
-49 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+54 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:50:5
+  --> $DIR/invalid-target.rs:55:5
    |
-50 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+55 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a use
-  --> $DIR/invalid-target.rs:51:5
+  --> $DIR/invalid-target.rs:56:5
    |
-51 |     vertex, // fn-only
+56 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:52:5
+  --> $DIR/invalid-target.rs:57:5
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+57 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:52:14
+  --> $DIR/invalid-target.rs:57:14
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+57 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:52:24
+  --> $DIR/invalid-target.rs:57:24
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+57 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:52:44
+  --> $DIR/invalid-target.rs:57:44
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+57 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:52:57
+  --> $DIR/invalid-target.rs:57:57
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+57 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:52:63
+  --> $DIR/invalid-target.rs:57:63
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+57 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a use
-  --> $DIR/invalid-target.rs:53:5
+  --> $DIR/invalid-target.rs:58:5
    |
-53 |     unroll_loops, // fn/closure-only
+58 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:58:5
+  --> $DIR/invalid-target.rs:63:5
    |
-58 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+63 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:58:14
+  --> $DIR/invalid-target.rs:63:14
    |
-58 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+63 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:58:21
+  --> $DIR/invalid-target.rs:63:21
    |
-58 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+63 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:59:5
+  --> $DIR/invalid-target.rs:64:5
    |
-59 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+64 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a module
-  --> $DIR/invalid-target.rs:60:5
+  --> $DIR/invalid-target.rs:65:5
    |
-60 |     vertex, // fn-only
+65 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:61:5
+  --> $DIR/invalid-target.rs:66:5
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+66 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:61:14
+  --> $DIR/invalid-target.rs:66:14
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+66 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:61:24
+  --> $DIR/invalid-target.rs:66:24
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+66 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:61:44
+  --> $DIR/invalid-target.rs:66:44
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+66 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:61:57
+  --> $DIR/invalid-target.rs:66:57
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+66 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:61:63
+  --> $DIR/invalid-target.rs:66:63
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+66 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a module
-  --> $DIR/invalid-target.rs:62:5
+  --> $DIR/invalid-target.rs:67:5
    |
-62 |     unroll_loops, // fn/closure-only
+67 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:67:5
+  --> $DIR/invalid-target.rs:72:5
    |
-67 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+72 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:67:14
+  --> $DIR/invalid-target.rs:72:14
    |
-67 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+72 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:67:21
+  --> $DIR/invalid-target.rs:72:21
    |
-67 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+72 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:68:5
+  --> $DIR/invalid-target.rs:73:5
    |
-68 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+73 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign module
-  --> $DIR/invalid-target.rs:69:5
+  --> $DIR/invalid-target.rs:74:5
    |
-69 |     vertex, // fn-only
+74 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:5
+  --> $DIR/invalid-target.rs:75:5
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+75 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:14
+  --> $DIR/invalid-target.rs:75:14
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+75 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:24
+  --> $DIR/invalid-target.rs:75:24
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+75 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:44
+  --> $DIR/invalid-target.rs:75:44
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+75 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:57
+  --> $DIR/invalid-target.rs:75:57
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+75 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:63
+  --> $DIR/invalid-target.rs:75:63
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+75 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign module
-  --> $DIR/invalid-target.rs:71:5
+  --> $DIR/invalid-target.rs:76:5
    |
-71 |     unroll_loops, // fn/closure-only
+76 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:103:5
+   --> $DIR/invalid-target.rs:108:5
     |
-103 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+108 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:103:14
+   --> $DIR/invalid-target.rs:108:14
     |
-103 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+108 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:103:21
+   --> $DIR/invalid-target.rs:108:21
     |
-103 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+108 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:104:5
+   --> $DIR/invalid-target.rs:109:5
     |
-104 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+109 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a static item
-   --> $DIR/invalid-target.rs:105:5
+   --> $DIR/invalid-target.rs:110:5
     |
-105 |     vertex, // fn-only
+110 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:106:5
+   --> $DIR/invalid-target.rs:111:5
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+111 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:106:14
+   --> $DIR/invalid-target.rs:111:14
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+111 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:106:24
+   --> $DIR/invalid-target.rs:111:24
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+111 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:106:44
+   --> $DIR/invalid-target.rs:111:44
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+111 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:106:57
+   --> $DIR/invalid-target.rs:111:57
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+111 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:106:63
+   --> $DIR/invalid-target.rs:111:63
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+111 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a static item
-   --> $DIR/invalid-target.rs:107:5
+   --> $DIR/invalid-target.rs:112:5
     |
-107 |     unroll_loops, // fn/closure-only
+112 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:112:5
+   --> $DIR/invalid-target.rs:117:5
     |
-112 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+117 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:112:14
+   --> $DIR/invalid-target.rs:117:14
     |
-112 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+117 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:112:21
+   --> $DIR/invalid-target.rs:117:21
     |
-112 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+117 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:113:5
+   --> $DIR/invalid-target.rs:118:5
     |
-113 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+118 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a constant item
-   --> $DIR/invalid-target.rs:114:5
+   --> $DIR/invalid-target.rs:119:5
     |
-114 |     vertex, // fn-only
+119 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:115:5
+   --> $DIR/invalid-target.rs:120:5
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:115:14
+   --> $DIR/invalid-target.rs:120:14
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:115:24
+   --> $DIR/invalid-target.rs:120:24
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:115:44
+   --> $DIR/invalid-target.rs:120:44
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:115:57
+   --> $DIR/invalid-target.rs:120:57
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:115:63
+   --> $DIR/invalid-target.rs:120:63
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a constant item
-   --> $DIR/invalid-target.rs:116:5
-    |
-116 |     unroll_loops, // fn/closure-only
-    |     ^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
    --> $DIR/invalid-target.rs:121:5
     |
-121 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
-    |     ^^^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:121:14
-    |
-121 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
-    |              ^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:121:21
-    |
-121 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
-    |                     ^^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:122:5
-    |
-122 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function, not on a type alias
-   --> $DIR/invalid-target.rs:123:5
-    |
-123 |     vertex, // fn-only
-    |     ^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:124:5
-    |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |     ^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:124:14
-    |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |              ^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:124:24
-    |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                        ^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:124:44
-    |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                            ^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:124:57
-    |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                         ^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:124:63
-    |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                               ^^^^^^^^^
-
-error: attribute is only valid on a function or closure, not on a type alias
-   --> $DIR/invalid-target.rs:125:5
-    |
-125 |     unroll_loops, // fn/closure-only
+121 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:126:5
+    |
+126 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+    |     ^^^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:126:14
+    |
+126 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+    |              ^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:126:21
+    |
+126 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+    |                     ^^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:127:5
+    |
+127 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function, not on a type alias
+   --> $DIR/invalid-target.rs:128:5
+    |
+128 |     vertex, // fn-only
+    |     ^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:129:5
+    |
+129 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |     ^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:129:14
+    |
+129 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |              ^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:129:24
+    |
+129 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                        ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:129:44
+    |
+129 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                            ^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:129:57
+    |
+129 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:129:63
+    |
+129 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
+
+error: attribute is only valid on a function or closure, not on a type alias
    --> $DIR/invalid-target.rs:130:5
     |
-130 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+130 |     unroll_loops, // fn/closure-only
+    |     ^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:135:5
+    |
+135 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:130:14
+   --> $DIR/invalid-target.rs:135:14
     |
-130 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+135 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:130:21
+   --> $DIR/invalid-target.rs:135:21
     |
-130 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+135 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:131:5
+   --> $DIR/invalid-target.rs:136:5
     |
-131 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+136 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a type alias
-   --> $DIR/invalid-target.rs:132:5
+   --> $DIR/invalid-target.rs:137:5
     |
-132 |     vertex, // fn-only
+137 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:133:5
+   --> $DIR/invalid-target.rs:138:5
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:133:14
+   --> $DIR/invalid-target.rs:138:14
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:133:24
+   --> $DIR/invalid-target.rs:138:24
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:133:44
+   --> $DIR/invalid-target.rs:138:44
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:133:57
+   --> $DIR/invalid-target.rs:138:57
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:133:63
+   --> $DIR/invalid-target.rs:138:63
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a type alias
-   --> $DIR/invalid-target.rs:134:5
+   --> $DIR/invalid-target.rs:139:5
     |
-134 |     unroll_loops, // fn/closure-only
+139 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:141:5
+   --> $DIR/invalid-target.rs:148:5
     |
-141 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+148 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:141:14
+   --> $DIR/invalid-target.rs:148:14
     |
-141 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+148 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:141:21
+   --> $DIR/invalid-target.rs:148:21
     |
-141 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+148 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:142:5
+   --> $DIR/invalid-target.rs:149:5
     |
-142 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+149 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a enum
-   --> $DIR/invalid-target.rs:143:5
+   --> $DIR/invalid-target.rs:150:5
     |
-143 |     vertex, // fn-only
+150 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:144:5
+   --> $DIR/invalid-target.rs:151:5
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+151 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:144:14
+   --> $DIR/invalid-target.rs:151:14
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+151 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:144:24
+   --> $DIR/invalid-target.rs:151:24
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+151 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:144:44
+   --> $DIR/invalid-target.rs:151:44
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+151 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:144:57
+   --> $DIR/invalid-target.rs:151:57
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+151 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:144:63
+   --> $DIR/invalid-target.rs:151:63
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+151 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a enum
-   --> $DIR/invalid-target.rs:145:5
+   --> $DIR/invalid-target.rs:152:5
     |
-145 |     unroll_loops, // fn/closure-only
+152 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:149:9
+   --> $DIR/invalid-target.rs:156:9
     |
-149 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+156 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:149:18
+   --> $DIR/invalid-target.rs:156:18
     |
-149 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+156 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:149:25
+   --> $DIR/invalid-target.rs:156:25
     |
-149 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+156 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:150:9
+   --> $DIR/invalid-target.rs:157:9
     |
-150 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+157 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a enum variant
-   --> $DIR/invalid-target.rs:151:9
+   --> $DIR/invalid-target.rs:158:9
     |
-151 |         vertex, // fn-only
+158 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:152:9
+   --> $DIR/invalid-target.rs:159:9
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+159 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:152:18
+   --> $DIR/invalid-target.rs:159:18
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+159 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:152:28
+   --> $DIR/invalid-target.rs:159:28
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+159 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:152:48
+   --> $DIR/invalid-target.rs:159:48
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+159 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:152:61
+   --> $DIR/invalid-target.rs:159:61
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+159 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:152:67
+   --> $DIR/invalid-target.rs:159:67
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+159 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a enum variant
-   --> $DIR/invalid-target.rs:153:9
+   --> $DIR/invalid-target.rs:160:9
     |
-153 |         unroll_loops, // fn/closure-only
+160 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:157:13
+   --> $DIR/invalid-target.rs:164:13
     |
-157 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+164 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:157:22
+   --> $DIR/invalid-target.rs:164:22
     |
-157 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+164 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:157:29
+   --> $DIR/invalid-target.rs:164:29
     |
-157 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+164 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:158:13
+   --> $DIR/invalid-target.rs:165:13
     |
-158 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+165 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct field
-   --> $DIR/invalid-target.rs:159:13
+   --> $DIR/invalid-target.rs:166:13
     |
-159 |             vertex, // fn-only
+166 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:160:13
+   --> $DIR/invalid-target.rs:167:13
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+167 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:160:22
+   --> $DIR/invalid-target.rs:167:22
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+167 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:160:32
+   --> $DIR/invalid-target.rs:167:32
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+167 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:160:52
+   --> $DIR/invalid-target.rs:167:52
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+167 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:160:65
+   --> $DIR/invalid-target.rs:167:65
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+167 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:160:71
+   --> $DIR/invalid-target.rs:167:71
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+167 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
-   --> $DIR/invalid-target.rs:161:13
+   --> $DIR/invalid-target.rs:168:13
     |
-161 |             unroll_loops, // fn/closure-only
+168 |             unroll_loops, // fn/closure-only
     |             ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:168:5
+   --> $DIR/invalid-target.rs:175:5
     |
-168 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+175 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:168:14
+   --> $DIR/invalid-target.rs:175:14
     |
-168 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+175 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:168:21
+   --> $DIR/invalid-target.rs:175:21
     |
-168 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+175 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:169:5
+   --> $DIR/invalid-target.rs:176:5
     |
-169 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+176 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a union
-   --> $DIR/invalid-target.rs:170:5
+   --> $DIR/invalid-target.rs:177:5
     |
-170 |     vertex, // fn-only
+177 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:171:5
+   --> $DIR/invalid-target.rs:178:5
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+178 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:171:14
+   --> $DIR/invalid-target.rs:178:14
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+178 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:171:24
+   --> $DIR/invalid-target.rs:178:24
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+178 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:171:44
+   --> $DIR/invalid-target.rs:178:44
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+178 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:171:57
+   --> $DIR/invalid-target.rs:178:57
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+178 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:171:63
+   --> $DIR/invalid-target.rs:178:63
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+178 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a union
-   --> $DIR/invalid-target.rs:172:5
+   --> $DIR/invalid-target.rs:179:5
     |
-172 |     unroll_loops, // fn/closure-only
+179 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:176:9
+   --> $DIR/invalid-target.rs:183:9
     |
-176 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+183 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:176:18
+   --> $DIR/invalid-target.rs:183:18
     |
-176 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+183 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:176:25
+   --> $DIR/invalid-target.rs:183:25
     |
-176 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+183 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:177:9
+   --> $DIR/invalid-target.rs:184:9
     |
-177 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+184 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct field
-   --> $DIR/invalid-target.rs:178:9
+   --> $DIR/invalid-target.rs:185:9
     |
-178 |         vertex, // fn-only
+185 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:179:9
+   --> $DIR/invalid-target.rs:186:9
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:179:18
+   --> $DIR/invalid-target.rs:186:18
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:179:28
+   --> $DIR/invalid-target.rs:186:28
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:179:48
+   --> $DIR/invalid-target.rs:186:48
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:179:61
+   --> $DIR/invalid-target.rs:186:61
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:179:67
+   --> $DIR/invalid-target.rs:186:67
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
-   --> $DIR/invalid-target.rs:180:9
+   --> $DIR/invalid-target.rs:187:9
     |
-180 |         unroll_loops, // fn/closure-only
+187 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct
-   --> $DIR/invalid-target.rs:186:5
+   --> $DIR/invalid-target.rs:193:5
     |
-186 |     vertex, // fn-only
+193 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:187:5
+   --> $DIR/invalid-target.rs:194:5
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+194 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:187:14
+   --> $DIR/invalid-target.rs:194:14
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+194 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:187:24
+   --> $DIR/invalid-target.rs:194:24
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+194 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:187:44
+   --> $DIR/invalid-target.rs:194:44
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+194 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:187:57
+   --> $DIR/invalid-target.rs:194:57
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+194 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:187:63
+   --> $DIR/invalid-target.rs:194:63
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+194 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct
-   --> $DIR/invalid-target.rs:188:5
+   --> $DIR/invalid-target.rs:195:5
     |
-188 |     unroll_loops, // fn/closure-only
+195 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:192:9
+   --> $DIR/invalid-target.rs:199:9
     |
-192 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+199 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:192:18
+   --> $DIR/invalid-target.rs:199:18
     |
-192 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+199 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:192:25
+   --> $DIR/invalid-target.rs:199:25
     |
-192 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+199 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:193:9
+   --> $DIR/invalid-target.rs:200:9
     |
-193 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+200 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct field
-   --> $DIR/invalid-target.rs:194:9
+   --> $DIR/invalid-target.rs:201:9
     |
-194 |         vertex, // fn-only
+201 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:195:9
+   --> $DIR/invalid-target.rs:202:9
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:195:18
+   --> $DIR/invalid-target.rs:202:18
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:195:28
+   --> $DIR/invalid-target.rs:202:28
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:195:48
+   --> $DIR/invalid-target.rs:202:48
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:195:61
+   --> $DIR/invalid-target.rs:202:61
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:195:67
+   --> $DIR/invalid-target.rs:202:67
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
-   --> $DIR/invalid-target.rs:196:9
+   --> $DIR/invalid-target.rs:203:9
     |
-196 |         unroll_loops, // fn/closure-only
+203 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:202:5
+   --> $DIR/invalid-target.rs:209:5
     |
-202 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+209 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:202:14
+   --> $DIR/invalid-target.rs:209:14
     |
-202 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+209 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:202:21
+   --> $DIR/invalid-target.rs:209:21
     |
-202 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+209 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:203:5
+   --> $DIR/invalid-target.rs:210:5
     |
-203 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+210 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a item
-   --> $DIR/invalid-target.rs:204:5
+   --> $DIR/invalid-target.rs:211:5
     |
-204 |     vertex, // fn-only
+211 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:205:5
+   --> $DIR/invalid-target.rs:212:5
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+212 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:205:14
+   --> $DIR/invalid-target.rs:212:14
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+212 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:205:24
+   --> $DIR/invalid-target.rs:212:24
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+212 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:205:44
+   --> $DIR/invalid-target.rs:212:44
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+212 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:205:57
+   --> $DIR/invalid-target.rs:212:57
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+212 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:205:63
+   --> $DIR/invalid-target.rs:212:63
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+212 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a item
-   --> $DIR/invalid-target.rs:206:5
+   --> $DIR/invalid-target.rs:213:5
     |
-206 |     unroll_loops, // fn/closure-only
+213 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:227:5
+   --> $DIR/invalid-target.rs:234:5
     |
-227 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+234 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:227:14
+   --> $DIR/invalid-target.rs:234:14
     |
-227 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+234 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:227:21
+   --> $DIR/invalid-target.rs:234:21
     |
-227 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+234 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:228:5
+   --> $DIR/invalid-target.rs:235:5
     |
-228 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+235 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a trait alias
-   --> $DIR/invalid-target.rs:229:5
+   --> $DIR/invalid-target.rs:236:5
     |
-229 |     vertex, // fn-only
+236 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:230:5
+   --> $DIR/invalid-target.rs:237:5
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+237 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:230:14
+   --> $DIR/invalid-target.rs:237:14
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+237 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:230:24
+   --> $DIR/invalid-target.rs:237:24
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+237 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:230:44
+   --> $DIR/invalid-target.rs:237:44
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+237 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:230:57
+   --> $DIR/invalid-target.rs:237:57
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+237 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:230:63
+   --> $DIR/invalid-target.rs:237:63
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+237 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a trait alias
-   --> $DIR/invalid-target.rs:231:5
+   --> $DIR/invalid-target.rs:238:5
     |
-231 |     unroll_loops, // fn/closure-only
+238 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:236:5
+   --> $DIR/invalid-target.rs:243:5
     |
-236 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+243 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:236:14
+   --> $DIR/invalid-target.rs:243:14
     |
-236 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+243 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:236:21
+   --> $DIR/invalid-target.rs:243:21
     |
-236 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+243 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:237:5
+   --> $DIR/invalid-target.rs:244:5
     |
-237 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+244 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a trait
-   --> $DIR/invalid-target.rs:238:5
+   --> $DIR/invalid-target.rs:245:5
     |
-238 |     vertex, // fn-only
+245 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:239:5
+   --> $DIR/invalid-target.rs:246:5
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+246 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:239:14
+   --> $DIR/invalid-target.rs:246:14
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+246 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:239:24
+   --> $DIR/invalid-target.rs:246:24
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+246 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:239:44
+   --> $DIR/invalid-target.rs:246:44
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+246 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:239:57
+   --> $DIR/invalid-target.rs:246:57
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+246 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:239:63
+   --> $DIR/invalid-target.rs:246:63
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+246 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a trait
-   --> $DIR/invalid-target.rs:240:5
+   --> $DIR/invalid-target.rs:247:5
     |
-240 |     unroll_loops, // fn/closure-only
+247 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:279:5
+   --> $DIR/invalid-target.rs:286:5
     |
-279 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+286 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:279:14
+   --> $DIR/invalid-target.rs:286:14
     |
-279 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+286 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:279:21
+   --> $DIR/invalid-target.rs:286:21
     |
-279 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+286 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a item
-   --> $DIR/invalid-target.rs:280:5
+   --> $DIR/invalid-target.rs:287:5
     |
-280 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+287 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a item
-   --> $DIR/invalid-target.rs:281:5
+   --> $DIR/invalid-target.rs:288:5
     |
-281 |     vertex, // fn-only
+288 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:282:5
+   --> $DIR/invalid-target.rs:289:5
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+289 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:282:14
+   --> $DIR/invalid-target.rs:289:14
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+289 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:282:24
+   --> $DIR/invalid-target.rs:289:24
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+289 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:282:44
+   --> $DIR/invalid-target.rs:289:44
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+289 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:282:57
+   --> $DIR/invalid-target.rs:289:57
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+289 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a item
-   --> $DIR/invalid-target.rs:282:63
+   --> $DIR/invalid-target.rs:289:63
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+289 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a item
-   --> $DIR/invalid-target.rs:283:5
+   --> $DIR/invalid-target.rs:290:5
     |
-283 |     unroll_loops, // fn/closure-only
+290 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:313:5
+   --> $DIR/invalid-target.rs:320:5
     |
-313 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+320 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:313:14
+   --> $DIR/invalid-target.rs:320:14
     |
-313 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+320 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:313:21
+   --> $DIR/invalid-target.rs:320:21
     |
-313 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+320 |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:314:5
+   --> $DIR/invalid-target.rs:321:5
     |
-314 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+321 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:315:5
+   --> $DIR/invalid-target.rs:322:5
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+322 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:315:14
+   --> $DIR/invalid-target.rs:322:14
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+322 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:315:24
+   --> $DIR/invalid-target.rs:322:24
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+322 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:315:44
+   --> $DIR/invalid-target.rs:322:44
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+322 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:315:57
+   --> $DIR/invalid-target.rs:322:57
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+322 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:315:63
+   --> $DIR/invalid-target.rs:322:63
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+322 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:319:9
+   --> $DIR/invalid-target.rs:326:9
     |
-319 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+326 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:319:18
+   --> $DIR/invalid-target.rs:326:18
     |
-319 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+326 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:319:25
+   --> $DIR/invalid-target.rs:326:25
     |
-319 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+326 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:320:9
+   --> $DIR/invalid-target.rs:327:9
     |
-320 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+327 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a function param
-   --> $DIR/invalid-target.rs:321:9
+   --> $DIR/invalid-target.rs:328:9
     |
-321 |         vertex, // fn-only
+328 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function or closure, not on a function param
-   --> $DIR/invalid-target.rs:322:9
+   --> $DIR/invalid-target.rs:329:9
     |
-322 |         unroll_loops, // fn/closure-only
+329 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:327:9
+   --> $DIR/invalid-target.rs:334:9
     |
-327 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+334 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:327:18
+   --> $DIR/invalid-target.rs:334:18
     |
-327 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+334 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:327:25
+   --> $DIR/invalid-target.rs:334:25
     |
-327 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+334 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:328:9
+   --> $DIR/invalid-target.rs:335:9
     |
-328 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+335 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a statement
-   --> $DIR/invalid-target.rs:329:9
+   --> $DIR/invalid-target.rs:336:9
     |
-329 |         vertex, // fn-only
+336 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:330:9
+   --> $DIR/invalid-target.rs:337:9
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+337 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:330:18
+   --> $DIR/invalid-target.rs:337:18
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+337 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:330:28
+   --> $DIR/invalid-target.rs:337:28
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+337 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:330:48
+   --> $DIR/invalid-target.rs:337:48
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+337 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:330:61
+   --> $DIR/invalid-target.rs:337:61
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+337 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:330:67
+   --> $DIR/invalid-target.rs:337:67
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+337 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a statement
-   --> $DIR/invalid-target.rs:331:9
+   --> $DIR/invalid-target.rs:338:9
     |
-331 |         unroll_loops, // fn/closure-only
+338 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:337:13
+   --> $DIR/invalid-target.rs:343:13
     |
-337 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+343 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:337:22
+   --> $DIR/invalid-target.rs:343:22
     |
-337 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+343 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:337:29
+   --> $DIR/invalid-target.rs:343:29
     |
-337 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+343 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:338:13
+   --> $DIR/invalid-target.rs:344:13
     |
-338 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+344 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a closure
-   --> $DIR/invalid-target.rs:339:13
+   --> $DIR/invalid-target.rs:345:13
     |
-339 |             vertex, // fn-only
+345 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:340:13
+   --> $DIR/invalid-target.rs:346:13
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+346 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:340:22
+   --> $DIR/invalid-target.rs:346:22
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+346 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:340:32
+   --> $DIR/invalid-target.rs:346:32
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+346 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:340:52
+   --> $DIR/invalid-target.rs:346:52
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+346 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:340:65
+   --> $DIR/invalid-target.rs:346:65
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+346 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:340:71
+   --> $DIR/invalid-target.rs:346:71
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+346 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:346:13
+   --> $DIR/invalid-target.rs:352:13
     |
-346 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+352 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:346:22
+   --> $DIR/invalid-target.rs:352:22
     |
-346 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+352 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:346:29
+   --> $DIR/invalid-target.rs:352:29
     |
-346 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+352 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:347:13
+   --> $DIR/invalid-target.rs:353:13
     |
-347 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+353 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a expression
-   --> $DIR/invalid-target.rs:348:13
+   --> $DIR/invalid-target.rs:354:13
     |
-348 |             vertex, // fn-only
+354 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:349:13
+   --> $DIR/invalid-target.rs:355:13
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+355 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:349:22
+   --> $DIR/invalid-target.rs:355:22
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+355 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:349:32
+   --> $DIR/invalid-target.rs:355:32
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+355 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:349:52
+   --> $DIR/invalid-target.rs:355:52
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+355 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:349:65
+   --> $DIR/invalid-target.rs:355:65
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+355 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:349:71
+   --> $DIR/invalid-target.rs:355:71
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+355 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a expression
-   --> $DIR/invalid-target.rs:350:13
+   --> $DIR/invalid-target.rs:356:13
     |
-350 |             unroll_loops, // fn/closure-only
+356 |             unroll_loops, // fn/closure-only
     |             ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:357:13
+   --> $DIR/invalid-target.rs:363:13
     |
-357 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+363 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:357:22
+   --> $DIR/invalid-target.rs:363:22
     |
-357 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+363 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:357:29
+   --> $DIR/invalid-target.rs:363:29
     |
-357 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
+363 |             sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:358:13
+   --> $DIR/invalid-target.rs:364:13
     |
-358 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+364 |             image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a match arm
-   --> $DIR/invalid-target.rs:359:13
+   --> $DIR/invalid-target.rs:365:13
     |
-359 |             vertex, // fn-only
+365 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:360:13
+   --> $DIR/invalid-target.rs:366:13
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+366 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:360:22
+   --> $DIR/invalid-target.rs:366:22
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+366 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:360:32
+   --> $DIR/invalid-target.rs:366:32
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+366 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:360:52
+   --> $DIR/invalid-target.rs:366:52
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+366 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:360:65
+   --> $DIR/invalid-target.rs:366:65
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+366 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:360:71
+   --> $DIR/invalid-target.rs:366:71
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+366 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a match arm
-   --> $DIR/invalid-target.rs:361:13
+   --> $DIR/invalid-target.rs:367:13
     |
-361 |             unroll_loops, // fn/closure-only
+367 |             unroll_loops, // fn/closure-only
     |             ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:244:9
+   --> $DIR/invalid-target.rs:251:9
     |
-244 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+251 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:244:18
+   --> $DIR/invalid-target.rs:251:18
     |
-244 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+251 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:244:25
+   --> $DIR/invalid-target.rs:251:25
     |
-244 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+251 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:245:9
+   --> $DIR/invalid-target.rs:252:9
     |
-245 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+252 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated type
-   --> $DIR/invalid-target.rs:246:9
+   --> $DIR/invalid-target.rs:253:9
     |
-246 |         vertex, // fn-only
+253 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:247:9
+   --> $DIR/invalid-target.rs:254:9
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+254 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:247:18
+   --> $DIR/invalid-target.rs:254:18
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+254 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:247:28
+   --> $DIR/invalid-target.rs:254:28
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+254 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:247:48
+   --> $DIR/invalid-target.rs:254:48
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+254 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:247:61
+   --> $DIR/invalid-target.rs:254:61
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+254 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:247:67
+   --> $DIR/invalid-target.rs:254:67
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+254 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated type
-   --> $DIR/invalid-target.rs:248:9
+   --> $DIR/invalid-target.rs:255:9
     |
-248 |         unroll_loops, // fn/closure-only
+255 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:253:9
+   --> $DIR/invalid-target.rs:260:9
     |
-253 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+260 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:253:18
+   --> $DIR/invalid-target.rs:260:18
     |
-253 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+260 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:253:25
+   --> $DIR/invalid-target.rs:260:25
     |
-253 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+260 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:254:9
+   --> $DIR/invalid-target.rs:261:9
     |
-254 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+261 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated const
-   --> $DIR/invalid-target.rs:255:9
+   --> $DIR/invalid-target.rs:262:9
     |
-255 |         vertex, // fn-only
+262 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:256:9
+   --> $DIR/invalid-target.rs:263:9
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:256:18
+   --> $DIR/invalid-target.rs:263:18
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:256:28
+   --> $DIR/invalid-target.rs:263:28
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:256:48
+   --> $DIR/invalid-target.rs:263:48
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:256:61
+   --> $DIR/invalid-target.rs:263:61
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:256:67
+   --> $DIR/invalid-target.rs:263:67
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
-   --> $DIR/invalid-target.rs:257:9
+   --> $DIR/invalid-target.rs:264:9
     |
-257 |         unroll_loops, // fn/closure-only
+264 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:262:9
+   --> $DIR/invalid-target.rs:269:9
     |
-262 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+269 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:262:18
+   --> $DIR/invalid-target.rs:269:18
     |
-262 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+269 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:262:25
+   --> $DIR/invalid-target.rs:269:25
     |
-262 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+269 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:263:9
+   --> $DIR/invalid-target.rs:270:9
     |
-263 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+270 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a method
-   --> $DIR/invalid-target.rs:264:9
+   --> $DIR/invalid-target.rs:271:9
     |
-264 |         vertex, // fn-only
+271 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:265:9
+   --> $DIR/invalid-target.rs:272:9
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+272 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:265:18
+   --> $DIR/invalid-target.rs:272:18
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+272 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:265:28
+   --> $DIR/invalid-target.rs:272:28
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+272 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:265:48
+   --> $DIR/invalid-target.rs:272:48
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+272 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:265:61
+   --> $DIR/invalid-target.rs:272:61
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+272 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:265:67
+   --> $DIR/invalid-target.rs:272:67
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+272 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a method
-   --> $DIR/invalid-target.rs:266:9
+   --> $DIR/invalid-target.rs:273:9
     |
-266 |         unroll_loops, // fn/closure-only
+273 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:271:9
+   --> $DIR/invalid-target.rs:278:9
     |
-271 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+278 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:271:18
+   --> $DIR/invalid-target.rs:278:18
     |
-271 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+278 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:271:25
+   --> $DIR/invalid-target.rs:278:25
     |
-271 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+278 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:272:9
+   --> $DIR/invalid-target.rs:279:9
     |
-272 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+279 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:273:9
+   --> $DIR/invalid-target.rs:280:9
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+280 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:273:18
+   --> $DIR/invalid-target.rs:280:18
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+280 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:273:28
+   --> $DIR/invalid-target.rs:280:28
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+280 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:273:48
+   --> $DIR/invalid-target.rs:280:48
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+280 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:273:61
+   --> $DIR/invalid-target.rs:280:61
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+280 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:273:67
+   --> $DIR/invalid-target.rs:280:67
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+280 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:210:9
+   --> $DIR/invalid-target.rs:217:9
     |
-210 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+217 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:210:18
+   --> $DIR/invalid-target.rs:217:18
     |
-210 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+217 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:210:25
+   --> $DIR/invalid-target.rs:217:25
     |
-210 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+217 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:211:9
+   --> $DIR/invalid-target.rs:218:9
     |
-211 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+218 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated const
-   --> $DIR/invalid-target.rs:212:9
+   --> $DIR/invalid-target.rs:219:9
     |
-212 |         vertex, // fn-only
+219 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:213:9
+   --> $DIR/invalid-target.rs:220:9
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+220 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:213:18
+   --> $DIR/invalid-target.rs:220:18
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+220 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:213:28
+   --> $DIR/invalid-target.rs:220:28
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+220 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:213:48
+   --> $DIR/invalid-target.rs:220:48
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+220 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:213:61
+   --> $DIR/invalid-target.rs:220:61
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+220 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:213:67
+   --> $DIR/invalid-target.rs:220:67
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+220 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
-   --> $DIR/invalid-target.rs:214:9
+   --> $DIR/invalid-target.rs:221:9
     |
-214 |         unroll_loops, // fn/closure-only
+221 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:219:9
+   --> $DIR/invalid-target.rs:226:9
     |
-219 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+226 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:219:18
+   --> $DIR/invalid-target.rs:226:18
     |
-219 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+226 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:219:25
+   --> $DIR/invalid-target.rs:226:25
     |
-219 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+226 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:220:9
+   --> $DIR/invalid-target.rs:227:9
     |
-220 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+227 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:221:9
+   --> $DIR/invalid-target.rs:228:9
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+228 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:221:18
+   --> $DIR/invalid-target.rs:228:18
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+228 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:221:28
+   --> $DIR/invalid-target.rs:228:28
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+228 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:221:48
+   --> $DIR/invalid-target.rs:228:48
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+228 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:221:61
+   --> $DIR/invalid-target.rs:228:61
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+228 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:221:67
+   --> $DIR/invalid-target.rs:228:67
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+228 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:287:9
+   --> $DIR/invalid-target.rs:294:9
     |
-287 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+294 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:287:18
+   --> $DIR/invalid-target.rs:294:18
     |
-287 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+294 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:287:25
+   --> $DIR/invalid-target.rs:294:25
     |
-287 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+294 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:288:9
+   --> $DIR/invalid-target.rs:295:9
     |
-288 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+295 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated type
-   --> $DIR/invalid-target.rs:289:9
+   --> $DIR/invalid-target.rs:296:9
     |
-289 |         vertex, // fn-only
+296 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:290:9
+   --> $DIR/invalid-target.rs:297:9
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+297 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:290:18
+   --> $DIR/invalid-target.rs:297:18
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+297 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:290:28
+   --> $DIR/invalid-target.rs:297:28
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+297 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:290:48
+   --> $DIR/invalid-target.rs:297:48
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+297 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:290:61
+   --> $DIR/invalid-target.rs:297:61
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+297 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:290:67
+   --> $DIR/invalid-target.rs:297:67
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+297 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated type
-   --> $DIR/invalid-target.rs:291:9
+   --> $DIR/invalid-target.rs:298:9
     |
-291 |         unroll_loops, // fn/closure-only
+298 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:296:9
+   --> $DIR/invalid-target.rs:303:9
     |
-296 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+303 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:296:18
+   --> $DIR/invalid-target.rs:303:18
     |
-296 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+303 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:296:25
+   --> $DIR/invalid-target.rs:303:25
     |
-296 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+303 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:297:9
+   --> $DIR/invalid-target.rs:304:9
     |
-297 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+304 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated const
-   --> $DIR/invalid-target.rs:298:9
+   --> $DIR/invalid-target.rs:305:9
     |
-298 |         vertex, // fn-only
+305 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:299:9
+   --> $DIR/invalid-target.rs:306:9
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+306 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:299:18
+   --> $DIR/invalid-target.rs:306:18
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+306 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:299:28
+   --> $DIR/invalid-target.rs:306:28
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+306 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:299:48
+   --> $DIR/invalid-target.rs:306:48
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+306 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:299:61
+   --> $DIR/invalid-target.rs:306:61
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+306 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:299:67
+   --> $DIR/invalid-target.rs:306:67
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+306 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
-   --> $DIR/invalid-target.rs:300:9
+   --> $DIR/invalid-target.rs:307:9
     |
-300 |         unroll_loops, // fn/closure-only
+307 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:305:9
+   --> $DIR/invalid-target.rs:312:9
     |
-305 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+312 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:305:18
+   --> $DIR/invalid-target.rs:312:18
     |
-305 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+312 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:305:25
+   --> $DIR/invalid-target.rs:312:25
     |
-305 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+312 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a method
-   --> $DIR/invalid-target.rs:306:9
+   --> $DIR/invalid-target.rs:313:9
     |
-306 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+313 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:307:9
+   --> $DIR/invalid-target.rs:314:9
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:307:18
+   --> $DIR/invalid-target.rs:314:18
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:307:28
+   --> $DIR/invalid-target.rs:314:28
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:307:48
+   --> $DIR/invalid-target.rs:314:48
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:307:61
+   --> $DIR/invalid-target.rs:314:61
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a method
-   --> $DIR/invalid-target.rs:307:67
+   --> $DIR/invalid-target.rs:314:67
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:75:9
+  --> $DIR/invalid-target.rs:80:9
    |
-75 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+80 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:75:18
+  --> $DIR/invalid-target.rs:80:18
    |
-75 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+80 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:75:25
+  --> $DIR/invalid-target.rs:80:25
    |
-75 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+80 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:76:9
+  --> $DIR/invalid-target.rs:81:9
    |
-76 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+81 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign type
-  --> $DIR/invalid-target.rs:77:9
+  --> $DIR/invalid-target.rs:82:9
    |
-77 |         vertex, // fn-only
+82 |         vertex, // fn-only
    |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:78:9
+  --> $DIR/invalid-target.rs:83:9
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+83 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:78:18
+  --> $DIR/invalid-target.rs:83:18
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+83 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:78:28
+  --> $DIR/invalid-target.rs:83:28
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+83 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:78:48
+  --> $DIR/invalid-target.rs:83:48
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+83 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:78:61
+  --> $DIR/invalid-target.rs:83:61
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+83 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:78:67
+  --> $DIR/invalid-target.rs:83:67
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+83 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign type
-  --> $DIR/invalid-target.rs:79:9
+  --> $DIR/invalid-target.rs:84:9
    |
-79 |         unroll_loops, // fn/closure-only
+84 |         unroll_loops, // fn/closure-only
    |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:84:9
+  --> $DIR/invalid-target.rs:89:9
    |
-84 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+89 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:84:18
+  --> $DIR/invalid-target.rs:89:18
    |
-84 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+89 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:84:25
+  --> $DIR/invalid-target.rs:89:25
    |
-84 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+89 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:85:9
+  --> $DIR/invalid-target.rs:90:9
    |
-85 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+90 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign static item
-  --> $DIR/invalid-target.rs:86:9
+  --> $DIR/invalid-target.rs:91:9
    |
-86 |         vertex, // fn-only
+91 |         vertex, // fn-only
    |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:87:9
+  --> $DIR/invalid-target.rs:92:9
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+92 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:87:18
+  --> $DIR/invalid-target.rs:92:18
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+92 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:87:28
+  --> $DIR/invalid-target.rs:92:28
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+92 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:87:48
+  --> $DIR/invalid-target.rs:92:48
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+92 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:87:61
+  --> $DIR/invalid-target.rs:92:61
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+92 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:87:67
+  --> $DIR/invalid-target.rs:92:67
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+92 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign static item
-  --> $DIR/invalid-target.rs:88:9
+  --> $DIR/invalid-target.rs:93:9
    |
-88 |         unroll_loops, // fn/closure-only
+93 |         unroll_loops, // fn/closure-only
    |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:93:9
+  --> $DIR/invalid-target.rs:98:9
    |
-93 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+98 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:93:18
+  --> $DIR/invalid-target.rs:98:18
    |
-93 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+98 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:93:25
+  --> $DIR/invalid-target.rs:98:25
    |
-93 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
+98 |         sampler, block, sampled_image, // struct-only (incl. `image_type`)
    |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:94:9
+  --> $DIR/invalid-target.rs:99:9
    |
-94 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+99 |         image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign function
-  --> $DIR/invalid-target.rs:95:9
-   |
-95 |         vertex, // fn-only
-   |         ^^^^^^
+   --> $DIR/invalid-target.rs:100:9
+    |
+100 |         vertex, // fn-only
+    |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:96:9
-   |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-   |         ^^^^^^^
+   --> $DIR/invalid-target.rs:101:9
+    |
+101 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:96:18
-   |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-   |                  ^^^^^^^^
+   --> $DIR/invalid-target.rs:101:18
+    |
+101 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:96:28
-   |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-   |                            ^^^^^^^^^^^^^^^^^^
+   --> $DIR/invalid-target.rs:101:28
+    |
+101 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:96:48
-   |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-   |                                                ^^^^^^^^^^^
+   --> $DIR/invalid-target.rs:101:48
+    |
+101 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:96:61
-   |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-   |                                                             ^^^^
+   --> $DIR/invalid-target.rs:101:61
+    |
+101 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:96:67
-   |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-   |                                                                   ^^^^^^^^^
+   --> $DIR/invalid-target.rs:101:67
+    |
+101 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign function
-  --> $DIR/invalid-target.rs:97:9
-   |
-97 |         unroll_loops, // fn/closure-only
-   |         ^^^^^^^^^^^^
+   --> $DIR/invalid-target.rs:102:9
+    |
+102 |         unroll_loops, // fn/closure-only
+    |         ^^^^^^^^^^^^
 
 error: #[spirv(..)] cannot be applied to a macro
-  --> $DIR/invalid-target.rs:28:1
+  --> $DIR/invalid-target.rs:33:1
    |
-28 | / #[spirv(
-29 | |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
-30 | |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
-31 | |     vertex, // fn-only
-32 | |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-33 | |     unroll_loops, // fn/closure-only
-34 | | )]
+33 | / #[spirv(
+34 | |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
+35 | |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+36 | |     vertex, // fn-only
+37 | |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+38 | |     unroll_loops, // fn/closure-only
+39 | | )]
    | |__^
 
 error: aborting due to 462 previous errors

--- a/tests/ui/spirv-attr/invalid-target.stderr
+++ b/tests/ui/spirv-attr/invalid-target.stderr
@@ -31,32 +31,38 @@ error: attribute is only valid on a function, not on a lifetime parameter
 error: attribute is only valid on a function parameter, not on a lifetime parameter
    --> $DIR/invalid-target.rs:372:9
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
    --> $DIR/invalid-target.rs:372:18
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
    --> $DIR/invalid-target.rs:372:28
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
    --> $DIR/invalid-target.rs:372:48
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
    --> $DIR/invalid-target.rs:372:61
     |
-372 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:372:67
+    |
+372 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a lifetime parameter
    --> $DIR/invalid-target.rs:373:9
@@ -97,32 +103,38 @@ error: attribute is only valid on a function, not on a type parameter
 error: attribute is only valid on a function parameter, not on a type parameter
    --> $DIR/invalid-target.rs:381:9
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
    --> $DIR/invalid-target.rs:381:18
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
    --> $DIR/invalid-target.rs:381:28
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
    --> $DIR/invalid-target.rs:381:48
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
    --> $DIR/invalid-target.rs:381:61
     |
-381 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a type parameter
+   --> $DIR/invalid-target.rs:381:67
+    |
+381 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a type parameter
    --> $DIR/invalid-target.rs:382:9
@@ -163,32 +175,38 @@ error: attribute is only valid on a function, not on a const parameter
 error: attribute is only valid on a function parameter, not on a const parameter
    --> $DIR/invalid-target.rs:390:9
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
    --> $DIR/invalid-target.rs:390:18
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
    --> $DIR/invalid-target.rs:390:28
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
    --> $DIR/invalid-target.rs:390:48
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
    --> $DIR/invalid-target.rs:390:61
     |
-390 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a const parameter
+   --> $DIR/invalid-target.rs:390:67
+    |
+390 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a const parameter
    --> $DIR/invalid-target.rs:391:9
@@ -229,32 +247,38 @@ error: attribute is only valid on a function, not on a extern crate
 error: attribute is only valid on a function parameter, not on a extern crate
   --> $DIR/invalid-target.rs:43:5
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
   --> $DIR/invalid-target.rs:43:14
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
   --> $DIR/invalid-target.rs:43:24
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
   --> $DIR/invalid-target.rs:43:44
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
   --> $DIR/invalid-target.rs:43:57
    |
-43 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a extern crate
+  --> $DIR/invalid-target.rs:43:63
+   |
+43 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a extern crate
   --> $DIR/invalid-target.rs:44:5
@@ -295,32 +319,38 @@ error: attribute is only valid on a function, not on a use
 error: attribute is only valid on a function parameter, not on a use
   --> $DIR/invalid-target.rs:52:5
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
   --> $DIR/invalid-target.rs:52:14
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
   --> $DIR/invalid-target.rs:52:24
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
   --> $DIR/invalid-target.rs:52:44
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
   --> $DIR/invalid-target.rs:52:57
    |
-52 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a use
+  --> $DIR/invalid-target.rs:52:63
+   |
+52 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a use
   --> $DIR/invalid-target.rs:53:5
@@ -361,32 +391,38 @@ error: attribute is only valid on a function, not on a module
 error: attribute is only valid on a function parameter, not on a module
   --> $DIR/invalid-target.rs:61:5
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
   --> $DIR/invalid-target.rs:61:14
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
   --> $DIR/invalid-target.rs:61:24
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
   --> $DIR/invalid-target.rs:61:44
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
   --> $DIR/invalid-target.rs:61:57
    |
-61 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a module
+  --> $DIR/invalid-target.rs:61:63
+   |
+61 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a module
   --> $DIR/invalid-target.rs:62:5
@@ -427,32 +463,38 @@ error: attribute is only valid on a function, not on a foreign module
 error: attribute is only valid on a function parameter, not on a foreign module
   --> $DIR/invalid-target.rs:70:5
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
   --> $DIR/invalid-target.rs:70:14
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
   --> $DIR/invalid-target.rs:70:24
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
   --> $DIR/invalid-target.rs:70:44
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
   --> $DIR/invalid-target.rs:70:57
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a foreign module
+  --> $DIR/invalid-target.rs:70:63
+   |
+70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign module
   --> $DIR/invalid-target.rs:71:5
@@ -493,32 +535,38 @@ error: attribute is only valid on a function, not on a static item
 error: attribute is only valid on a function parameter, not on a static item
    --> $DIR/invalid-target.rs:106:5
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
    --> $DIR/invalid-target.rs:106:14
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
    --> $DIR/invalid-target.rs:106:24
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
    --> $DIR/invalid-target.rs:106:44
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
    --> $DIR/invalid-target.rs:106:57
     |
-106 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a static item
+   --> $DIR/invalid-target.rs:106:63
+    |
+106 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a static item
    --> $DIR/invalid-target.rs:107:5
@@ -559,32 +607,38 @@ error: attribute is only valid on a function, not on a constant item
 error: attribute is only valid on a function parameter, not on a constant item
    --> $DIR/invalid-target.rs:115:5
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
    --> $DIR/invalid-target.rs:115:14
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
    --> $DIR/invalid-target.rs:115:24
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
    --> $DIR/invalid-target.rs:115:44
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
    --> $DIR/invalid-target.rs:115:57
     |
-115 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a constant item
+   --> $DIR/invalid-target.rs:115:63
+    |
+115 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a constant item
    --> $DIR/invalid-target.rs:116:5
@@ -625,32 +679,38 @@ error: attribute is only valid on a function, not on a type alias
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:124:5
     |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:124:14
     |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:124:24
     |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:124:44
     |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:124:57
     |
-124 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:124:63
+    |
+124 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a type alias
    --> $DIR/invalid-target.rs:125:5
@@ -691,32 +751,38 @@ error: attribute is only valid on a function, not on a type alias
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:133:5
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:133:14
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:133:24
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:133:44
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:133:57
     |
-133 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:133:63
+    |
+133 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a type alias
    --> $DIR/invalid-target.rs:134:5
@@ -757,32 +823,38 @@ error: attribute is only valid on a function, not on a enum
 error: attribute is only valid on a function parameter, not on a enum
    --> $DIR/invalid-target.rs:144:5
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
    --> $DIR/invalid-target.rs:144:14
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
    --> $DIR/invalid-target.rs:144:24
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
    --> $DIR/invalid-target.rs:144:44
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
    --> $DIR/invalid-target.rs:144:57
     |
-144 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a enum
+   --> $DIR/invalid-target.rs:144:63
+    |
+144 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a enum
    --> $DIR/invalid-target.rs:145:5
@@ -823,32 +895,38 @@ error: attribute is only valid on a function, not on a enum variant
 error: attribute is only valid on a function parameter, not on a enum variant
    --> $DIR/invalid-target.rs:152:9
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
    --> $DIR/invalid-target.rs:152:18
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
    --> $DIR/invalid-target.rs:152:28
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
    --> $DIR/invalid-target.rs:152:48
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
    --> $DIR/invalid-target.rs:152:61
     |
-152 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a enum variant
+   --> $DIR/invalid-target.rs:152:67
+    |
+152 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a enum variant
    --> $DIR/invalid-target.rs:153:9
@@ -889,32 +967,38 @@ error: attribute is only valid on a function, not on a struct field
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:160:13
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:160:22
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:160:32
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:160:52
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:160:65
     |
-160 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
+
+error: attribute is only valid on a function parameter, not on a struct field
+   --> $DIR/invalid-target.rs:160:71
+    |
+160 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
    --> $DIR/invalid-target.rs:161:13
@@ -955,32 +1039,38 @@ error: attribute is only valid on a function, not on a union
 error: attribute is only valid on a function parameter, not on a union
    --> $DIR/invalid-target.rs:171:5
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
    --> $DIR/invalid-target.rs:171:14
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
    --> $DIR/invalid-target.rs:171:24
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
    --> $DIR/invalid-target.rs:171:44
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
    --> $DIR/invalid-target.rs:171:57
     |
-171 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a union
+   --> $DIR/invalid-target.rs:171:63
+    |
+171 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a union
    --> $DIR/invalid-target.rs:172:5
@@ -1021,32 +1111,38 @@ error: attribute is only valid on a function, not on a struct field
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:179:9
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:179:18
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:179:28
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:179:48
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:179:61
     |
-179 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a struct field
+   --> $DIR/invalid-target.rs:179:67
+    |
+179 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
    --> $DIR/invalid-target.rs:180:9
@@ -1063,32 +1159,38 @@ error: attribute is only valid on a function, not on a struct
 error: attribute is only valid on a function parameter, not on a struct
    --> $DIR/invalid-target.rs:187:5
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
    --> $DIR/invalid-target.rs:187:14
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
    --> $DIR/invalid-target.rs:187:24
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
    --> $DIR/invalid-target.rs:187:44
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
    --> $DIR/invalid-target.rs:187:57
     |
-187 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a struct
+   --> $DIR/invalid-target.rs:187:63
+    |
+187 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct
    --> $DIR/invalid-target.rs:188:5
@@ -1129,32 +1231,38 @@ error: attribute is only valid on a function, not on a struct field
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:195:9
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:195:18
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:195:28
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:195:48
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
    --> $DIR/invalid-target.rs:195:61
     |
-195 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a struct field
+   --> $DIR/invalid-target.rs:195:67
+    |
+195 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
    --> $DIR/invalid-target.rs:196:9
@@ -1195,32 +1303,38 @@ error: attribute is only valid on a function, not on a item
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:205:5
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:205:14
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:205:24
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:205:44
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:205:57
     |
-205 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a item
+   --> $DIR/invalid-target.rs:205:63
+    |
+205 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a item
    --> $DIR/invalid-target.rs:206:5
@@ -1261,32 +1375,38 @@ error: attribute is only valid on a function, not on a trait alias
 error: attribute is only valid on a function parameter, not on a trait alias
    --> $DIR/invalid-target.rs:230:5
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
    --> $DIR/invalid-target.rs:230:14
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
    --> $DIR/invalid-target.rs:230:24
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
    --> $DIR/invalid-target.rs:230:44
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
    --> $DIR/invalid-target.rs:230:57
     |
-230 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a trait alias
+   --> $DIR/invalid-target.rs:230:63
+    |
+230 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a trait alias
    --> $DIR/invalid-target.rs:231:5
@@ -1327,32 +1447,38 @@ error: attribute is only valid on a function, not on a trait
 error: attribute is only valid on a function parameter, not on a trait
    --> $DIR/invalid-target.rs:239:5
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
    --> $DIR/invalid-target.rs:239:14
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
    --> $DIR/invalid-target.rs:239:24
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
    --> $DIR/invalid-target.rs:239:44
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
    --> $DIR/invalid-target.rs:239:57
     |
-239 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a trait
+   --> $DIR/invalid-target.rs:239:63
+    |
+239 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a trait
    --> $DIR/invalid-target.rs:240:5
@@ -1393,32 +1519,38 @@ error: attribute is only valid on a function, not on a item
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:282:5
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:282:14
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:282:24
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:282:44
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a item
    --> $DIR/invalid-target.rs:282:57
     |
-282 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a item
+   --> $DIR/invalid-target.rs:282:63
+    |
+282 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a item
    --> $DIR/invalid-target.rs:283:5
@@ -1453,32 +1585,38 @@ error: attribute is only valid on a struct, not on a function
 error: attribute is only valid on a function parameter, not on a function
    --> $DIR/invalid-target.rs:315:5
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
    --> $DIR/invalid-target.rs:315:14
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
    --> $DIR/invalid-target.rs:315:24
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
    --> $DIR/invalid-target.rs:315:44
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
    --> $DIR/invalid-target.rs:315:57
     |
-315 |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a function
+   --> $DIR/invalid-target.rs:315:63
+    |
+315 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function param
    --> $DIR/invalid-target.rs:319:9
@@ -1549,32 +1687,38 @@ error: attribute is only valid on a function, not on a statement
 error: attribute is only valid on a function parameter, not on a statement
    --> $DIR/invalid-target.rs:330:9
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
    --> $DIR/invalid-target.rs:330:18
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
    --> $DIR/invalid-target.rs:330:28
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
    --> $DIR/invalid-target.rs:330:48
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
    --> $DIR/invalid-target.rs:330:61
     |
-330 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a statement
+   --> $DIR/invalid-target.rs:330:67
+    |
+330 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a statement
    --> $DIR/invalid-target.rs:331:9
@@ -1615,32 +1759,38 @@ error: attribute is only valid on a function, not on a closure
 error: attribute is only valid on a function parameter, not on a closure
    --> $DIR/invalid-target.rs:340:13
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
    --> $DIR/invalid-target.rs:340:22
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
    --> $DIR/invalid-target.rs:340:32
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
    --> $DIR/invalid-target.rs:340:52
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
    --> $DIR/invalid-target.rs:340:65
     |
-340 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
+
+error: attribute is only valid on a function parameter, not on a closure
+   --> $DIR/invalid-target.rs:340:71
+    |
+340 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a expression
    --> $DIR/invalid-target.rs:346:13
@@ -1675,32 +1825,38 @@ error: attribute is only valid on a function, not on a expression
 error: attribute is only valid on a function parameter, not on a expression
    --> $DIR/invalid-target.rs:349:13
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
    --> $DIR/invalid-target.rs:349:22
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
    --> $DIR/invalid-target.rs:349:32
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
    --> $DIR/invalid-target.rs:349:52
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
    --> $DIR/invalid-target.rs:349:65
     |
-349 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
+
+error: attribute is only valid on a function parameter, not on a expression
+   --> $DIR/invalid-target.rs:349:71
+    |
+349 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a expression
    --> $DIR/invalid-target.rs:350:13
@@ -1741,32 +1897,38 @@ error: attribute is only valid on a function, not on a match arm
 error: attribute is only valid on a function parameter, not on a match arm
    --> $DIR/invalid-target.rs:360:13
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
    --> $DIR/invalid-target.rs:360:22
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
    --> $DIR/invalid-target.rs:360:32
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
    --> $DIR/invalid-target.rs:360:52
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
    --> $DIR/invalid-target.rs:360:65
     |
-360 |             uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
+
+error: attribute is only valid on a function parameter, not on a match arm
+   --> $DIR/invalid-target.rs:360:71
+    |
+360 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a match arm
    --> $DIR/invalid-target.rs:361:13
@@ -1807,32 +1969,38 @@ error: attribute is only valid on a function, not on a associated type
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:247:9
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:247:18
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:247:28
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:247:48
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:247:61
     |
-247 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a associated type
+   --> $DIR/invalid-target.rs:247:67
+    |
+247 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated type
    --> $DIR/invalid-target.rs:248:9
@@ -1873,32 +2041,38 @@ error: attribute is only valid on a function, not on a associated const
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:256:9
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:256:18
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:256:28
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:256:48
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:256:61
     |
-256 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a associated const
+   --> $DIR/invalid-target.rs:256:67
+    |
+256 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
    --> $DIR/invalid-target.rs:257:9
@@ -1939,32 +2113,38 @@ error: attribute is only valid on a function, not on a method
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:265:9
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:265:18
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:265:28
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:265:48
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:265:61
     |
-265 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a method
+   --> $DIR/invalid-target.rs:265:67
+    |
+265 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a method
    --> $DIR/invalid-target.rs:266:9
@@ -1999,32 +2179,38 @@ error: attribute is only valid on a struct, not on a method
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:273:9
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:273:18
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:273:28
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:273:48
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:273:61
     |
-273 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a method
+   --> $DIR/invalid-target.rs:273:67
+    |
+273 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
    --> $DIR/invalid-target.rs:210:9
@@ -2059,32 +2245,38 @@ error: attribute is only valid on a function, not on a associated const
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:213:9
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:213:18
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:213:28
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:213:48
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:213:61
     |
-213 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a associated const
+   --> $DIR/invalid-target.rs:213:67
+    |
+213 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
    --> $DIR/invalid-target.rs:214:9
@@ -2119,32 +2311,38 @@ error: attribute is only valid on a struct, not on a method
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:221:9
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:221:18
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:221:28
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:221:48
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:221:61
     |
-221 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a method
+   --> $DIR/invalid-target.rs:221:67
+    |
+221 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
    --> $DIR/invalid-target.rs:287:9
@@ -2179,32 +2377,38 @@ error: attribute is only valid on a function, not on a associated type
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:290:9
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:290:18
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:290:28
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:290:48
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
    --> $DIR/invalid-target.rs:290:61
     |
-290 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a associated type
+   --> $DIR/invalid-target.rs:290:67
+    |
+290 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated type
    --> $DIR/invalid-target.rs:291:9
@@ -2245,32 +2449,38 @@ error: attribute is only valid on a function, not on a associated const
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:299:9
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:299:18
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:299:28
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:299:48
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
    --> $DIR/invalid-target.rs:299:61
     |
-299 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a associated const
+   --> $DIR/invalid-target.rs:299:67
+    |
+299 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
    --> $DIR/invalid-target.rs:300:9
@@ -2305,32 +2515,38 @@ error: attribute is only valid on a struct, not on a method
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:307:9
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:307:18
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:307:28
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:307:48
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a method
    --> $DIR/invalid-target.rs:307:61
     |
-307 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a method
+   --> $DIR/invalid-target.rs:307:67
+    |
+307 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
   --> $DIR/invalid-target.rs:75:9
@@ -2365,32 +2581,38 @@ error: attribute is only valid on a function, not on a foreign type
 error: attribute is only valid on a function parameter, not on a foreign type
   --> $DIR/invalid-target.rs:78:9
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
   --> $DIR/invalid-target.rs:78:18
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
   --> $DIR/invalid-target.rs:78:28
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
   --> $DIR/invalid-target.rs:78:48
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
   --> $DIR/invalid-target.rs:78:61
    |
-78 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a foreign type
+  --> $DIR/invalid-target.rs:78:67
+   |
+78 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign type
   --> $DIR/invalid-target.rs:79:9
@@ -2431,32 +2653,38 @@ error: attribute is only valid on a function, not on a foreign static item
 error: attribute is only valid on a function parameter, not on a foreign static item
   --> $DIR/invalid-target.rs:87:9
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
   --> $DIR/invalid-target.rs:87:18
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
   --> $DIR/invalid-target.rs:87:28
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
   --> $DIR/invalid-target.rs:87:48
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
   --> $DIR/invalid-target.rs:87:61
    |
-87 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a foreign static item
+  --> $DIR/invalid-target.rs:87:67
+   |
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign static item
   --> $DIR/invalid-target.rs:88:9
@@ -2497,32 +2725,38 @@ error: attribute is only valid on a function, not on a foreign function
 error: attribute is only valid on a function parameter, not on a foreign function
   --> $DIR/invalid-target.rs:96:9
    |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
   --> $DIR/invalid-target.rs:96:18
    |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
   --> $DIR/invalid-target.rs:96:28
    |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
   --> $DIR/invalid-target.rs:96:48
    |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
   --> $DIR/invalid-target.rs:96:61
    |
-96 |         uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a foreign function
+  --> $DIR/invalid-target.rs:96:67
+   |
+96 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign function
   --> $DIR/invalid-target.rs:97:9
@@ -2537,10 +2771,10 @@ error: #[spirv(..)] cannot be applied to a macro
 29 | |     sampler, block, sampled_image, // struct-only (incl. `image_type`)
 30 | |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
 31 | |     vertex, // fn-only
-32 | |     uniform, position, descriptor_set = 0, binding = 0, flat, // param-only
+32 | |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
 33 | |     unroll_loops, // fn/closure-only
 34 | | )]
    | |__^
 
-error: aborting due to 423 previous errors
+error: aborting due to 462 previous errors
 

--- a/tests/ui/spirv-attr/invariant-invalid.rs
+++ b/tests/ui/spirv-attr/invariant-invalid.rs
@@ -1,0 +1,7 @@
+// Tests that the invariant attribute can't be applied on inputs
+// build-fail
+
+use spirv_std as _;
+
+#[spirv(vertex)]
+pub fn main(#[spirv(invariant)] input: f32) {}

--- a/tests/ui/spirv-attr/invariant-invalid.stderr
+++ b/tests/ui/spirv-attr/invariant-invalid.stderr
@@ -1,0 +1,8 @@
+error: #[spirv(invariant)] is only valid on Output variables
+ --> $DIR/invariant-invalid.rs:7:21
+  |
+7 | pub fn main(#[spirv(invariant)] input: f32) {}
+  |                     ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/spirv-attr/invariant.rs
+++ b/tests/ui/spirv-attr/invariant.rs
@@ -1,0 +1,7 @@
+// Tests that the invariant attribute works
+// build-pass
+
+use spirv_std as _;
+
+#[spirv(vertex)]
+pub fn main(#[spirv(invariant)] output: &mut f32) {}

--- a/tests/ui/spirv-attr/multiple.rs
+++ b/tests/ui/spirv-attr/multiple.rs
@@ -38,6 +38,8 @@ fn _entry(
     #[spirv(binding = 0, binding = 1)] _diff_binding: (),
 
     #[spirv(flat, flat)] _flat: (),
+
+    #[spirv(invariant, invariant)] _invariant: (),
 ) {}
 
 #[spirv(unroll_loops, unroll_loops)]

--- a/tests/ui/spirv-attr/multiple.rs
+++ b/tests/ui/spirv-attr/multiple.rs
@@ -10,7 +10,14 @@ struct _SameIntrinsicType {}
 
 #[spirv(
     sampler,
-    image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
+    image_type(
+        dim = "Dim2D",
+        depth = 0,
+        arrayed = 0,
+        multisampled = 0,
+        sampled = 1,
+        image_format = "Unknown"
+    )
 )]
 struct _DiffIntrinsicType {}
 
@@ -40,7 +47,8 @@ fn _entry(
     #[spirv(flat, flat)] _flat: (),
 
     #[spirv(invariant, invariant)] _invariant: (),
-) {}
+) {
+}
 
 #[spirv(unroll_loops, unroll_loops)]
 fn _unroll_loops() {}

--- a/tests/ui/spirv-attr/multiple.stderr
+++ b/tests/ui/spirv-attr/multiple.stderr
@@ -166,17 +166,29 @@ note: previous #[spirv(flat)] attribute
 40 |     #[spirv(flat, flat)] _flat: (),
    |             ^^^^
 
-error: only one #[spirv(unroll_loops)] attribute is allowed on a function
-  --> $DIR/multiple.rs:43:23
+error: only one #[spirv(invariant)] attribute is allowed on a function param
+  --> $DIR/multiple.rs:42:24
    |
-43 | #[spirv(unroll_loops, unroll_loops)]
+42 |     #[spirv(invariant, invariant)] _invariant: (),
+   |                        ^^^^^^^^^
+   |
+note: previous #[spirv(invariant)] attribute
+  --> $DIR/multiple.rs:42:13
+   |
+42 |     #[spirv(invariant, invariant)] _invariant: (),
+   |             ^^^^^^^^^
+
+error: only one #[spirv(unroll_loops)] attribute is allowed on a function
+  --> $DIR/multiple.rs:45:23
+   |
+45 | #[spirv(unroll_loops, unroll_loops)]
    |                       ^^^^^^^^^^^^
    |
 note: previous #[spirv(unroll_loops)] attribute
-  --> $DIR/multiple.rs:43:9
+  --> $DIR/multiple.rs:45:9
    |
-43 | #[spirv(unroll_loops, unroll_loops)]
+45 | #[spirv(unroll_loops, unroll_loops)]
    |         ^^^^^^^^^^^^
 
-error: aborting due to 15 previous errors
+error: aborting due to 16 previous errors
 

--- a/tests/ui/spirv-attr/multiple.stderr
+++ b/tests/ui/spirv-attr/multiple.stderr
@@ -13,8 +13,14 @@ note: previous intrinsic type attribute
 error: only one intrinsic type attribute is allowed on a struct
   --> $DIR/multiple.rs:13:5
    |
-13 |     image_type(dim = "Dim2D", depth = 0, arrayed = 0, multisampled = 0, sampled = 1, image_format = "Unknown"),
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+13 | /     image_type(
+14 | |         dim = "Dim2D",
+15 | |         depth = 0,
+16 | |         arrayed = 0,
+...  |
+19 | |         image_format = "Unknown"
+20 | |     )
+   | |_____^
    |
 note: previous intrinsic type attribute
   --> $DIR/multiple.rs:12:5
@@ -23,171 +29,171 @@ note: previous intrinsic type attribute
    |     ^^^^^^^
 
 error: only one #[spirv(block)] attribute is allowed on a struct
-  --> $DIR/multiple.rs:17:16
+  --> $DIR/multiple.rs:24:16
    |
-17 | #[spirv(block, block)]
+24 | #[spirv(block, block)]
    |                ^^^^^
    |
 note: previous #[spirv(block)] attribute
-  --> $DIR/multiple.rs:17:9
+  --> $DIR/multiple.rs:24:9
    |
-17 | #[spirv(block, block)]
+24 | #[spirv(block, block)]
    |         ^^^^^
 
 error: only one entry-point attribute is allowed on a function
-  --> $DIR/multiple.rs:20:17
+  --> $DIR/multiple.rs:27:17
    |
-20 | #[spirv(vertex, vertex)]
+27 | #[spirv(vertex, vertex)]
    |                 ^^^^^^
    |
 note: previous entry-point attribute
-  --> $DIR/multiple.rs:20:9
+  --> $DIR/multiple.rs:27:9
    |
-20 | #[spirv(vertex, vertex)]
+27 | #[spirv(vertex, vertex)]
    |         ^^^^^^
 
 error: only one entry-point attribute is allowed on a function
-  --> $DIR/multiple.rs:23:17
+  --> $DIR/multiple.rs:30:17
    |
-23 | #[spirv(vertex, fragment)]
+30 | #[spirv(vertex, fragment)]
    |                 ^^^^^^^^
    |
 note: previous entry-point attribute
-  --> $DIR/multiple.rs:23:9
+  --> $DIR/multiple.rs:30:9
    |
-23 | #[spirv(vertex, fragment)]
+30 | #[spirv(vertex, fragment)]
    |         ^^^^^^
 
 error: only one storage class attribute is allowed on a function param
-  --> $DIR/multiple.rs:28:22
+  --> $DIR/multiple.rs:35:22
    |
-28 |     #[spirv(uniform, uniform)] _same_storage_class: (),
+35 |     #[spirv(uniform, uniform)] _same_storage_class: (),
    |                      ^^^^^^^
    |
 note: previous storage class attribute
-  --> $DIR/multiple.rs:28:13
+  --> $DIR/multiple.rs:35:13
    |
-28 |     #[spirv(uniform, uniform)] _same_storage_class: (),
+35 |     #[spirv(uniform, uniform)] _same_storage_class: (),
    |             ^^^^^^^
 
 error: only one storage class attribute is allowed on a function param
-  --> $DIR/multiple.rs:29:22
+  --> $DIR/multiple.rs:36:22
    |
-29 |     #[spirv(uniform, push_constant)] _diff_storage_class: (),
+36 |     #[spirv(uniform, push_constant)] _diff_storage_class: (),
    |                      ^^^^^^^^^^^^^
    |
 note: previous storage class attribute
-  --> $DIR/multiple.rs:29:13
+  --> $DIR/multiple.rs:36:13
    |
-29 |     #[spirv(uniform, push_constant)] _diff_storage_class: (),
+36 |     #[spirv(uniform, push_constant)] _diff_storage_class: (),
    |             ^^^^^^^
 
 error: only one builtin attribute is allowed on a function param
-  --> $DIR/multiple.rs:31:23
+  --> $DIR/multiple.rs:38:23
    |
-31 |     #[spirv(position, position)] _same_builtin: (),
+38 |     #[spirv(position, position)] _same_builtin: (),
    |                       ^^^^^^^^
    |
 note: previous builtin attribute
-  --> $DIR/multiple.rs:31:13
+  --> $DIR/multiple.rs:38:13
    |
-31 |     #[spirv(position, position)] _same_builtin: (),
+38 |     #[spirv(position, position)] _same_builtin: (),
    |             ^^^^^^^^
 
 error: only one builtin attribute is allowed on a function param
-  --> $DIR/multiple.rs:32:23
+  --> $DIR/multiple.rs:39:23
    |
-32 |     #[spirv(position, vertex_index)] _diff_builtin: (),
+39 |     #[spirv(position, vertex_index)] _diff_builtin: (),
    |                       ^^^^^^^^^^^^
    |
 note: previous builtin attribute
-  --> $DIR/multiple.rs:32:13
+  --> $DIR/multiple.rs:39:13
    |
-32 |     #[spirv(position, vertex_index)] _diff_builtin: (),
+39 |     #[spirv(position, vertex_index)] _diff_builtin: (),
    |             ^^^^^^^^
 
 error: only one #[spirv(descriptor_set)] attribute is allowed on a function param
-  --> $DIR/multiple.rs:34:33
+  --> $DIR/multiple.rs:41:33
    |
-34 |     #[spirv(descriptor_set = 0, descriptor_set = 0)] _same_descriptor_set: (),
+41 |     #[spirv(descriptor_set = 0, descriptor_set = 0)] _same_descriptor_set: (),
    |                                 ^^^^^^^^^^^^^^^^^^
    |
 note: previous #[spirv(descriptor_set)] attribute
-  --> $DIR/multiple.rs:34:13
+  --> $DIR/multiple.rs:41:13
    |
-34 |     #[spirv(descriptor_set = 0, descriptor_set = 0)] _same_descriptor_set: (),
+41 |     #[spirv(descriptor_set = 0, descriptor_set = 0)] _same_descriptor_set: (),
    |             ^^^^^^^^^^^^^^^^^^
 
 error: only one #[spirv(descriptor_set)] attribute is allowed on a function param
-  --> $DIR/multiple.rs:35:33
+  --> $DIR/multiple.rs:42:33
    |
-35 |     #[spirv(descriptor_set = 0, descriptor_set = 1)] _diff_descriptor_set: (),
+42 |     #[spirv(descriptor_set = 0, descriptor_set = 1)] _diff_descriptor_set: (),
    |                                 ^^^^^^^^^^^^^^^^^^
    |
 note: previous #[spirv(descriptor_set)] attribute
-  --> $DIR/multiple.rs:35:13
+  --> $DIR/multiple.rs:42:13
    |
-35 |     #[spirv(descriptor_set = 0, descriptor_set = 1)] _diff_descriptor_set: (),
+42 |     #[spirv(descriptor_set = 0, descriptor_set = 1)] _diff_descriptor_set: (),
    |             ^^^^^^^^^^^^^^^^^^
 
 error: only one #[spirv(binding)] attribute is allowed on a function param
-  --> $DIR/multiple.rs:37:26
+  --> $DIR/multiple.rs:44:26
    |
-37 |     #[spirv(binding = 0, binding = 0)] _same_binding: (),
+44 |     #[spirv(binding = 0, binding = 0)] _same_binding: (),
    |                          ^^^^^^^^^^^
    |
 note: previous #[spirv(binding)] attribute
-  --> $DIR/multiple.rs:37:13
+  --> $DIR/multiple.rs:44:13
    |
-37 |     #[spirv(binding = 0, binding = 0)] _same_binding: (),
+44 |     #[spirv(binding = 0, binding = 0)] _same_binding: (),
    |             ^^^^^^^^^^^
 
 error: only one #[spirv(binding)] attribute is allowed on a function param
-  --> $DIR/multiple.rs:38:26
+  --> $DIR/multiple.rs:45:26
    |
-38 |     #[spirv(binding = 0, binding = 1)] _diff_binding: (),
+45 |     #[spirv(binding = 0, binding = 1)] _diff_binding: (),
    |                          ^^^^^^^^^^^
    |
 note: previous #[spirv(binding)] attribute
-  --> $DIR/multiple.rs:38:13
+  --> $DIR/multiple.rs:45:13
    |
-38 |     #[spirv(binding = 0, binding = 1)] _diff_binding: (),
+45 |     #[spirv(binding = 0, binding = 1)] _diff_binding: (),
    |             ^^^^^^^^^^^
 
 error: only one #[spirv(flat)] attribute is allowed on a function param
-  --> $DIR/multiple.rs:40:19
+  --> $DIR/multiple.rs:47:19
    |
-40 |     #[spirv(flat, flat)] _flat: (),
+47 |     #[spirv(flat, flat)] _flat: (),
    |                   ^^^^
    |
 note: previous #[spirv(flat)] attribute
-  --> $DIR/multiple.rs:40:13
+  --> $DIR/multiple.rs:47:13
    |
-40 |     #[spirv(flat, flat)] _flat: (),
+47 |     #[spirv(flat, flat)] _flat: (),
    |             ^^^^
 
 error: only one #[spirv(invariant)] attribute is allowed on a function param
-  --> $DIR/multiple.rs:42:24
+  --> $DIR/multiple.rs:49:24
    |
-42 |     #[spirv(invariant, invariant)] _invariant: (),
+49 |     #[spirv(invariant, invariant)] _invariant: (),
    |                        ^^^^^^^^^
    |
 note: previous #[spirv(invariant)] attribute
-  --> $DIR/multiple.rs:42:13
+  --> $DIR/multiple.rs:49:13
    |
-42 |     #[spirv(invariant, invariant)] _invariant: (),
+49 |     #[spirv(invariant, invariant)] _invariant: (),
    |             ^^^^^^^^^
 
 error: only one #[spirv(unroll_loops)] attribute is allowed on a function
-  --> $DIR/multiple.rs:45:23
+  --> $DIR/multiple.rs:53:23
    |
-45 | #[spirv(unroll_loops, unroll_loops)]
+53 | #[spirv(unroll_loops, unroll_loops)]
    |                       ^^^^^^^^^^^^
    |
 note: previous #[spirv(unroll_loops)] attribute
-  --> $DIR/multiple.rs:45:9
+  --> $DIR/multiple.rs:53:9
    |
-45 | #[spirv(unroll_loops, unroll_loops)]
+53 | #[spirv(unroll_loops, unroll_loops)]
    |         ^^^^^^^^^^^^
 
 error: aborting due to 16 previous errors


### PR DESCRIPTION
Fixes #536

Also, my editor kept on formatting the tests, so I've formatted all the tests and added a CI step to make sure they stay formatted.

Reviewing just the first commit to review the `.stderr` changes might be good, as the format mucks it up hardcore and makes it difficult to see what changed.