### PR TITLE
Add validation test for DST `StorageBuffer` + `#[spirv(block)]`.

### DIFF
--- a/tests/ui/storage_class/push_constant.rs
+++ b/tests/ui/storage_class/push_constant.rs
@@ -1,4 +1,5 @@
-// Test that using push constants work.
+// Test that using push constants passes (Vulkan) validation.
+
 // build-pass
 use spirv_std as _;
 

--- a/tests/ui/storage_class/storage_buffer-dst.rs
+++ b/tests/ui/storage_class/storage_buffer-dst.rs
@@ -1,0 +1,16 @@
+// Test that using DST (i.e. slice) storage buffers passes (Vulkan) validation.
+
+// build-pass
+use spirv_std as _;
+
+// `Block` decoration is required for storage buffers when compiling for Vulkan.
+#[cfg_attr(not(target_env = "unknown"), spirv(block))]
+pub struct SliceF32 {
+    rta: [f32],
+}
+
+#[spirv(fragment)]
+pub fn main(#[spirv(storage_buffer, descriptor_set = 0, binding = 0)] slice: &mut SliceF32) {
+    let float: f32 = slice.rta[0];
+    let _ = float;
+}


### PR DESCRIPTION
Ideally we'd be testing `Uniform`s instead of `StorageBuffer`s but the former need `BufferBlock` *not* `Block` when used with DSTs (i.e. `OpTypeRuntimeArray`). AFAICT, `#[spirv(block)]` needs to be replaced with some deduction and `OpTypeStruct`-wrapping logic if we want to support both.