### PR TITLE
default.nix: replace `stdenv.lib` with `lib` to silence warning.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ in with pkgs; stdenv.mkDerivation rec {
   ];
 
   # Runtime dependencies.
-  LD_LIBRARY_PATH = with xlibs; stdenv.lib.makeLibraryPath [
+  LD_LIBRARY_PATH = with xlibs; lib.makeLibraryPath [
     libX11 libXcursor libXi libXrandr vulkan-loader
   ];
 }


### PR DESCRIPTION
The warning in question:
> trace: Warning: `stdenv.lib` is deprecated and will be removed in the next release. Please use `lib` instead. For more information see https://github.com/NixOS/nixpkgs/issues/108938