### PR TITLE
Add `--no-deps` to cargo doc check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Rustfmt tests
         run: rustfmt --check tests/ui/**/*.rs
       - name: Check docs are valid
-        run: RUSTDOCFLAGS=-Dwarnings cargo doc
+        run: RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps
       - name: Clippy
         run: .github/workflows/clippy.sh
 


### PR DESCRIPTION
By default `cargo doc` documents all crates in the graph, including dependencies, which causes it to take a significant amount of time (~12 minutes according to CI)