### PR TITLE
`#[spirv(uniform)]` is actually immutable in the absence of `BufferBlock`.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -246,6 +246,7 @@ impl<'tcx> CodegenCx<'tcx> {
             let expected_mutbl = match storage_class {
                 StorageClass::UniformConstant
                 | StorageClass::Input
+                | StorageClass::Uniform
                 | StorageClass::PushConstant => hir::Mutability::Not,
 
                 _ => hir::Mutability::Mut,

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -463,7 +463,7 @@ fn index_user_dst() {
         r#"
 #[spirv(fragment)]
 pub fn main(
-    #[spirv(uniform, descriptor_set = 0, binding = 0)] slice: &mut SliceF32,
+    #[spirv(uniform, descriptor_set = 0, binding = 0)] slice: &SliceF32,
 ) {
     let float: f32 = slice.rta[0];
     let _ = float;


### PR DESCRIPTION
The Vulkan spec [has a nice "correspondence" table](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#interfaces-resources-storage-class-correspondence), and it includes this:
Resource type | Storage Class | Decoration
-- | -- | --
uniform buffer | `Uniform` | `Block`
storage buffer | `Uniform` | `BufferBlock`
storage buffer | `StorageBuffer` | `Block`

What this is saying, roughly, is that `Uniform`+`BufferBlock` is another way of saying `StorageBuffer`+`Block` (and specifically the old, deprecated way, before `StorageBuffer` was added to SPIR-V as a Storage Class).

Per the Vulkan spec [elsewhere](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#descriptorsets-storagebuffer), we have these descriptions:
* **Storage Buffer**: "... that load, store, and atomic operations **can** be performed on"
* **Uniform Buffer**: "... that load operations **can** be performed on"

Based on this, I believe that `Uniform` having been used to represent `StorageBuffer` before the latter was a thing, is the *only* reason SPIR-V doesn't say `Uniform` is read-only.

And if we never allow `Uniform`+`BufferBlock` (i.e. we require `StorageBuffer`+`Block` to be used instead), then we can just require `Uniform` to be read-only.