### PR TITLE
Update version and remove usage of or_patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "compute-shader"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 dependencies = [
  "spirv-std",
 ]
@@ -2100,7 +2100,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 dependencies = [
  "bimap",
  "hashbrown",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-builder"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 dependencies = [
  "bitflags",
  "num-traits",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-types"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 
 [[package]]
 name = "spirv_cross"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-builder"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-std/macros/Cargo.toml
+++ b/crates/spirv-std/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-std/macros/src/image.rs
+++ b/crates/spirv-std/macros/src/image.rs
@@ -77,9 +77,9 @@ impl Parse for ImageType {
                 let int = input.parse::<syn::LitInt>().unwrap();
                 set_unique!(
                     dimensionality = match (int.base10_digits(), int.suffix()) {
-                        ("1", "D" | "d") => Dimensionality::OneD,
-                        ("2", "D" | "d") => Dimensionality::TwoD,
-                        ("3", "D" | "d") => Dimensionality::ThreeD,
+                        ("1", "D") | ("1", "d") => Dimensionality::OneD,
+                        ("2", "D") | ("2", "d") => Dimensionality::TwoD,
+                        ("3", "D") | ("3", "d") => Dimensionality::ThreeD,
                         _ => return Err(syn::Error::new(int.span(), "Unexpected integer")),
                     }
                 );

--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -51,7 +51,8 @@
 )]
 // END - Embark standard lints v0.3
 // crate-specific exceptions:
-#![allow()]
+// `or_patterns` is not stable yet.
+#![allow(clippy::unnested_or_patterns)]
 
 mod image;
 

--- a/crates/spirv-std/shared/Cargo.toml
+++ b/crates/spirv-std/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spirv-types"
 description = "SPIR-V types shared between spirv-std and spirv-std-macros"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/compute-shader/Cargo.toml
+++ b/examples/shaders/compute-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-shader"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Another version, because I accidentally used `or_patterns` without realising it for parsing the image macro. I'm not sure why this didn't come up during my local testing of the new version.