### PR TITLE
Unbreak CI (fix control_barrier and memory_barrier tests).

### DIFF
--- a/crates/spirv-std/src/arch/barrier.rs
+++ b/crates/spirv-std/src/arch/barrier.rs
@@ -65,13 +65,14 @@ pub unsafe fn control_barrier<
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpMemoryBarrier")]
 #[inline]
-pub unsafe fn memory_barrier<const MEMORY: Scope, const SEMANTICS: Semantics>() {
+// FIXME(eddyb) use a `bitflags!` `Semantics` for `SEMANTICS`.
+pub unsafe fn memory_barrier<const MEMORY: Scope, const SEMANTICS: u32>() {
     asm! {
         "%u32 = OpTypeInt 32 0",
         "%memory = OpConstant %u32 {memory}",
         "%semantics = OpConstant %u32 {semantics}",
         "OpMemoryBarrier %memory %semantics",
         memory = const MEMORY as u8,
-        semantics = const SEMANTICS as u8,
+        semantics = const SEMANTICS,
     }
 }

--- a/crates/spirv-std/src/memory.rs
+++ b/crates/spirv-std/src/memory.rs
@@ -21,6 +21,7 @@ pub enum Scope {
     QueueFamily = 5,
 }
 
+// FIXME(eddyb) use `bitflags!` for this.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Semantics {
     /// No memory semantics.

--- a/tests/ui/arch/control_barrier.rs
+++ b/tests/ui/arch/control_barrier.rs
@@ -9,8 +9,8 @@ use spirv_std::memory::{Scope, Semantics};
 pub fn main() {
     unsafe {
         spirv_std::arch::control_barrier::<
-            { Scope::Workgroup },
-            { Scope::Workgroup },
+            { Scope::Subgroup },
+            { Scope::Subgroup },
             { Semantics::None },
         >();
     }

--- a/tests/ui/arch/memory_barrier.rs
+++ b/tests/ui/arch/memory_barrier.rs
@@ -9,8 +9,8 @@ use spirv_std::memory::{Scope, Semantics};
 pub fn main() {
     unsafe {
         spirv_std::arch::memory_barrier::<
-            { Scope::Workgroup },
-            { Semantics::None },
+            { Scope::Subgroup },
+            { (Semantics::AcquireRelease as u32) | (Semantics::UniformMemory as u32) },
         >();
     }
 }


### PR DESCRIPTION
#519 was landed with a stale (2 week old at this point) CI, predating the introduction of Vulkan validation on CI, and now `main` itself doesn't pass CI anymore.

I don't like my `Semantics` bodge, but it being a bitset means using `enum` is just wrong.

I could've switched it to `bitflags!` but it seemed easier to just work around it for now.