### PR TITLE
Remove memcmp from spirv-std

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -247,8 +247,8 @@ fn invoke_rustc(builder: &SpirvBuilder, multimodule: bool) -> Result<PathBuf, Sp
     cargo.args(&[
         "build",
         "--message-format=json-render-diagnostics",
-        "-Z",
-        "build-std=core",
+        "-Zbuild-std=core",
+        "-Zbuild-std-features=compiler-builtins-mem",
         "--target",
         "spirv-unknown-unknown",
     ]);

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -115,24 +115,3 @@ fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[lang = "eh_personality"]
 extern "C" fn rust_eh_personality() {}
-
-/// libcore requires a few external symbols to be defined:
-/// <https://github.com/rust-lang/rust/blob/c2bc344eb23d8c1d18e803b3f1e631cf99926fbb/library/core/src/lib.rs#L23-L27>
-/// TODO: This is copied from `compiler_builtins/mem.rs`. Can we use that one instead? The note in the above link says
-/// "[the symbols] can also be provided by the compiler-builtins crate". The memcpy in `compiler_builtins` is behind a
-/// "mem" feature flag - can we enable that somehow?
-/// <https://github.com/rust-lang/compiler-builtins/blob/eff506cd49b637f1ab5931625a33cef7e91fbbf6/src/mem.rs#L12-L13>
-#[allow(clippy::missing_safety_doc)]
-#[no_mangle]
-pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
-    let mut i = 0;
-    while i < n {
-        let a = *s1.add(i);
-        let b = *s2.add(i);
-        if a != b {
-            return a as i32 - b as i32;
-        }
-        i += 1;
-    }
-    0
-}

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -174,6 +174,7 @@ fn build_deps(deps_target_dir: &Path, codegen_backend_path: &Path, target: &str)
             "-p",
             "compiletests-deps-helper",
             "-Zbuild-std=core",
+            "-Zbuild-std-features=compiler-builtins-mem",
             &*format!("--target={}", target),
         ])
         .arg("--target-dir")


### PR DESCRIPTION
Ran into issues when building with conflicting symbols when building spirv-std for other non SPIR-V platforms.