### PR TITLE
Avoid ever building rustc_codegen_spirv more than once in release mode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,10 @@ name = "rustc_codegen_spirv"
 version = "0.4.0-alpha.2"
 dependencies = [
  "bimap",
+ "hashbrown",
  "indexmap",
+ "libc",
+ "num-traits",
  "pipe",
  "pretty_assertions",
  "rspirv",
@@ -2111,6 +2114,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "spirv-tools",
+ "syn",
  "tar",
  "tempfile",
  "topological-sort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,12 @@ members = [
 opt-level = 3
 codegen-units = 16
 
+# HACK(eddyb) this is the default but without explicitly specifying it, Cargo
+# will treat the identical settings in `[profile.release.build-override]` above
+# as different sets of `rustc` flags and will not reuse artifacts between them.
+[profile.release]
+codegen-units = 16
+
 [patch.crates-io]
 spirv-std = { path = "./crates/spirv-std" }
 spirv-std-macros = { path = "./crates/spirv-std-macros" }

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -27,6 +27,14 @@ use-installed-tools = ["spirv-tools/use-installed-tools"]
 use-compiled-tools = ["spirv-tools/use-compiled-tools"]
 
 [dependencies]
+# HACK(eddyb) these only exist to unify features across dependency trees,
+# in order to avoid multiple separate instances of `rustc_codegen_spirv`.
+hashbrown = { version = "0.9", features = ["default"] }
+libc = { version = "0.2", features = ["align", "extra_traits"] }
+num-traits = { version = "0.2", features = ["libm"] }
+syn = { version = "1", features = ["visit", "visit-mut"] }
+
+# Normal dependencies.
 bimap = "0.6"
 indexmap = "1.6.0"
 rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "ee1e913" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,13 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 
+# See rustc_codegen_spirv/Cargo.toml for details on these features
+[features]
+default = ["use-compiled-tools"]
+use-installed-tools = ["rustc_codegen_spirv/use-installed-tools"]
+use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
+
 [dependencies]
 compiletest = { version = "0.6.0", package = "compiletest_rs" }
-rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv" }
+rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", default-features = false }
 structopt = "0.3.21"


### PR DESCRIPTION
This PR allows these 3 commands to share the same `rustc_codegen_spirv` build (this also means `spirv-tools-sys` *also* only compiles all the C++ code only once, which can itself take a significant amount of time):
```sh
# Examples (via build dependency).
cargo build --release -p example-runner-wgpu

# Old tests (via direct dependency).
cargo test --release -p spirv-builder

# New tests (also direct dependency, but also implicitly release mode).
cargo compiletest
```

Sadly, I'm not aware of relevant automation (though one could already exist), but here's what I found:
* between regular dependencies and build dependencies, features aren't always unified, and these differed:
  * `syn` (used by `serde_derive` -> `serde` -> `rustc_codegen_spirv`)
  * `libc` (used by `jobserver` -> `cc` -> `spirv-tools-sys` -> `rustc_codegen_spirv`)
  * `hashbrown` (used by `indexmap` -> `rustc_codegen_spirv`)
  * `num_traits` (used by `rspirv` -> `rustc_codegen_spirv`)
* `tests/Cargo.toml` (`cargo compiletest`) didn't have the system of `use-{installed,compiled}-tools` features that `spirv-builder` has, resulting in an extra `--cfg 'feature="default"'` passed when building `rustc_codegen_spirv`
* our `[profile.release.build-override]` contains `codegen-units = 16`, and that *is* the default for release mode *except* the actual default is baked into `rustc`, so Cargo doesn't actually normally pass it in release mode

<hr/>

I'm not really happy with just fixing it right now, we should try to come up with a test for "did we waste time building ~~everything~~ some things twice" (e.g. checking the `target` dir for multiple copies of some crates?).

But I don't even think we build anything (other than `cargo compiletest`) in release mode on CI.
We did try release mode CI in #494, but it took longer and I now think it might be the duplication.
Since we're already running `cargo compiletest` on CI, I suspect that if we land this PR we *should* be able to move to release mode, and see a benefit. In fact I might just test that myself once we have data for this PR itself.