### PR TITLE
structurizer: split regions into `Divergent` vs `Convergent`, and optimize based on that.

### DIFF
--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -16,6 +16,7 @@
 //! [`spirv-tools`]: https://embarkstudios.github.io/rust-gpu/api/spirv_tools
 //! [`spirv-tools-sys`]: https://embarkstudios.github.io/rust-gpu/api/spirv_tools_sys
 #![feature(rustc_private)]
+#![feature(assert_matches)]
 #![feature(once_cell)]
 // BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -233,28 +233,26 @@ OpBranch %8
 %8 = OpLabel
 %9 = OpPhi %10 %11 %7 %12 %13
 %14 = OpPhi %2 %4 %7 %15 %13
-%16 = OpPhi %17 %18 %7 %19 %13
-OpLoopMerge %20 %13 Unroll
-OpBranchConditional %16 %21 %20
-%21 = OpLabel
-%22 = OpSLessThan %17 %9 %23
-OpSelectionMerge %24 None
-OpBranchConditional %22 %25 %26
-%25 = OpLabel
-%27 = OpIMul %2 %28 %14
-%29 = OpIAdd %2 %27 %5
-%30 = OpIAdd %10 %9 %31
-OpBranch %24
-%26 = OpLabel
-OpReturnValue %14
+OpLoopMerge %16 %13 Unroll
+OpBranchConditional %17 %18 %16
+%18 = OpLabel
+%19 = OpSLessThan %20 %9 %21
+OpSelectionMerge %22 None
+OpBranchConditional %19 %23 %24
+%23 = OpLabel
+%25 = OpIMul %2 %26 %14
+%27 = OpIAdd %2 %25 %5
+%28 = OpIAdd %10 %9 %29
+OpBranch %22
 %24 = OpLabel
-%12 = OpPhi %10 %30 %25
-%15 = OpPhi %2 %29 %25
-%19 = OpPhi %17 %18 %25
+OpReturnValue %14
+%22 = OpLabel
+%12 = OpPhi %10 %28 %23
+%15 = OpPhi %2 %27 %23
 OpBranch %13
 %13 = OpLabel
 OpBranch %8
-%20 = OpLabel
+%16 = OpLabel
 OpUnreachable
 OpFunctionEnd"#,
     );
@@ -493,14 +491,13 @@ OpBranch %25
 %25 = OpLabel
 OpBranch %26
 %26 = OpLabel
-%27 = OpPhi %16 %28 %25 %28 %29
-OpLoopMerge %30 %29 None
-OpBranchConditional %27 %31 %30
-%31 = OpLabel
-OpBranch %29
-%29 = OpLabel
-OpBranch %26
+OpLoopMerge %27 %28 None
+OpBranchConditional %29 %30 %27
 %30 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %26
+%27 = OpLabel
 OpUnreachable
 %17 = OpLabel
 OpUnreachable


### PR DESCRIPTION
The first commit is a pretty large refactor that ended up a bit worse than I expected.
We might just want to have this instead (and call it in a few places):
```rust
impl Region {
    fn diverges(&self) -> bool {
        self.exits.is_empty()
    }
}
```

The second commit is just an on-the-fly `OpPhi` simplification that we should probably merge completely separately.

And the third commit is "clever hack" (to remove some unnecessary empty blocks, see example below) that could also probably be done without the first commit, it just didn't hit me that it was possible before the refactor.

<details>
<summary>(click to open example code & before/after graphs for the third commit)</summary>

```rust
pub fn marker() {}

pub fn shortcircuit_and(a: bool, b: bool) {
    if a && b {
        marker();
    }
}
```

### Before
[![](http://build.lyken.rs/~eddy/tmp/rFdU/_.svg)](http://build.lyken.rs/~eddy/tmp/rFdU/_.svg)

### After
[![](http://build.lyken.rs/~eddy/tmp/8dZP/_.svg)](http://build.lyken.rs/~eddy/tmp/8dZP/_.svg)

</details>