### PR TITLE
Allow constant references (to constant data), when they're valid SPIR-V.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -838,8 +838,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     }
 
     fn load(&mut self, ptr: Self::Value, _align: Align) -> Self::Value {
-        // See comment on `SpirvValueKind::ConstantPointer`
-        if let Some(value) = ptr.const_ptr_val(self) {
+        if let Some(value) = ptr.const_fold_load(self) {
             return value;
         }
         let ty = match self.lookup_type(ptr.ty) {
@@ -1665,9 +1664,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         };
         let src_element_size = src_pointee.and_then(|p| self.lookup_type(p).sizeof(self));
         if src_element_size.is_some() && src_element_size == const_size.map(Size::from_bytes) {
-            // See comment on `SpirvValueKind::ConstantPointer`
-
-            if let Some(const_value) = src.const_ptr_val(self) {
+            if let Some(const_value) = src.const_fold_load(self) {
                 self.store(const_value, dst, Align::from_bytes(0).unwrap());
             } else {
                 self.emit()

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -38,8 +38,8 @@ macro_rules! simple_op {
                             let size = Size::from_bits(bits);
                             let as_u128 = |const_val| {
                                 let x = match const_val {
-                                    SpirvConst::U32(_, x) => x as u128,
-                                    SpirvConst::U64(_, x) => x as u128,
+                                    SpirvConst::U32(x) => x as u128,
+                                    SpirvConst::U64(x) => x as u128,
                                     _ => return None,
                                 };
                                 Some(if signed {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -16,27 +16,27 @@ use rustc_target::abi::{self, AddressSpace, HasDataLayout, Integer, LayoutOf, Pr
 impl<'tcx> CodegenCx<'tcx> {
     pub fn constant_u8(&self, span: Span, val: u8) -> SpirvValue {
         let ty = SpirvType::Integer(8, false).def(span, self);
-        self.builder.def_constant(SpirvConst::U32(ty, val as u32))
+        self.builder.def_constant(ty, SpirvConst::U32(val as u32))
     }
 
     pub fn constant_u16(&self, span: Span, val: u16) -> SpirvValue {
         let ty = SpirvType::Integer(16, false).def(span, self);
-        self.builder.def_constant(SpirvConst::U32(ty, val as u32))
+        self.builder.def_constant(ty, SpirvConst::U32(val as u32))
     }
 
     pub fn constant_i32(&self, span: Span, val: i32) -> SpirvValue {
         let ty = SpirvType::Integer(32, !self.kernel_mode).def(span, self);
-        self.builder.def_constant(SpirvConst::U32(ty, val as u32))
+        self.builder.def_constant(ty, SpirvConst::U32(val as u32))
     }
 
     pub fn constant_u32(&self, span: Span, val: u32) -> SpirvValue {
         let ty = SpirvType::Integer(32, false).def(span, self);
-        self.builder.def_constant(SpirvConst::U32(ty, val))
+        self.builder.def_constant(ty, SpirvConst::U32(val))
     }
 
     pub fn constant_u64(&self, span: Span, val: u64) -> SpirvValue {
         let ty = SpirvType::Integer(64, false).def(span, self);
-        self.builder.def_constant(SpirvConst::U64(ty, val))
+        self.builder.def_constant(ty, SpirvConst::U64(val))
     }
 
     pub fn constant_int(&self, ty: Word, val: u64) -> SpirvValue {
@@ -44,18 +44,18 @@ impl<'tcx> CodegenCx<'tcx> {
             SpirvType::Integer(bits @ 8..=32, signed) => {
                 let size = Size::from_bits(bits);
                 let val = val as u128;
-                self.builder.def_constant(SpirvConst::U32(
+                self.builder.def_constant(
                     ty,
-                    if signed {
+                    SpirvConst::U32(if signed {
                         size.sign_extend(val)
                     } else {
                         size.truncate(val)
-                    } as u32,
-                ))
+                    } as u32),
+                )
             }
-            SpirvType::Integer(64, _) => self.builder.def_constant(SpirvConst::U64(ty, val)),
+            SpirvType::Integer(64, _) => self.builder.def_constant(ty, SpirvConst::U64(val)),
             SpirvType::Bool => match val {
-                0 | 1 => self.builder.def_constant(SpirvConst::Bool(ty, val != 0)),
+                0 | 1 => self.builder.def_constant(ty, SpirvConst::Bool(val != 0)),
                 _ => self
                     .tcx
                     .sess
@@ -76,23 +76,23 @@ impl<'tcx> CodegenCx<'tcx> {
     pub fn constant_f32(&self, span: Span, val: f32) -> SpirvValue {
         let ty = SpirvType::Float(32).def(span, self);
         self.builder
-            .def_constant(SpirvConst::F32(ty, val.to_bits()))
+            .def_constant(ty, SpirvConst::F32(val.to_bits()))
     }
 
     pub fn constant_f64(&self, span: Span, val: f64) -> SpirvValue {
         let ty = SpirvType::Float(64).def(span, self);
         self.builder
-            .def_constant(SpirvConst::F64(ty, val.to_bits()))
+            .def_constant(ty, SpirvConst::F64(val.to_bits()))
     }
 
     pub fn constant_float(&self, ty: Word, val: f64) -> SpirvValue {
         match self.lookup_type(ty) {
             SpirvType::Float(32) => self
                 .builder
-                .def_constant(SpirvConst::F32(ty, (val as f32).to_bits())),
+                .def_constant(ty, SpirvConst::F32((val as f32).to_bits())),
             SpirvType::Float(64) => self
                 .builder
-                .def_constant(SpirvConst::F64(ty, val.to_bits())),
+                .def_constant(ty, SpirvConst::F64(val.to_bits())),
             other => self.tcx.sess.fatal(&format!(
                 "constant_float invalid on type {}",
                 other.debug(ty, self)
@@ -102,19 +102,19 @@ impl<'tcx> CodegenCx<'tcx> {
 
     pub fn constant_bool(&self, span: Span, val: bool) -> SpirvValue {
         let ty = SpirvType::Bool.def(span, self);
-        self.builder.def_constant(SpirvConst::Bool(ty, val))
+        self.builder.def_constant(ty, SpirvConst::Bool(val))
     }
 
     pub fn constant_composite(&self, ty: Word, val: Vec<Word>) -> SpirvValue {
-        self.builder.def_constant(SpirvConst::Composite(ty, val))
+        self.builder.def_constant(ty, SpirvConst::Composite(val))
     }
 
     pub fn constant_null(&self, ty: Word) -> SpirvValue {
-        self.builder.def_constant(SpirvConst::Null(ty))
+        self.builder.def_constant(ty, SpirvConst::Null)
     }
 
     pub fn undef(&self, ty: Word) -> SpirvValue {
-        self.builder.def_constant(SpirvConst::Undef(ty))
+        self.builder.def_constant(ty, SpirvConst::Undef)
     }
 }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -4,7 +4,7 @@ use crate::builder_spirv::{SpirvConst, SpirvValue, SpirvValueExt};
 use crate::spirv_type::SpirvType;
 use rspirv::spirv::Word;
 use rustc_codegen_ssa::mir::place::PlaceRef;
-use rustc_codegen_ssa::traits::{ConstMethods, MiscMethods, StaticMethods};
+use rustc_codegen_ssa::traits::{BaseTypeMethods, ConstMethods, MiscMethods, StaticMethods};
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::{AllocId, Allocation, GlobalAlloc, Pointer, ScalarMaybeUninit};
 use rustc_middle::ty::layout::TyAndLayout;
@@ -166,7 +166,12 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
             .spirv_type(DUMMY_SP, self);
         // FIXME(eddyb) include the actual byte data.
         (
-            self.make_constant_pointer(DUMMY_SP, self.undef(str_ty)),
+            self.builder.def_constant(
+                self.type_ptr_to(str_ty),
+                SpirvConst::PtrTo {
+                    pointee: self.undef(str_ty).def_cx(self),
+                },
+            ),
             self.const_usize(len as u64),
         )
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -264,9 +264,8 @@ impl<'tcx> StaticMethods for CodegenCx<'tcx> {
         let mut v = self.create_const_alloc(alloc, value_ty);
 
         if self.lookup_type(v.ty) == SpirvType::Bool {
-            let val = self.builder.lookup_const(v).unwrap();
-            let val_int = match val {
-                SpirvConst::Bool(_, val) => val as u8,
+            let val_int = match self.builder.lookup_const(v).unwrap() {
+                SpirvConst::Bool(val) => val as u8,
                 _ => bug!(),
             };
             v = self.constant_u8(span, val_int);

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -6,14 +6,14 @@ use crate::decorations::UnrollLoopsDecoration;
 use crate::spirv_type::SpirvType;
 use rspirv::spirv::{FunctionControl, LinkageType, StorageClass, Word};
 use rustc_attr::InlineAttr;
-use rustc_codegen_ssa::traits::{PreDefineMethods, StaticMethods};
+use rustc_codegen_ssa::traits::{BaseTypeMethods, PreDefineMethods, StaticMethods};
 use rustc_middle::bug;
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
 use rustc_middle::mir::mono::{Linkage, MonoItem, Visibility};
 use rustc_middle::ty::layout::FnAbiExt;
 use rustc_middle::ty::{self, Instance, ParamEnv, TypeFoldable};
 use rustc_span::def_id::DefId;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::Span;
 use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::{Align, LayoutOf};
 
@@ -242,7 +242,12 @@ impl<'tcx> PreDefineMethods<'tcx> for CodegenCx<'tcx> {
 
 impl<'tcx> StaticMethods for CodegenCx<'tcx> {
     fn static_addr_of(&self, cv: Self::Value, _align: Align, _kind: Option<&str>) -> Self::Value {
-        self.make_constant_pointer(DUMMY_SP, cv)
+        self.builder.def_constant(
+            self.type_ptr_to(cv.ty),
+            SpirvConst::PtrTo {
+                pointee: cv.def_cx(self),
+            },
+        )
     }
 
     fn codegen_static(&self, def_id: DefId, _is_mutable: bool) {

--- a/tests/ui/lang/consts/nested-ref-in-composite.rs
+++ b/tests/ui/lang/consts/nested-ref-in-composite.rs
@@ -1,0 +1,28 @@
+// Test `&'static T` constants where the `T` values themselves contain references,
+// nested in `OpConstantComposite` (structs/arrays) - currently these are disallowed.
+
+// build-fail
+
+use spirv_std as _;
+
+use glam::{const_mat2, Mat2, Vec2};
+
+#[inline(never)]
+fn pair_deep_load(r: &'static (&'static u32, &'static f32)) -> (u32, f32) {
+    (*r.0, *r.1)
+}
+
+#[inline(never)]
+fn array3_deep_load(r: &'static [&'static u32; 3]) -> [u32; 3] {
+    [*r[0], *r[1], *r[2]]
+}
+
+#[spirv(fragment)]
+pub fn main_pair(pair_out: &mut (u32, f32)) {
+    *pair_out = pair_deep_load(&(&123, &3.14));
+}
+
+#[spirv(fragment)]
+pub fn main_array3(array3_out: &mut [u32; 3]) {
+    *array3_out = array3_deep_load(&[&0, &1, &2]);
+}

--- a/tests/ui/lang/consts/nested-ref-in-composite.stderr
+++ b/tests/ui/lang/consts/nested-ref-in-composite.stderr
@@ -1,0 +1,27 @@
+error: constant arrays/structs cannot contain pointers to other constants
+  --> $DIR/nested-ref-in-composite.rs:22:17
+   |
+22 |     *pair_out = pair_deep_load(&(&123, &3.14));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Stack:
+           nested_ref_in_composite::main_pair
+           Unnamed function ID %26
+
+error: constant arrays/structs cannot contain pointers to other constants
+  --> $DIR/nested-ref-in-composite.rs:27:19
+   |
+27 |     *array3_out = array3_deep_load(&[&0, &1, &2]);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Stack:
+           nested_ref_in_composite::main_array3
+           Unnamed function ID %33
+
+error: invalid binary:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
+  |
+  = note: spirv-val failed
+  = note: module `$TEST_BUILD_DIR/lang/consts/nested-ref-in-composite.stage-id.spv`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lang/consts/nested-ref.rs
+++ b/tests/ui/lang/consts/nested-ref.rs
@@ -1,0 +1,32 @@
+// Test `&'static &'static T` constants where the `T` values don't themselves
+// contain references, and where the `T` values aren't immediatelly loaded from.
+
+// build-pass
+
+use spirv_std as _;
+
+use glam::{const_mat2, Mat2, Vec2};
+
+#[inline(never)]
+fn deep_load(r: &'static &'static u32) -> u32 {
+    **r
+}
+
+const ROT90: &Mat2 = &const_mat2![[0.0, 1.0], [-1.0, 0.0]];
+
+#[inline(never)]
+fn deep_transpose(r: &'static &'static Mat2) -> Mat2 {
+    r.transpose()
+}
+
+#[spirv(fragment)]
+pub fn main(
+    scalar_out: &mut u32,
+    #[spirv(push_constant)] vec_in: &Vec2,
+    bool_out: &mut bool,
+    vec_out: &mut Vec2,
+) {
+    *scalar_out = deep_load(&&123);
+    *bool_out = vec_in == &Vec2::ZERO;
+    *vec_out = deep_transpose(&ROT90) * *vec_in;
+}

--- a/tests/ui/lang/consts/shallow-ref.rs
+++ b/tests/ui/lang/consts/shallow-ref.rs
@@ -1,0 +1,22 @@
+// Test `&'static T` constants where the `T` values don't themselves contain
+// references, and where the `T` values aren't immediatelly loaded from.
+
+// build-pass
+
+use spirv_std as _;
+
+use glam::{const_mat2, Mat2, Vec2};
+
+#[inline(never)]
+fn scalar_load(r: &'static u32) -> u32 {
+    *r
+}
+
+const ROT90: Mat2 = const_mat2![[0.0, 1.0], [-1.0, 0.0]];
+
+#[spirv(fragment)]
+pub fn main(scalar_out: &mut u32, vec_in: Vec2, bool_out: &mut bool, vec_out: &mut Vec2) {
+    *scalar_out = scalar_load(&123);
+    *bool_out = vec_in == Vec2::ZERO;
+    *vec_out = ROT90.transpose() * vec_in;
+}


### PR DESCRIPTION
This is trickier than it should reasonably be, because of some SPIR-V limitations.

A constant like `&&123` is valid in SPIR-V and generates something like this (types omitted for brevity):
```llvm
        %int_123 = OpConstant _ 123
    %ref_int_123 = OpVariable _ Private %int_123
%ref_ref_int_123 = OpVariable _ Private %ref_int_123
```

But a constant like `&(&1, &2)` isn't - its SPIR-V would have to be this, which doesn't pass validation:
```llvm
    %int_1 = OpConstant _ 1
%ref_int_1 = OpVariable _ Private %int_1
    %int_2 = OpConstant _ 2
%ref_int_2 = OpVariable _ Private %int_2
     %pair = OpConstantComposite _ %ref_int_1 %ref_int_2
 %ref_pair = OpVariable _ Private %ref_pair
```

The problem isn't even `%ref_pair`, but `%pair` itself: `OpConstantComposite` *must* have `OpConstant...` fields, but not (global, i.e. module-scoped) `OpVariable` fields (even if the storage class is `Private`).

This is pretty bizarre IMO, and I'm not 100% convinced it's intentional - it's possible the first case (with the nested `OpVariable`s) was never meant to be legal either.

<hr/>

Regardless of whether the rules make sense or not, this PR accounts for them, and you can see in the UI tests some simple examples what is allowed and what isn't (the `==` examples were the original motivation for this PR).

I've even tested that adding multiple extraneous references to the color constants in `mouse-shader` still works, but I suspect the loads get constant-folded anyway, so it's not much of a test.