### PR TITLE
CI check that docs are able to be built without warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,8 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Rustfmt tests
         run: rustfmt --check tests/ui/**/*.rs
+      - name: Check docs are valid
+        run: RUSTDOCFLAGS=-Dwarnings cargo doc
       - name: Clippy
         run: .github/workflows/clippy.sh
 

--- a/crates/spirv-std/src/arch/barrier.rs
+++ b/crates/spirv-std/src/arch/barrier.rs
@@ -23,10 +23,9 @@ use crate::memory::{Scope, Semantics};
 /// no such restriction starting with version 1.3.
 ///
 /// If used with the `TessellationControl` execution model, it also implicitly
-/// synchronizes the [`crate::storage_class::Output`] Storage Class: Writes to
-/// `Output` variables performed by any invocation executed prior to a
-/// [`control_barrier`] are visible to any other invocation proceeding beyond
-/// that [`control_barrier`].
+/// synchronizes the `output` storage class: Writes to `output` variables
+/// performed by any invocation executed prior to a [`control_barrier`] are
+/// visible to any other invocation proceeding beyond that [`control_barrier`].
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpControlBarrier")]
 #[inline]

--- a/crates/spirv-std/src/arch/derivative.rs
+++ b/crates/spirv-std/src/arch/derivative.rs
@@ -1,5 +1,3 @@
-//! The [`Derivative`] trait for getting derivatives and handling derivative
-//! operations in SPIR-V.
 use crate::float::Float;
 
 #[cfg(target_arch = "spirv")]
@@ -28,10 +26,9 @@ macro_rules! deriv_fn {
     };
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's
-/// X coordinate. Returns the same result as either
-/// [`Self::ddx_fine`] or [`Self::ddx_coarse`], selection of which one is
-/// dependent on external factors.
+/// Returns the partial derivative of `Self` with respect to the window's X
+/// coordinate. Returns the same result as either [`ddx_fine`] or
+/// [`ddx_coarse`], selection of which one is dependent on external factors.
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn ddx<F: Float>(component: F) -> F {
@@ -47,22 +44,21 @@ pub fn ddx_fine<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdxFine, true)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's
-/// X coordinate. Uses local differencing based on the value of `Self` for
-/// the current fragment’s neighbors, and possibly, but not necessarily,
-/// includes the value of `Self` for the current fragment. That is, over a
-/// given area, the implementation can compute X derivatives in fewer
-/// unique locations than would be allowed by [`Self::ddx_fine`].
+/// Returns the partial derivative of `Self` with respect to the window's X
+/// coordinate. Uses local differencing based on the value of `Self` for the
+/// current fragment’s neighbors, and possibly, but not necessarily, includes
+/// the value of `Self` for the current fragment. That is, over a given area,
+/// the implementation can compute X derivatives in fewer unique locations than
+/// would be allowed by [`ddx_fine`].
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn ddx_coarse<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdxCoarse, true)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's
-/// Y coordinate. Returns the same result as either [`Self::ddy_fine`] or
-/// [`Self::ddy_coarse`], selection of which one is dependent on
-/// external factors.
+/// Returns the partial derivative of `Self` with respect to the window's Y
+/// coordinate. Returns the same result as either [`ddy_fine`] or
+/// [`ddy_coarse`], selection of which one is dependent on external factors.
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn ddy<F: Float>(component: F) -> F {
@@ -78,36 +74,36 @@ pub fn ddy_fine<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdyFine, true)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's
-/// Y coordinate. Uses local differencing based on the value of `Self` for
-/// the current fragment’s neighbors, and possibly, but not necessarily,
-/// includes the value of `Self` for the current fragment. That is, over a
-/// given area, the implementation can compute Y derivatives in fewer
-/// unique locations than would be allowed by [`Derivative::ddy_fine`].
+/// Returns the partial derivative of `Self` with respect to the window's Y
+/// coordinate. Uses local differencing based on the value of `Self` for the
+/// current fragment’s neighbors, and possibly, but not necessarily, includes
+/// the value of `Self` for the current fragment. That is, over a given area,
+/// the implementation can compute Y derivatives in fewer unique locations than
+/// would be allowed by [`ddy_fine`].
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn ddy_coarse<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdyCoarse, true)
 }
 
-/// Returns the sum of the absolute values of [`Self::ddx`] and
-/// [`Self::ddy`] as a single operation.
+/// Returns the sum of the absolute values of [`ddx`] and [`ddy`] as a single
+/// operation.
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn fwidth<F: Float>(component: F) -> F {
     deriv_fn!(component, OpFwidth, false)
 }
 
-/// Returns the sum of the absolute values of [`Self::ddx_fine`] and
-/// [`Self::ddy_fine`] as a single operation.
+/// Returns the sum of the absolute values of [`ddx_fine`] and [`ddy_fine`] as a
+/// single operation.
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn fwidth_fine<F: Float>(component: F) -> F {
     deriv_fn!(component, OpFwidthFine, true)
 }
 
-/// Returns the sum of the absolute values of [`Self::ddx_coarse`] and
-/// [`Self::ddy_coarse`] as a single operation.
+/// Returns the sum of the absolute values of [`ddx_coarse`] and [`ddy_coarse`]
+/// as a single operation.
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn fwidth_coarse<F: Float>(component: F) -> F {

--- a/crates/spirv-std/src/arch/derivative.rs
+++ b/crates/spirv-std/src/arch/derivative.rs
@@ -26,7 +26,7 @@ macro_rules! deriv_fn {
     };
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's X
+/// Returns the partial derivative of `component` with respect to the window's X
 /// coordinate. Returns the same result as either [`ddx_fine`] or
 /// [`ddx_coarse`], selection of which one is dependent on external factors.
 #[spirv_std_macros::vectorized]
@@ -35,8 +35,8 @@ pub fn ddx<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdx, false)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's
-/// X coordinate. Uses local differencing based on the value of `Self` for
+/// Returns the partial derivative of `component` with respect to the window's X
+/// coordinate. Uses local differencing based on the value of `component` for
 /// the current fragment and its immediate neighbor(s).
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
@@ -44,19 +44,19 @@ pub fn ddx_fine<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdxFine, true)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's X
-/// coordinate. Uses local differencing based on the value of `Self` for the
-/// current fragment’s neighbors, and possibly, but not necessarily, includes
-/// the value of `Self` for the current fragment. That is, over a given area,
-/// the implementation can compute X derivatives in fewer unique locations than
-/// would be allowed by [`ddx_fine`].
+/// Returns the partial derivative of `component` with respect to the window's X
+/// coordinate. Uses local differencing based on the value of `component` for
+/// the current fragment’s neighbors, and possibly, but not necessarily,
+/// includes the value of `component` for the current fragment. That is, over a
+/// given area, the implementation can compute X derivatives in fewer unique
+/// locations than would be allowed by [`ddx_fine`].
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn ddx_coarse<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdxCoarse, true)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's Y
+/// Returns the partial derivative of `component` with respect to the window's Y
 /// coordinate. Returns the same result as either [`ddy_fine`] or
 /// [`ddy_coarse`], selection of which one is dependent on external factors.
 #[spirv_std_macros::vectorized]
@@ -65,8 +65,8 @@ pub fn ddy<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdy, false)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's
-/// Y coordinate. Uses local differencing based on the value of `Self` for
+/// Returns the partial derivative of `component` with respect to the window's Y
+/// coordinate. Uses local differencing based on the value of `component` for
 /// the current fragment and its immediate neighbor(s).
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
@@ -74,12 +74,12 @@ pub fn ddy_fine<F: Float>(component: F) -> F {
     deriv_fn!(component, OpDPdyFine, true)
 }
 
-/// Returns the partial derivative of `Self` with respect to the window's Y
-/// coordinate. Uses local differencing based on the value of `Self` for the
-/// current fragment’s neighbors, and possibly, but not necessarily, includes
-/// the value of `Self` for the current fragment. That is, over a given area,
-/// the implementation can compute Y derivatives in fewer unique locations than
-/// would be allowed by [`ddy_fine`].
+/// Returns the partial derivative of `component` with respect to the window's Y
+/// coordinate. Uses local differencing based on the value of `component` for
+/// the current fragment’s neighbors, and possibly, but not necessarily,
+/// includes the value of `component` for the current fragment. That is, over a
+/// given area, the implementation can compute Y derivatives in fewer unique
+/// locations than would be allowed by [`ddy_fine`].
 #[spirv_std_macros::vectorized]
 #[spirv_std_macros::gpu_only]
 pub fn ddy_coarse<F: Float>(component: F) -> F {

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -10,7 +10,7 @@ pub struct AccelerationStructure {
 }
 
 impl AccelerationStructure {
-    /// Converts a 64-bit integer into an [`AccelerationStructureKHR`].
+    /// Converts a 64-bit integer into an [`AccelerationStructure`].
     /// # Safety
     /// The 64-bit integer must point to a valid acceleration structure.
     #[spirv_std_macros::gpu_only]

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -31,7 +31,7 @@ impl AccelerationStructure {
         loop {}
     }
 
-    /// Converts a vector of two 32 bit integers into an [`AccelerationStructureKHR`].
+    /// Converts a vector of two 32 bit integers into an [`AccelerationStructure`].
     /// # Safety
     /// The combination must point to a valid acceleration structure.
     #[spirv_std_macros::gpu_only]


### PR DESCRIPTION
I got annoyed that tons of warnings get spewed when running `cargo doc`, so, made it a CI check.

I've intentionally not fixed one instance of ``[`AccelerationStructureKHR`]`` to make sure CI properly fails with the new check, I'll fix after it fails.

(The diff here is a bit annoying since I reflowed all the comments I touched to 80 columns - I _think_ rust convention is that they should actually reflow at 100 columns, but all the comments I touched seemed to be consistent at reflowing at roughly around 80 columns, so I kept that)