### PR TITLE
fix rustdoc with hack

### DIFF
--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -122,3 +122,8 @@ fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[lang = "eh_personality"]
 extern "C" fn rust_eh_personality() {}
+
+// See: https://github.com/rust-lang/rust/issues/84738
+#[doc(hidden)]
+/// [`spirv_types`]
+pub fn workaround_rustdoc_ice_84738() {}

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -125,5 +125,5 @@ extern "C" fn rust_eh_personality() {}
 
 // See: https://github.com/rust-lang/rust/issues/84738
 #[doc(hidden)]
-/// [`spirv_types`]
+/// [spirv_types]
 pub fn workaround_rustdoc_ice_84738() {}


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/84738 for details, but essentially having this function's docs reference `spirv_types` it fixes the ICE when building docs.