### PR TITLE
Address review comments on #576 (Deprecate #[spirv(block)] and auto-wrap in "interface blocks" instead).

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -134,7 +134,7 @@ impl<'tcx> CodegenCx<'tcx> {
             .iter()
             .zip(hir_params)
             .map(|(entry_fn_arg, hir_param)| {
-                self.declare_interface_global_for_param(
+                self.declare_shader_interface_for_param(
                     entry_fn_arg.layout,
                     hir_param,
                     &mut op_entry_point_interface_operands,
@@ -334,7 +334,7 @@ impl<'tcx> CodegenCx<'tcx> {
         (spirv_ty, storage_class)
     }
 
-    fn declare_interface_global_for_param(
+    fn declare_shader_interface_for_param(
         &self,
         layout: TyAndLayout<'tcx>,
         hir_param: &hir::Param<'tcx>,

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -518,7 +518,7 @@ impl fmt::Debug for SpirvTypePrinter<'_, '_> {
                 .finish(),
 
             SpirvType::InterfaceBlock { inner_type } => f
-                .debug_struct("SampledImage")
+                .debug_struct("InterfaceBlock")
                 .field("id", &self.id)
                 .field("inner_type", &self.cx.debug_type(inner_type))
                 .finish(),


### PR DESCRIPTION
(This is needed because #576 got merged before all the reviews could be done)

Same as last time, most of the commits are small(er) refactors. The last one consolidates all the logic to do with adjusting the global interface `OpVariable` pointer to match the entry `fn` call argument, into `declare_shader_interface_for_param`, instead of being nested in some closure in `shader_entry_stub`.