### PR TITLE
Enable incremental for release mode via `[profile.<...>]` overrides.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,20 @@ members = [
     "tests/deps-helper",
 ]
 
-# Compile build-dependencies in release mode with
-# the same settings as regular dependencies.
+# Enable incremental by default in release mode.
+[profile.release]
+incremental = true
+# HACK(eddyb) this is the default but without explicitly specifying it, Cargo
+# will treat the identical settings in `[profile.release.build-override]` below
+# as different sets of `rustc` flags and will not reuse artifacts between them.
+codegen-units = 256
+
+# Compile build-dependencies in release mode with the same settings
+# as regular dependencies (including the incremental enabled above).
 [profile.release.build-override]
 opt-level = 3
-codegen-units = 16
-
-# HACK(eddyb) this is the default but without explicitly specifying it, Cargo
-# will treat the identical settings in `[profile.release.build-override]` above
-# as different sets of `rustc` flags and will not reuse artifacts between them.
-[profile.release]
-codegen-units = 16
+incremental = true
+codegen-units = 256
 
 [patch.crates-io]
 spirv-std = { path = "./crates/spirv-std" }


### PR DESCRIPTION
Timings for `rustc_codegen_spirv` (obtained from `cargo build -p example-runner-wgpu -Z timings=info`, triggering rebuilds each time with `touch crates/rustc_codegen_spirv/src/lib.rs`):

Mode | Unchanged | Small change
---- | --------- | ------------
debug+incremental | 16.5s | 20s
release (*before this PR*) | 23s | -
release+incremental | 3.5s | 12.5s

The reason debug mode is so slow is, AFAIK, linking debuginfo (390MB `.so` in debug mode, vs 12MB in release mode).

I remember talking to @Jasper-Bekkers a while back about debug vs release, and I speculated that with incremental, release mode should be decent for rapid prototyping (and if you're running any tests, it's a huge speedup).

Seems like the data supports my hunch, but 23 seconds for release mode before this PR is already faster than I thought, so there's less of a huge benefit (though maybe on other systems it may be more pronounced?).