### PR TITLE
Deprecate `#[spirv(block)]` and auto-wrap in "interface blocks" instead.

### DIFF
--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -367,6 +367,16 @@ impl CheckSpirvAttrVisitor<'_> {
                 },
             }
         }
+
+        // At this point we have all of the attributes (valid for this target),
+        // so we can perform further checks, emit warnings, etc.
+
+        if let Some(block_attr) = aggregated_attrs.block {
+            self.tcx.sess.span_warn(
+                block_attr.span,
+                "#[spirv(block)] is no longer needed and should be removed",
+            );
+        }
     }
 }
 

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -232,6 +232,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             SpirvType::Image { .. } => self.fatal("cannot memset image"),
             SpirvType::Sampler => self.fatal("cannot memset sampler"),
             SpirvType::SampledImage { .. } => self.fatal("cannot memset sampled image"),
+            SpirvType::InterfaceBlock { .. } => self.fatal("cannot memset interface block"),
         }
     }
 
@@ -288,6 +289,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             SpirvType::Image { .. } => self.fatal("cannot memset image"),
             SpirvType::Sampler => self.fatal("cannot memset sampler"),
             SpirvType::SampledImage { .. } => self.fatal("cannot memset sampled image"),
+            SpirvType::InterfaceBlock { .. } => self.fatal("cannot memset interface block"),
         }
     }
 
@@ -1041,6 +1043,10 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             SpirvType::Array { element, .. }
             | SpirvType::RuntimeArray { element, .. }
             | SpirvType::Vector { element, .. } => element,
+            SpirvType::InterfaceBlock { inner_type } => {
+                assert_eq!(idx, 0);
+                inner_type
+            }
             other => self.fatal(&format!(
                 "struct_gep not on struct, array, or vector type: {:?}, index {}",
                 other, idx

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -180,7 +180,6 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
             field_types,
             field_offsets,
             field_names: None,
-            is_block: false,
         }
         .def(DUMMY_SP, self);
         self.constant_composite(struct_ty, elts.iter().map(|f| f.def_cx(self)).collect())
@@ -524,6 +523,10 @@ impl<'tcx> CodegenCx<'tcx> {
                 .tcx
                 .sess
                 .fatal("Cannot create a constant sampled image value"),
+            SpirvType::InterfaceBlock { .. } => self
+                .tcx
+                .sess
+                .fatal("Cannot create a constant interface block value"),
         }
     }
 }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -149,7 +149,6 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             field_types: els.to_vec(),
             field_offsets,
             field_names: None,
-            is_block: false,
         }
         .def(DUMMY_SP, self)
     }
@@ -167,16 +166,18 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
                     .sess
                     .fatal(&format!("Invalid float width in type_kind: {}", other)),
             },
-            SpirvType::Adt { .. } | SpirvType::Opaque { .. } => TypeKind::Struct,
+            SpirvType::Adt { .. } | SpirvType::Opaque { .. } | SpirvType::InterfaceBlock { .. } => {
+                TypeKind::Struct
+            }
             SpirvType::Vector { .. } => TypeKind::Vector,
             SpirvType::Array { .. } | SpirvType::RuntimeArray { .. } => TypeKind::Array,
             SpirvType::Pointer { .. } => TypeKind::Pointer,
             SpirvType::Function { .. } => TypeKind::Function,
             // HACK(eddyb) this is probably the closest `TypeKind` (which is still
             // very much LLVM-specific, sadly) has to offer to "resource handle".
-            SpirvType::Image { .. } |
-            SpirvType::Sampler |
-            SpirvType::SampledImage { .. } => TypeKind::Token,
+            SpirvType::Image { .. } | SpirvType::Sampler | SpirvType::SampledImage { .. } => {
+                TypeKind::Token
+            }
         }
     }
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type {

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -16,6 +16,7 @@
 //! [`spirv-tools`]: https://embarkstudios.github.io/rust-gpu/api/spirv_tools
 //! [`spirv-tools-sys`]: https://embarkstudios.github.io/rust-gpu/api/spirv_tools_sys
 #![feature(rustc_private)]
+#![feature(assert_matches)]
 #![feature(once_cell)]
 // BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -95,9 +95,8 @@ extern crate rustc_target;
 
 macro_rules! assert_ty_eq {
     ($codegen_cx:expr, $left:expr, $right:expr) => {
-        assert_eq!(
-            $left,
-            $right,
+        assert!(
+            $left == $right,
             "Expected types to be equal:\n{}\n==\n{}",
             $codegen_cx.debug_type($left),
             $codegen_cx.debug_type($right)

--- a/crates/spirv-builder/src/test/basic.rs
+++ b/crates/spirv-builder/src/test/basic.rs
@@ -461,44 +461,39 @@ fn index_user_dst() {
         r#"
 #[spirv(fragment)]
 pub fn main(
-    #[spirv(uniform, descriptor_set = 0, binding = 0)] slice: &SliceF32,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] slice: &mut [f32],
 ) {
-    let float: f32 = slice.rta[0];
+    let float: f32 = slice[0];
     let _ = float;
-}
-
-pub struct SliceF32 {
-    rta: [f32],
 }
         "#,
         "main",
         r#"%1 = OpFunction %2 None %3
 %4 = OpLabel
-%5 = OpArrayLength %6 %7 0
-%8 = OpCompositeInsert %9 %7 %10 0
-%11 = OpCompositeInsert %9 %5 %8 1
-%12 = OpAccessChain %13 %7 %14
-%15 = OpULessThan %16 %14 %5
+%5 = OpAccessChain %6 %7 %8
+%9 = OpArrayLength %10 %7 0
+%11 = OpCompositeInsert %12 %5 %13 0
+%14 = OpCompositeInsert %12 %9 %11 1
+%15 = OpULessThan %16 %8 %9
 OpSelectionMerge %17 None
 OpBranchConditional %15 %18 %19
 %18 = OpLabel
-%20 = OpAccessChain %13 %7 %14
-%21 = OpInBoundsAccessChain %22 %20 %14
-%23 = OpLoad %24 %21
+%20 = OpInBoundsAccessChain %21 %5 %8
+%22 = OpLoad %23 %20
 OpReturn
 %19 = OpLabel
+OpBranch %24
+%24 = OpLabel
 OpBranch %25
 %25 = OpLabel
-OpBranch %26
-%26 = OpLabel
-%27 = OpPhi %16 %28 %25 %28 %29
-OpLoopMerge %30 %29 None
-OpBranchConditional %27 %31 %30
-%31 = OpLabel
-OpBranch %29
-%29 = OpLabel
-OpBranch %26
+%26 = OpPhi %16 %27 %24 %27 %28
+OpLoopMerge %29 %28 None
+OpBranchConditional %26 %30 %29
 %30 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %25
+%29 = OpLabel
 OpUnreachable
 %17 = OpLabel
 OpUnreachable

--- a/crates/spirv-std/src/arch/barrier.rs
+++ b/crates/spirv-std/src/arch/barrier.rs
@@ -65,13 +65,14 @@ pub unsafe fn control_barrier<
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpMemoryBarrier")]
 #[inline]
-pub unsafe fn memory_barrier<const MEMORY: Scope, const SEMANTICS: Semantics>() {
+// FIXME(eddyb) use a `bitflags!` `Semantics` for `SEMANTICS`.
+pub unsafe fn memory_barrier<const MEMORY: Scope, const SEMANTICS: u32>() {
     asm! {
         "%u32 = OpTypeInt 32 0",
         "%memory = OpConstant %u32 {memory}",
         "%semantics = OpConstant %u32 {semantics}",
         "OpMemoryBarrier %memory %semantics",
         memory = const MEMORY as u8,
-        semantics = const SEMANTICS as u8,
+        semantics = const SEMANTICS,
     }
 }

--- a/crates/spirv-std/src/memory.rs
+++ b/crates/spirv-std/src/memory.rs
@@ -21,6 +21,7 @@ pub enum Scope {
     QueueFamily = 5,
 }
 
+// FIXME(eddyb) use `bitflags!` for this.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Semantics {
     /// No memory semantics.

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -68,24 +68,6 @@ fn main(
 
 Both descriptor_set and binding take an integer argument that specifies the uniform's index.
 
-## Block
-
-This attribute is a temporary quick fix before we implement a more fully-featured binding model. If you get validation errors about missing a Block decoration on a struct due to being used as uniform block data, try adding this attribute to the struct definition. If you get errors around the struct definition not being an aggregate, but rather the type of the field, try adding `#[repr(C)]` to the struct definition.
-
-Example:
-
-```rust
-#[spirv(block)]
-struct Thing {
-    a: Vec4,
-    b: Vec4,
-    c: Vec4,
-}
-
-#[spirv(fragment)]
-fn main(#[spirv(push_constant)] obj: &ShaderConstants) { }
-```
-
 ## Flat
 
 The flat attribute corresponds to the flat keyword in glsl - in other words, the data is not interpolated across the triangle when invoking the fragment shader.

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -1,15 +1,6 @@
 //! Ported to Rust from <https://github.com/Tw1ddle/Sky-Shader/blob/master/src/shaders/glsl/sky.fragment>
 
-#![cfg_attr(
-    target_arch = "spirv",
-    no_std,
-    feature(register_attr, lang_items),
-    register_attr(spirv)
-)]
-
-#[cfg(not(target_arch = "spirv"))]
-#[macro_use]
-pub extern crate spirv_std_macros;
+#![cfg_attr(target_arch = "spirv", no_std, feature(lang_items))]
 
 use core::f32::consts::PI;
 use glam::{vec3, Vec3};
@@ -21,7 +12,6 @@ pub use glam;
 #[cfg(target_arch = "spirv")]
 use spirv_std::num_traits::Float;
 
-#[spirv(block)]
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct ShaderConstants {

--- a/tests/ui/arch/control_barrier.rs
+++ b/tests/ui/arch/control_barrier.rs
@@ -9,8 +9,8 @@ use spirv_std::memory::{Scope, Semantics};
 pub fn main() {
     unsafe {
         spirv_std::arch::control_barrier::<
-            { Scope::Workgroup },
-            { Scope::Workgroup },
+            { Scope::Subgroup },
+            { Scope::Subgroup },
             { Semantics::None },
         >();
     }

--- a/tests/ui/arch/memory_barrier.rs
+++ b/tests/ui/arch/memory_barrier.rs
@@ -9,8 +9,8 @@ use spirv_std::memory::{Scope, Semantics};
 pub fn main() {
     unsafe {
         spirv_std::arch::memory_barrier::<
-            { Scope::Workgroup },
-            { Semantics::None },
+            { Scope::Subgroup },
+            { (Semantics::AcquireRelease as u32) | (Semantics::UniformMemory as u32) },
         >();
     }
 }

--- a/tests/ui/image/issue_527.rs
+++ b/tests/ui/image/issue_527.rs
@@ -1,21 +1,16 @@
 use glam::*;
 
-#[spirv(block)]
-pub struct PointsBuffer {
-    points: [UVec2; 100],
-}
-
 #[spirv(compute(threads(1)))]
 pub fn main_cs(
     #[spirv(global_invocation_id)] id: UVec3,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] points_buffer: &mut PointsBuffer,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] points_buffer: &mut [UVec2; 100],
     #[spirv(descriptor_set = 1, binding = 1)] image: &spirv_std::StorageImage2d,
 ) {
     unsafe { asm!("OpCapability StorageImageWriteWithoutFormat") };
     let position = id.xy();
     for i in 0..100usize {
-        let p0 = &points_buffer.points[i];
-        let p1 = &points_buffer.points[i + 1];
+        let p0 = &points_buffer[i];
+        let p1 = &points_buffer[i + 1];
         if p0.x == position.x && p1.y == position.y {
             unsafe {
                 image.write(position, vec2(1.0, 0.0));

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -2,7 +2,7 @@ error: pointer has non-null integer address
   |
   = note: Stack:
           allocate_const_scalar::main
-          Unnamed function ID %5
+          Unnamed function ID %4
 
 error: invalid binary:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |

--- a/tests/ui/spirv-attr/bad-infer-storage-class.stderr
+++ b/tests/ui/spirv-attr/bad-infer-storage-class.stderr
@@ -1,10 +1,13 @@
-error: storage class UniformConstant was inferred from type, but Uniform was specified in attribute
+error: storage class mismatch
  --> $DIR/bad-infer-storage-class.rs:7:13
   |
 7 | pub fn main(#[spirv(uniform)] error: &Image2d, #[spirv(uniform_constant)] warning: &Image2d) {}
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |             ^^^^^^^^-------^^^^^^^^^^--------
+  |                     |                |
+  |                     |                UniformConstant inferred from type
+  |                     Uniform specified in attribute
   |
-note: remove storage class attribute to use UniformConstant as storage class
+help: remove storage class attribute to use UniformConstant as storage class
  --> $DIR/bad-infer-storage-class.rs:7:21
   |
 7 | pub fn main(#[spirv(uniform)] error: &Image2d, #[spirv(uniform_constant)] warning: &Image2d) {}

--- a/tests/ui/spirv-attr/multiple.stderr
+++ b/tests/ui/spirv-attr/multiple.stderr
@@ -40,6 +40,12 @@ note: previous #[spirv(block)] attribute
 24 | #[spirv(block, block)]
    |         ^^^^^
 
+warning: #[spirv(block)] is no longer needed and should be removed
+  --> $DIR/multiple.rs:24:9
+   |
+24 | #[spirv(block, block)]
+   |         ^^^^^
+
 error: only one entry-point attribute is allowed on a function
   --> $DIR/multiple.rs:27:17
    |
@@ -196,5 +202,5 @@ note: previous #[spirv(unroll_loops)] attribute
 53 | #[spirv(unroll_loops, unroll_loops)]
    |         ^^^^^^^^^^^^
 
-error: aborting due to 16 previous errors
+error: aborting due to 16 previous errors; 1 warning emitted
 

--- a/tests/ui/storage_class/push_constant.rs
+++ b/tests/ui/storage_class/push_constant.rs
@@ -4,8 +4,6 @@
 use spirv_std as _;
 
 #[derive(Copy, Clone)]
-// `Block` decoration is required for push constants when compiling for Vulkan.
-#[cfg_attr(not(target_env = "unknown"), spirv(block))]
 pub struct ShaderConstants {
     pub width: u32,
     pub height: u32,

--- a/tests/ui/storage_class/storage_buffer-dst.rs
+++ b/tests/ui/storage_class/storage_buffer-dst.rs
@@ -3,14 +3,8 @@
 // build-pass
 use spirv_std as _;
 
-// `Block` decoration is required for storage buffers when compiling for Vulkan.
-#[cfg_attr(not(target_env = "unknown"), spirv(block))]
-pub struct SliceF32 {
-    rta: [f32],
-}
-
 #[spirv(fragment)]
-pub fn main(#[spirv(storage_buffer, descriptor_set = 0, binding = 0)] slice: &mut SliceF32) {
-    let float: f32 = slice.rta[0];
+pub fn main(#[spirv(storage_buffer, descriptor_set = 0, binding = 0)] slice: &mut [f32]) {
+    let float: f32 = slice[0];
     let _ = float;
 }


### PR DESCRIPTION
As per [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#interfaces-resources) and [OpenGL](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_gl_spirv.txt) requirements:
* `PushConstant`, `Uniform` and `StorageBufer` interface variables *must* have a `Block`-decorated `OpTypeStruct` type
  * this "struct" type is called an "interface block" and serves mostly as a grouping construct
  * as per https://github.com/EmbarkStudios/rust-gpu/issues/391#issuecomment-813090156, having a `struct` (with some fields) inside an "interface block" shouldn't differ from having those same fields in the "interface block" itself
  * after this PR, we automatically generate a single-field "interface block" for these storage classes, instead of requiring the user to declare a `struct` and annotate it with `#[spirv(block)]`
* `Input`/`Output` can also use "interface blocks", but it's not mandatory
  * we'd probably want to think a bit more about this once/if we have usecases in mind

Most of the commits in this PR are small refactors, leading up to the last commit, which is the actual change.

Because of `#[spirv(block)]` being deprecated instead of outright removed, this isn't a breaking change, except for slices, where you have to remove the `struct` wrapping the `[T]` that you previously had to add - it's now just:
```rust
#[spirv(storage_buffer, descriptor_set = 0, binding = 0)] slice: &mut [f32],
```

The auto-generated "interface block" also allows simpler uniforms like this to "just work":
```rust
#[spirv(uniform, descriptor_set = 1, binding = 0)] u_view_proj: &Mat4,
```

Closes #391.

**EDIT**: temporarily rebased on top of #577 to unbreak CI.