### PR TITLE
Add track_caller to type lookups

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -124,6 +124,7 @@ impl<'tcx> CodegenCx<'tcx> {
         self.builder.builder(cursor)
     }
 
+    #[track_caller]
     pub fn lookup_type(&self, ty: Word) -> SpirvType {
         self.type_cache.lookup(ty)
     }

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -705,6 +705,7 @@ impl TypeCache<'_> {
         self.type_defs.borrow().get_by_right(ty).copied()
     }
 
+    #[track_caller]
     pub fn lookup(&self, word: Word) -> SpirvType {
         self.type_defs
             .borrow()


### PR DESCRIPTION
Adds `#[track_caller]` to `lookup_type` and `TypeCache::lookup`. This makes panics from the `expect` in `TypeCache::lookup` more helpful as the message will include where the compiler tried to lookup the type.