### PR TITLE
rustc_codegen_spirv: use `FxHash{Map,Set}` instead of the std ones.

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -5,6 +5,7 @@ use crate::attr::{AggregatedSpirvAttributes, IntrinsicType};
 use crate::codegen_cx::CodegenCx;
 use crate::spirv_type::SpirvType;
 use rspirv::spirv::{Capability, StorageClass, Word};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::ErrorReported;
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{FnAbiExt, TyAndLayout};
@@ -18,7 +19,6 @@ use rustc_target::abi::{
 };
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::fmt;
 
 /// If a struct contains a pointer to itself, even indirectly, then doing a naiive recursive walk
@@ -28,7 +28,7 @@ use std::fmt;
 /// tracking.
 #[derive(Default)]
 pub struct RecursivePointeeCache<'tcx> {
-    map: RefCell<HashMap<PointeeTy<'tcx>, PointeeDefState>>,
+    map: RefCell<FxHashMap<PointeeTy<'tcx>, PointeeDefState>>,
 }
 
 impl<'tcx> RecursivePointeeCache<'tcx> {

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -12,14 +12,14 @@ use rspirv::spirv::{
 use rustc_ast::ast::{InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::traits::{AsmBuilderMethods, InlineAsmOperandRef};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::LlvmInlineAsmInner;
 use rustc_middle::bug;
 use rustc_span::source_map::Span;
 use rustc_target::asm::{InlineAsmRegClass, InlineAsmRegOrRegClass, SpirVInlineAsmRegClass};
-use std::collections::{HashMap, HashSet};
 
 pub struct InstructionTable {
-    table: HashMap<&'static str, &'static rspirv::grammar::Instruction<'static>>,
+    table: FxHashMap<&'static str, &'static rspirv::grammar::Instruction<'static>>,
 }
 
 impl InstructionTable {
@@ -133,9 +133,9 @@ impl<'a, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'tcx> {
             }
         }
 
-        let mut id_map = HashMap::new();
-        let mut defined_ids = HashSet::new();
-        let mut id_to_type_map = HashMap::new();
+        let mut id_map = FxHashMap::default();
+        let mut defined_ids = FxHashSet::default();
+        let mut id_to_type_map = FxHashMap::default();
         for operand in operands {
             if let InlineAsmOperandRef::In { reg: _, value } = operand {
                 let value = value.immediate();
@@ -241,8 +241,8 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
     fn insert_inst(
         &mut self,
-        id_map: &mut HashMap<&str, Word>,
-        defined_ids: &mut HashSet<Word>,
+        id_map: &mut FxHashMap<&str, Word>,
+        defined_ids: &mut FxHashSet<Word>,
         inst: dr::Instruction,
     ) {
         // Types declared must be registered in our type system.
@@ -339,9 +339,9 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
     fn codegen_asm<'a>(
         &mut self,
-        id_map: &mut HashMap<&'a str, Word>,
-        defined_ids: &mut HashSet<Word>,
-        id_to_type_map: &mut HashMap<Word, Word>,
+        id_map: &mut FxHashMap<&'a str, Word>,
+        defined_ids: &mut FxHashSet<Word>,
+        id_to_type_map: &mut FxHashMap<Word, Word>,
         mut tokens: impl Iterator<Item = Token<'a, 'cx, 'tcx>>,
     ) where
         'cx: 'a,
@@ -433,8 +433,8 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
     fn parse_operands<'a>(
         &mut self,
-        id_map: &mut HashMap<&'a str, Word>,
-        id_to_type_map: &HashMap<Word, Word>,
+        id_map: &mut FxHashMap<&'a str, Word>,
+        id_to_type_map: &FxHashMap<Word, Word>,
         mut tokens: impl Iterator<Item = Token<'a, 'cx, 'tcx>>,
         instruction: &mut dr::Instruction,
     ) where
@@ -537,7 +537,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
     fn infer_result_type(
         &self,
-        id_to_type_map: &HashMap<Word, Word>,
+        id_to_type_map: &FxHashMap<Word, Word>,
         instruction: &dr::Instruction,
     ) -> Option<Word> {
         use crate::spirv_type_constraints::{instruction_signatures, InstSig, TyListPat, TyPat};
@@ -673,8 +673,8 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
     fn parse_id_out<'a>(
         &mut self,
-        id_map: &mut HashMap<&'a str, Word>,
-        defined_ids: &mut HashSet<Word>,
+        id_map: &mut FxHashMap<&'a str, Word>,
+        defined_ids: &mut FxHashSet<Word>,
         token: Token<'a, 'cx, 'tcx>,
     ) -> Option<OutRegister<'a>> {
         match token {
@@ -762,7 +762,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
     fn parse_id_in<'a>(
         &mut self,
-        id_map: &mut HashMap<&'a str, Word>,
+        id_map: &mut FxHashMap<&'a str, Word>,
         token: Token<'a, 'cx, 'tcx>,
     ) -> Option<Word> {
         match token {
@@ -904,7 +904,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
     fn parse_one_operand<'a>(
         &mut self,
-        id_map: &mut HashMap<&'a str, Word>,
+        id_map: &mut FxHashMap<&'a str, Word>,
         inst: &mut dr::Instruction,
         kind: OperandKind,
         tokens: &mut impl Iterator<Item = Token<'a, 'cx, 'tcx>>,

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -7,6 +7,7 @@ use crate::spirv_type::SpirvType;
 use rspirv::dr::Operand;
 use rspirv::spirv::{Decoration, ExecutionModel, FunctionControl, StorageClass, Word};
 use rustc_codegen_ssa::traits::{BaseTypeMethods, BuilderMethods};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::ty::{Instance, Ty, TyKind};
@@ -15,7 +16,6 @@ use rustc_target::abi::{
     call::{ArgAbi, ArgAttribute, ArgAttributes, FnAbi, PassMode},
     LayoutOf, Size,
 };
-use std::collections::HashMap;
 
 impl<'tcx> CodegenCx<'tcx> {
     // Entry points declare their "interface" (all uniforms, inputs, outputs, etc.) as parameters.
@@ -132,7 +132,7 @@ impl<'tcx> CodegenCx<'tcx> {
 
         let mut bx = Builder::new_block(self, stub_fn, "");
         let mut call_args = vec![];
-        let mut decoration_locations = HashMap::new();
+        let mut decoration_locations = FxHashMap::default();
         for (entry_arg_abi, hir_param) in arg_abis.iter().zip(hir_params) {
             bx.set_span(hir_param.span);
             self.declare_shader_interface_for_param(
@@ -262,7 +262,7 @@ impl<'tcx> CodegenCx<'tcx> {
         op_entry_point_interface_operands: &mut Vec<Word>,
         bx: &mut Builder<'_, 'tcx>,
         call_args: &mut Vec<SpirvValue>,
-        decoration_locations: &mut HashMap<StorageClass, u32>,
+        decoration_locations: &mut FxHashMap<StorageClass, u32>,
     ) {
         let attrs = AggregatedSpirvAttributes::parse(self, self.tcx.hir().attrs(hir_param.hir_id));
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -30,7 +30,6 @@ use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::{HasDataLayout, TargetDataLayout};
 use rustc_target::spec::{HasTargetSpec, Target};
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
 use std::iter::once;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -41,9 +40,9 @@ pub struct CodegenCx<'tcx> {
     /// Spir-v module builder
     pub builder: BuilderSpirv,
     /// Map from MIR function to spir-v function ID
-    pub instances: RefCell<HashMap<Instance<'tcx>, SpirvValue>>,
+    pub instances: RefCell<FxHashMap<Instance<'tcx>, SpirvValue>>,
     /// Map from function ID to parameter list
-    pub function_parameter_values: RefCell<HashMap<Word, Vec<SpirvValue>>>,
+    pub function_parameter_values: RefCell<FxHashMap<Word, Vec<SpirvValue>>>,
     pub type_cache: TypeCache<'tcx>,
     /// Cache generated vtables
     pub vtables: RefCell<FxHashMap<(Ty<'tcx>, Option<PolyExistentialTraitRef<'tcx>>), SpirvValue>>,
@@ -51,17 +50,17 @@ pub struct CodegenCx<'tcx> {
     /// Invalid spir-v IDs that should be stripped from the final binary,
     /// each with its own reason and span that should be used for reporting
     /// (in the event that the value is actually needed)
-    zombie_decorations: RefCell<HashMap<Word, ZombieDecoration>>,
+    zombie_decorations: RefCell<FxHashMap<Word, ZombieDecoration>>,
     /// Functions that have `#[spirv(unroll_loops)]`, and therefore should
     /// get `LoopControl::UNROLL` applied to all of their loops' `OpLoopMerge`
     /// instructions, during structuralization.
-    unroll_loops_decorations: RefCell<HashMap<Word, UnrollLoopsDecoration>>,
+    unroll_loops_decorations: RefCell<FxHashMap<Word, UnrollLoopsDecoration>>,
     pub kernel_mode: bool,
     /// Cache of all the builtin symbols we need
     pub sym: Rc<Symbols>,
     pub instruction_table: InstructionTable,
-    pub zombie_undefs_for_system_fn_addrs: RefCell<HashMap<Word, Word>>,
-    pub libm_intrinsics: RefCell<HashMap<Word, super::builder::libm_intrinsics::LibmIntrinsic>>,
+    pub zombie_undefs_for_system_fn_addrs: RefCell<FxHashMap<Word, Word>>,
+    pub libm_intrinsics: RefCell<FxHashMap<Word, super::builder::libm_intrinsics::LibmIntrinsic>>,
 
     /// Simple `panic!("...")` and builtin panics (from MIR `Assert`s) call `#[lang = "panic"]`.
     pub panic_fn_id: Cell<Option<Word>>,

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -2,6 +2,7 @@ use crate::{linker, SpirvCodegenBackend, SpirvModuleBuffer, SpirvThinBuffer};
 use rustc_codegen_ssa::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule, ThinShared};
 use rustc_codegen_ssa::back::write::CodegenContext;
 use rustc_codegen_ssa::{CodegenResults, NativeLib};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::owning_ref::OwningRef;
 use rustc_data_structures::rustc_erase_owner;
 use rustc_data_structures::sync::MetadataRef;
@@ -13,7 +14,6 @@ use rustc_session::config::{CrateType, DebugInfo, Lto, OptLevel, OutputFilenames
 use rustc_session::output::{check_file_is_writeable, invalid_output_for_target, out_filename};
 use rustc_session::utils::NativeLibKind;
 use rustc_session::Session;
-use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::{CString, OsStr};
 use std::fs::File;
@@ -143,7 +143,7 @@ fn link_exe(
             if !out_dir.is_dir() {
                 std::fs::create_dir_all(&out_dir).unwrap();
             }
-            let mut hashmap = HashMap::new();
+            let mut hashmap = FxHashMap::default();
             for (name, spv_binary) in map {
                 let mut module_filename = out_dir.clone();
                 module_filename.push(sanitize_filename::sanitize(&name));
@@ -374,7 +374,7 @@ fn create_archive(files: &[&Path], metadata: &[u8], out_filename: &Path) {
         header.set_cksum();
         builder.append(&header, metadata).unwrap();
     }
-    let mut filenames = HashSet::new();
+    let mut filenames = FxHashSet::default();
     filenames.insert(OsStr::new(".metadata"));
     for file in files {
         assert!(

--- a/crates/rustc_codegen_spirv/src/linker/capability_computation.rs
+++ b/crates/rustc_codegen_spirv/src/linker/capability_computation.rs
@@ -1,10 +1,10 @@
 use rspirv::dr::{Instruction, Module};
 use rspirv::spirv::{Capability, Op};
-use std::collections::HashSet;
+use rustc_data_structures::fx::FxHashSet;
 
 pub fn remove_extra_capabilities(module: &mut Module) {
     let used_capabilities = used_capabilities(module);
-    let removable_capabilities: HashSet<Capability> = [
+    let removable_capabilities: FxHashSet<Capability> = [
         Capability::Int8,
         Capability::Int16,
         Capability::Int64,
@@ -24,8 +24,8 @@ pub fn remove_extra_capabilities(module: &mut Module) {
     remove_capabilities(module, &to_remove);
 }
 
-fn used_capabilities(module: &Module) -> HashSet<Capability> {
-    let mut set = HashSet::new();
+fn used_capabilities(module: &Module) -> FxHashSet<Capability> {
+    let mut set = FxHashSet::default();
     for inst in module.all_inst_iter() {
         set.extend(inst.class.capabilities);
         match inst.class.opcode {
@@ -56,7 +56,7 @@ fn used_capabilities(module: &Module) -> HashSet<Capability> {
     set
 }
 
-fn remove_capabilities(module: &mut Module, set: &HashSet<Capability>) {
+fn remove_capabilities(module: &mut Module, set: &FxHashSet<Capability>) {
     module.capabilities.retain(|inst| {
         inst.class.opcode != Op::Capability || !set.contains(&inst.operands[0].unwrap_capability())
     });
@@ -87,7 +87,7 @@ fn additional_extensions(module: &Module, inst: &Instruction) -> &'static [&'sta
 }
 
 pub fn remove_extra_extensions(module: &mut Module) {
-    let set: HashSet<&str> = module
+    let set: FxHashSet<&str> = module
         .all_inst_iter()
         .flat_map(|inst| {
             let extensions = inst.class.extensions.iter().copied();

--- a/crates/rustc_codegen_spirv/src/linker/new_structurizer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/new_structurizer.rs
@@ -2,7 +2,7 @@ use crate::decorations::UnrollLoopsDecoration;
 use indexmap::{indexmap, IndexMap};
 use rspirv::dr::{Block, Builder, Function, InsertPoint, Module, Operand};
 use rspirv::spirv::{LoopControl, Op, SelectionControl, Word};
-use std::collections::HashMap;
+use rustc_data_structures::fx::FxHashMap;
 use std::{iter, mem};
 
 /// Cached IDs of `OpTypeBool`, `OpConstantFalse`, and `OpConstantTrue`.
@@ -40,7 +40,7 @@ impl FuncBuilder<'_> {
 
 pub fn structurize(
     module: Module,
-    unroll_loops_decorations: HashMap<Word, UnrollLoopsDecoration>,
+    unroll_loops_decorations: FxHashMap<Word, UnrollLoopsDecoration>,
 ) -> Module {
     let mut builder = Builder::new_from_module(module);
 
@@ -100,7 +100,7 @@ pub fn structurize(
             block_id_to_idx,
             loop_control,
             incoming_edge_count: vec![],
-            regions: HashMap::new(),
+            regions: FxHashMap::default(),
         }
         .structurize_func();
     }
@@ -140,7 +140,7 @@ struct Structurizer<'a> {
     globals: Globals,
 
     func: FuncBuilder<'a>,
-    block_id_to_idx: HashMap<BlockId, BlockIdx>,
+    block_id_to_idx: FxHashMap<BlockId, BlockIdx>,
 
     /// `LoopControl` to use in all loops' `OpLoopMerge` instruction.
     /// Currently only affected by function-scoped `#[spirv(unroll_loops)]`.
@@ -151,7 +151,7 @@ struct Structurizer<'a> {
     /// (backedge count is subtracted to hide them from outer regions).
     incoming_edge_count: Vec<usize>,
 
-    regions: HashMap<BlockIdx, Region>,
+    regions: FxHashMap<BlockIdx, Region>,
 }
 
 impl Structurizer<'_> {

--- a/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
+++ b/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
@@ -1,6 +1,6 @@
 use rspirv::dr::{Block, Function, Module};
 use rspirv::spirv::{Op, Word};
-use std::collections::{HashMap, HashSet};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use std::mem::replace;
 
 pub fn shift_ids(module: &mut Module, add: u32) {
@@ -31,7 +31,7 @@ pub fn block_ordering_pass(func: &mut Function) {
     }
     fn visit_postorder(
         func: &Function,
-        visited: &mut HashSet<Word>,
+        visited: &mut FxHashSet<Word>,
         postorder: &mut Vec<Word>,
         current: Word,
     ) {
@@ -60,7 +60,7 @@ pub fn block_ordering_pass(func: &mut Function) {
         postorder.push(current);
     }
 
-    let mut visited = HashSet::new();
+    let mut visited = FxHashSet::default();
     let mut postorder = Vec::new();
 
     let entry_label = func.blocks[0].label_id().unwrap();
@@ -93,7 +93,7 @@ pub fn outgoing_edges(block: &Block) -> impl Iterator<Item = Word> + '_ {
 }
 
 pub fn compact_ids(module: &mut Module) -> u32 {
-    let mut remap = HashMap::new();
+    let mut remap = FxHashMap::default();
 
     let mut insert = |current_id: u32| -> u32 {
         let len = remap.len();

--- a/crates/rustc_codegen_spirv/src/linker/structurizer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/structurizer.rs
@@ -7,8 +7,9 @@ use rspirv::{
     dr::{Block, Builder, InsertPoint, Module, Operand},
     spirv::LoopControl,
 };
+use rustc_data_structures::fx::FxHashMap;
 use rustc_session::Session;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 
 pub struct LoopInfo {
     merge_id: Word,
@@ -127,7 +128,7 @@ impl ControlFlowInfo {
 pub fn structurize(
     sess: &Session,
     module: Module,
-    unroll_loops_decorations: HashMap<Word, UnrollLoopsDecoration>,
+    unroll_loops_decorations: FxHashMap<Word, UnrollLoopsDecoration>,
 ) -> Module {
     let mut builder = Builder::new_from_module(module);
 
@@ -686,7 +687,7 @@ pub fn insert_selection_merge_on_conditional_branch(
         }
     }
 
-    let mut modified_ids = HashMap::new();
+    let mut modified_ids = FxHashMap::default();
 
     // Find convergence point.
     for id in branch_conditional_ops.iter() {
@@ -798,7 +799,7 @@ pub fn insert_loop_merge_on_conditional_branch(
             }
         }
     }
-    let mut modified_ids = HashMap::new();
+    let mut modified_ids = FxHashMap::default();
 
     // Figure out which branch loops and which branch should merge, also find any potential break ops.
     for (id, looping_branch_idx) in branch_conditional_ops.iter() {

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -7,11 +7,11 @@ use rspirv::dr::Operand;
 use rspirv::spirv::{
     AccessQualifier, Capability, Decoration, Dim, ImageFormat, StorageClass, Word,
 };
+use rustc_data_structures::fx::FxHashMap;
 use rustc_span::def_id::DefId;
 use rustc_span::Span;
 use rustc_target::abi::{Align, Size};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fmt;
 use std::iter;
 use std::lazy::SyncLazy;
@@ -690,7 +690,7 @@ pub struct TypeCache<'tcx> {
     /// Set of names for a type (only `SpirvType::Adt` currently).
     /// The same `OpType*` may have multiple names if it's e.g. a generic
     /// `struct` where the generic parameters result in the same field types.
-    type_names: RefCell<HashMap<Word, IndexSet<TyLayoutNameKey<'tcx>>>>,
+    type_names: RefCell<FxHashMap<Word, IndexSet<TyLayoutNameKey<'tcx>>>>,
 }
 
 impl TypeCache<'_> {


### PR DESCRIPTION
`FxHash{Map,Set}` (i.e. `Hash{Map,Set}<_, _, FxHash>`) are standard across `rustc` crates because they offer generally better performance, but also more predictable performance (since they're not randomized).

From some quick testing this brings down the `link` time for `mouse-shader` from ~1.3s to ~1.05s.

There's [an internal `rustc` lint](https://github.com/rust-lang/rust/blob/673d0db5e393e9c64897005b470bfeb6d5aec61b/src/test/ui-fulldeps/internal-lints/default_hash_types.rs) to force using the `Fx` versions but it sadly requires `-Z unstable-options` to be enabled, which we could maybe set in CI via `RUSTFLAGS`, but it wouldn't be easy to have for local builds.