### PR TITLE
Emit OpLine instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -791,7 +791,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.7",
+ "redox_syscall 0.2.8",
  "winapi 0.3.9",
 ]
 
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -1395,9 +1395,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memmap2"
@@ -1539,7 +1539,7 @@ dependencies = [
  "log",
  "num-traits",
  "petgraph",
- "spirv_headers 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_headers 1.5.0",
  "thiserror",
 ]
 
@@ -1728,7 +1728,7 @@ checksum = "0c976c5018e7f1db4359616d8b31ef8ae7d9649b11803c0b38fff67fd2999fc8"
 dependencies = [
  "libc",
  "raw-window-handle",
- "redox_syscall 0.2.7",
+ "redox_syscall 0.2.8",
  "sdl2",
  "sdl2-sys",
  "wasm-bindgen",
@@ -1779,7 +1779,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.7",
+ "redox_syscall 0.2.8",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -2022,9 +2022,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -2036,14 +2036,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.7",
+ "redox_syscall 0.2.8",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -2077,20 +2077,20 @@ dependencies = [
 
 [[package]]
 name = "rspirv"
-version = "0.7.0"
-source = "git+https://github.com/gfx-rs/rspirv.git?rev=719cf08#719cf08e4af0436242707479e3509add5ec3d514"
+version = "0.8.0"
+source = "git+https://github.com/gfx-rs/rspirv.git?rev=4419db432d90cd333e62aae9669dd263acff0499#4419db432d90cd333e62aae9669dd263acff0499"
 dependencies = [
  "derive_more",
  "fxhash",
  "num-traits",
- "spirv_headers 1.5.0 (git+https://github.com/gfx-rs/rspirv.git?rev=719cf08)",
+ "spirv_headers 1.5.1",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
 
 [[package]]
 name = "rustc-hash"
@@ -2362,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8b450c59e36984d9b8fc26b08a650f447ae156b1c60be17c8bca2d8458942a"
+checksum = "663d6a7c1627d47e402e3a41076f6147bbe4bf11fd98687e1016599b3979f6d3"
 dependencies = [
  "memchr",
  "spirv-tools-sys",
@@ -2373,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools-sys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49ebe793f383c7488c3963b5fda139ef68486dafff3ce0b11ccd583c3927427"
+checksum = "cbb083780a3721ff6dd496dbdc3b90c033b443bec676918b89c179b330081983"
 dependencies = [
  "cc",
 ]
@@ -2407,8 +2407,8 @@ dependencies = [
 
 [[package]]
 name = "spirv_headers"
-version = "1.5.0"
-source = "git+https://github.com/gfx-rs/rspirv.git?rev=719cf08#719cf08e4af0436242707479e3509add5ec3d514"
+version = "1.5.1"
+source = "git+https://github.com/gfx-rs/rspirv.git?rev=4419db432d90cd333e62aae9669dd263acff0499#4419db432d90cd333e62aae9669dd263acff0499"
 dependencies = [
  "bitflags",
  "num-traits",
@@ -2517,7 +2517,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand",
- "redox_syscall 0.2.7",
+ "redox_syscall 0.2.8",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2636,9 +2636,9 @@ checksum = "aa7c7f42dea4b1b99439786f5633aeb9c14c1b53f75e282803c2ec2ad545873c"
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -2689,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2729,9 +2729,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unidiff"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -37,13 +37,13 @@ syn = { version = "1", features = ["visit", "visit-mut"] }
 # Normal dependencies.
 bimap = "0.6"
 indexmap = "1.6.0"
-rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "719cf08" }
+rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "4419db432d90cd333e62aae9669dd263acff0499" }
 rustc-demangle = "0.1.18"
 sanitize-filename = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"
-spirv-tools = { version = "0.5.0", default-features = false }
+spirv-tools = { version = "0.6.1", default-features = false }
 tar = "0.4.30"
 topological-sort = "0.1"
 

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -517,6 +517,10 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
     fn set_span(&mut self, span: Span) {
         self.current_span = Some(span);
+        let loc = self.cx.tcx.sess.source_map().lookup_char_pos(span.lo());
+        let file = self.builder.def_string(format!("{}", loc.file.name));
+        self.emit()
+            .line(file, loc.line as u32, loc.col_display as u32);
     }
 
     fn position_at_end(&mut self, llbb: Self::BasicBlock) {

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -318,6 +318,7 @@ pub struct BuilderSpirv {
     // allows getting that legality information without additional lookups.
     const_to_id: RefCell<FxHashMap<WithType<SpirvConst>, WithConstLegality<Word>>>,
     id_to_const: RefCell<FxHashMap<Word, WithConstLegality<SpirvConst>>>,
+    string_cache: RefCell<FxHashMap<String, Word>>,
 }
 
 impl BuilderSpirv {
@@ -367,6 +368,7 @@ impl BuilderSpirv {
             builder: RefCell::new(builder),
             const_to_id: Default::default(),
             id_to_const: Default::default(),
+            string_cache: Default::default(),
         }
     }
 
@@ -576,6 +578,17 @@ impl BuilderSpirv {
             SpirvConst::U32(v) => Some(v as u64),
             SpirvConst::U64(v) => Some(v),
             _ => None,
+        }
+    }
+
+    pub fn def_string(&self, s: String) -> Word {
+        use std::collections::hash_map::Entry;
+        match self.string_cache.borrow_mut().entry(s) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let key = entry.key().clone();
+                *entry.insert(self.builder(Default::default()).string(key))
+            }
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -339,7 +339,7 @@ impl CodegenArgs {
 
         if let Some(func) = &self.disassemble_fn {
             let id = module
-                .debugs
+                .debug_names
                 .iter()
                 .find(|inst| {
                     inst.class.opcode == rspirv::spirv::Op::Name

--- a/crates/rustc_codegen_spirv/src/linker/dce.rs
+++ b/crates/rustc_codegen_spirv/src/linker/dce.rs
@@ -76,7 +76,13 @@ fn kill_unrooted(module: &mut Module, rooted: &FxHashSet<Word>) {
     module
         .execution_modes
         .retain(|inst| is_rooted(inst, rooted));
-    module.debugs.retain(|inst| is_rooted(inst, rooted));
+    module
+        .debug_string_source
+        .retain(|inst| is_rooted(inst, rooted));
+    module.debug_names.retain(|inst| is_rooted(inst, rooted));
+    module
+        .debug_module_processed
+        .retain(|inst| is_rooted(inst, rooted));
     module.annotations.retain(|inst| is_rooted(inst, rooted));
     module
         .types_global_values

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -277,19 +277,16 @@ pub fn remove_duplicate_types(module: &mut Module) {
 pub fn remove_duplicate_lines(module: &mut Module) {
     for func in &mut module.functions {
         for block in &mut func.blocks {
-            let mut i = block.instructions.len();
-            loop {
-                if i == 0 {
-                    break;
+            block.instructions.dedup_by(|a, b| {
+                if a.class.opcode == Op::Line && b.class.opcode == Op::Line {
+                    // dedup_by removes the *second* element in a pair of duplicates. We want to
+                    // remove the *first* (so the last OpLine is kept). So, swap them! :D
+                    std::mem::swap(a, b);
+                    true
+                } else {
+                    false
                 }
-                i -= 1;
-                if i + 1 < block.instructions.len()
-                    && block.instructions[i].class.opcode == Op::Line
-                    && block.instructions[i + 1].class.opcode == Op::Line
-                {
-                    block.instructions.remove(i);
-                }
-            }
+            });
         }
     }
 }

--- a/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
+++ b/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
@@ -170,7 +170,7 @@ fn import_kill_annotations_and_debug(
                 !rewrite_rules.contains_key(&id) && !killed_parameters.contains(&id)
             })
     });
-    module.debugs.retain(|inst| {
+    module.debug_names.retain(|inst| {
         inst.operands.is_empty()
             || inst.operands[0].id_ref_any().map_or(true, |id| {
                 !rewrite_rules.contains_key(&id) && !killed_parameters.contains(&id)

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -40,7 +40,7 @@ pub fn inline(module: &mut Module) {
         }
     });
     // Drop OpName etc. for inlined functions
-    module.debugs.retain(|inst| {
+    module.debug_names.retain(|inst| {
         !inst.operands.iter().any(|op| {
             op.id_ref_any()
                 .map_or(false, |id| dropped_ids.contains(&id))

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -242,6 +242,12 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
             }
         }
     }
+
+    {
+        let _timer = sess.timer("link_remove_duplicate_lines");
+        duplicates::remove_duplicate_lines(&mut output);
+    }
+
     {
         let _timer = sess.timer("link_sort_globals");
         simple_passes::sort_globals(&mut output);

--- a/crates/rustc_codegen_spirv/src/linker/specializer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/specializer.rs
@@ -113,7 +113,7 @@ pub fn specialize(module: Module, specialization: impl Specialization) -> Module
     let mut debug_names = FxHashMap::default();
     if debug || dump_instances.is_some() {
         debug_names = module
-            .debugs
+            .debug_names
             .iter()
             .filter(|inst| inst.class.opcode == Op::Name)
             .map(|inst| {
@@ -2346,7 +2346,7 @@ impl<'a, S: Specialization> Expander<'a, S> {
         // HACK(eddyb) steal `Vec`s so that we can still call methods on `self` below.
         let module = self.builder.module_mut();
         let mut entry_points = mem::take(&mut module.entry_points);
-        let debugs = mem::take(&mut module.debugs);
+        let debug_names = mem::take(&mut module.debug_names);
         let annotations = mem::take(&mut module.annotations);
         let types_global_values = mem::take(&mut module.types_global_values);
         let functions = mem::take(&mut module.functions);
@@ -2418,7 +2418,7 @@ impl<'a, S: Specialization> Expander<'a, S> {
         };
 
         // Expand `Op(Member)Name %target ...` when `target` is "generic".
-        let expanded_debugs = expand_debug_or_annotation(debugs);
+        let expanded_debug_names = expand_debug_or_annotation(debug_names);
 
         // Expand `Op(Member)Decorate* %target ...`, when `target` is "generic".
         let expanded_annotations = expand_debug_or_annotation(annotations);
@@ -2516,7 +2516,7 @@ impl<'a, S: Specialization> Expander<'a, S> {
 
         let module = self.builder.module_mut();
         module.entry_points = entry_points;
-        module.debugs = expanded_debugs;
+        module.debug_names = expanded_debug_names;
         module.annotations = expanded_annotations;
         module.types_global_values = expanded_types_global_values;
         module.functions = expanded_functions;

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -105,7 +105,7 @@ fn spread_zombie(module: &mut Module, zombie: &mut FxHashMap<Word, ZombieInfo<'_
 
 fn get_names(module: &Module) -> FxHashMap<Word, &str> {
     module
-        .debugs
+        .debug_names
         .iter()
         .filter(|i| i.class.opcode == Op::Name)
         .map(|i| {
@@ -177,7 +177,7 @@ pub fn remove_zombies(sess: &Session, module: &mut Module) {
         for f in &module.functions {
             if let Some(reason) = is_zombie(f.def.as_ref().unwrap(), &zombies) {
                 let name_id = f.def_id().unwrap();
-                let name = module.debugs.iter().find(|inst| {
+                let name = module.debug_names.iter().find(|inst| {
                     inst.class.opcode == Op::Name && inst.operands[0].unwrap_id_ref() == name_id
                 });
                 let name = match name {
@@ -214,7 +214,13 @@ pub fn remove_zombies(sess: &Session, module: &mut Module) {
         .execution_modes
         .retain(|inst| is_zombie(inst, &zombies).is_none());
     module
-        .debugs
+        .debug_string_source
+        .retain(|inst| is_zombie(inst, &zombies).is_none());
+    module
+        .debug_names
+        .retain(|inst| is_zombie(inst, &zombies).is_none());
+    module
+        .debug_module_processed
         .retain(|inst| is_zombie(inst, &zombies).is_none());
     module
         .annotations

--- a/tests/ui/dis/add_two_ints.stderr
+++ b/tests/ui/dis/add_two_ints.stderr
@@ -2,6 +2,8 @@
 %4 = OpFunctionParameter  %2
 %5 = OpFunctionParameter  %2
 %6 = OpLabel
-%7 = OpIAdd  %2  %4 %5
-OpReturnValue %7
+OpLine %7 7 4
+%8 = OpIAdd  %2  %4 %5
+OpLine %7 8 1
+OpReturnValue %8
 OpFunctionEnd

--- a/tests/ui/dis/asm.stderr
+++ b/tests/ui/dis/asm.stderr
@@ -1,5 +1,7 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpMemoryBarrier %5 %6
+OpLine %5 8 8
+OpMemoryBarrier %6 %7
+OpLine %5 15 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/asm_add_two_ints.stderr
+++ b/tests/ui/dis/asm_add_two_ints.stderr
@@ -2,6 +2,8 @@
 %4 = OpFunctionParameter  %2
 %5 = OpFunctionParameter  %2
 %6 = OpLabel
-%7 = OpIAdd  %2  %4 %5
-OpReturnValue %7
+OpLine %7 9 8
+%8 = OpIAdd  %2  %4 %5
+OpLine %7 17 1
+OpReturnValue %8
 OpFunctionEnd

--- a/tests/ui/dis/asm_op_decorate.stderr
+++ b/tests/ui/dis/asm_op_decorate.stderr
@@ -4,7 +4,7 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-%2 = OpString "$DIR/asm_op_decorate.rs"
+%2 = OpString "$OPSTRING_FILENAME/asm_op_decorate.rs"
 OpName %3 "asm_op_decorate::add_decorate"
 OpName %4 "asm_op_decorate::main"
 OpDecorate %5 ArrayStride 4

--- a/tests/ui/dis/asm_op_decorate.stderr
+++ b/tests/ui/dis/asm_op_decorate.stderr
@@ -4,19 +4,20 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-OpName %2 "asm_op_decorate::add_decorate"
-OpName %3 "asm_op_decorate::main"
-OpDecorate %4 ArrayStride 4
-OpDecorate %5 DescriptorSet 0
-OpDecorate %5 Binding 0
-%6 = OpTypeVoid
-%7 = OpTypeFunction %6
-%8 = OpTypeInt 32 0
-%9 = OpConstant  %8  1
-%10 = OpTypeFloat 32
-%11 = OpTypeImage %10 2D 0 0 0 1 Unknown
-%12 = OpTypeSampledImage %11
-%4 = OpTypeRuntimeArray %12
-%13 = OpTypePointer UniformConstant %4
-%5 = OpVariable  %13  UniformConstant
-%14 = OpTypePointer UniformConstant %12
+%2 = OpString "$DIR/asm_op_decorate.rs"
+OpName %3 "asm_op_decorate::add_decorate"
+OpName %4 "asm_op_decorate::main"
+OpDecorate %5 ArrayStride 4
+OpDecorate %6 DescriptorSet 0
+OpDecorate %6 Binding 0
+%7 = OpTypeVoid
+%8 = OpTypeFunction %7
+%9 = OpTypeInt 32 0
+%10 = OpConstant  %9  1
+%11 = OpTypeFloat 32
+%12 = OpTypeImage %11 2D 0 0 0 1 Unknown
+%13 = OpTypeSampledImage %12
+%5 = OpTypeRuntimeArray %13
+%14 = OpTypePointer UniformConstant %5
+%6 = OpVariable  %14  UniformConstant
+%15 = OpTypePointer UniformConstant %13

--- a/tests/ui/dis/complex_image_sample_inst.stderr
+++ b/tests/ui/dis/complex_image_sample_inst.stderr
@@ -5,8 +5,10 @@
 %8 = OpFunctionParameter  %9
 %10 = OpFunctionParameter  %9
 %11 = OpLabel
-%12 = OpAccessChain  %13  %14 %15
-%16 = OpLoad  %17  %12
-%18 = OpImageSampleProjExplicitLod  %2  %16 %4 Grad|ConstOffset %5 %7 %19
-OpReturnValue %18
+OpLine %12 17 8
+%13 = OpAccessChain  %14  %15 %16
+%17 = OpLoad  %18  %13
+%19 = OpImageSampleProjExplicitLod  %2  %17 %4 Grad|ConstOffset %5 %7 %20
+OpLine %12 57 1
+OpReturnValue %19
 OpFunctionEnd

--- a/tests/ui/dis/custom_entry_point.stderr
+++ b/tests/ui/dis/custom_entry_point.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "hello_world"
 OpExecutionMode %1 OriginUpperLeft
-%2 = OpString "$DIR/custom_entry_point.rs"
+%2 = OpString "$OPSTRING_FILENAME/custom_entry_point.rs"
 OpName %3 "custom_entry_point::main"
 %4 = OpTypeVoid
 %5 = OpTypeFunction %4

--- a/tests/ui/dis/custom_entry_point.stderr
+++ b/tests/ui/dis/custom_entry_point.stderr
@@ -2,6 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "hello_world"
 OpExecutionMode %1 OriginUpperLeft
-OpName %2 "custom_entry_point::main"
-%3 = OpTypeVoid
-%4 = OpTypeFunction %3
+%2 = OpString "$DIR/custom_entry_point.rs"
+OpName %3 "custom_entry_point::main"
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4

--- a/tests/ui/dis/index_user_dst.stderr
+++ b/tests/ui/dis/index_user_dst.stderr
@@ -1,30 +1,37 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-%5 = OpAccessChain  %6  %7 %8
-%9 = OpArrayLength  %10  %7 0
-%11 = OpCompositeInsert  %12  %5 %13 0
-%14 = OpCompositeInsert  %12  %9 %11 1
-%15 = OpULessThan  %16  %8 %9
-OpSelectionMerge %17 None
-OpBranchConditional %15 %18 %19
-%18 = OpLabel
-%20 = OpInBoundsAccessChain  %21  %5 %8
-%22 = OpLoad  %23  %20
-OpReturn
+OpLine %5 7 12
+%6 = OpAccessChain  %7  %8 %9
+%10 = OpArrayLength  %11  %8 0
+OpLine %5 7 0
+%12 = OpCompositeInsert  %13  %6 %14 0
+%15 = OpCompositeInsert  %13  %10 %12 1
+OpLine %5 8 21
+%16 = OpULessThan  %17  %9 %10
+OpLine %5 8 21
+OpSelectionMerge %18 None
+OpBranchConditional %16 %19 %20
 %19 = OpLabel
-OpBranch %24
-%24 = OpLabel
+OpLine %5 8 21
+%21 = OpInBoundsAccessChain  %22  %6 %9
+%23 = OpLoad  %24  %21
+OpLine %5 10 1
+OpReturn
+%20 = OpLabel
+OpLine %5 8 21
 OpBranch %25
 %25 = OpLabel
-%26 = OpPhi  %16  %27 %24 %27 %28
-OpLoopMerge %29 %28 None
-OpBranchConditional %26 %30 %29
-%30 = OpLabel
-OpBranch %28
-%28 = OpLabel
-OpBranch %25
+OpBranch %26
+%26 = OpLabel
+%27 = OpPhi  %17  %28 %25 %28 %29
+OpLoopMerge %30 %29 None
+OpBranchConditional %27 %31 %30
+%31 = OpLabel
+OpBranch %29
 %29 = OpLabel
+OpBranch %26
+%30 = OpLabel
 OpUnreachable
-%17 = OpLabel
+%18 = OpLabel
 OpUnreachable
 OpFunctionEnd

--- a/tests/ui/dis/ptr_copy.stderr
+++ b/tests/ui/dis/ptr_copy.stderr
@@ -2,6 +2,8 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
+OpLine %8 7 13
 OpCopyMemory %6 %4
+OpLine %8 8 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -3,9 +3,14 @@
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
 %8 = OpVariable  %5  Function
-OpStore %8 %9
+OpLine %9 319 5
+OpStore %8 %10
+OpLine %11 694 8
 OpCopyMemory %8 %4
-%10 = OpLoad  %11  %8
-OpStore %6 %10
+OpLine %11 695 8
+%12 = OpLoad  %13  %8
+OpLine %14 7 13
+OpStore %6 %12
+OpLine %14 8 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -3,9 +3,14 @@
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
 %8 = OpVariable  %5  Function
-OpStore %8 %9
+OpLine %9 319 5
+OpStore %8 %10
+OpLine %11 694 8
 OpCopyMemory %8 %4
-%10 = OpLoad  %11  %8
-OpStore %6 %10
+OpLine %11 695 8
+%12 = OpLoad  %13  %8
+OpLine %14 7 13
+OpStore %6 %12
+OpLine %14 8 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -3,8 +3,12 @@
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
 %8 = OpVariable  %5  Function
-%9 = OpLoad  %10  %4
-OpStore %8 %9
+OpLine %9 7 35
+%10 = OpLoad  %11  %4
+OpLine %9 7 13
+OpStore %8 %10
+OpLine %12 886 8
 OpCopyMemory %6 %8
+OpLine %9 8 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -3,8 +3,12 @@
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
 %8 = OpVariable  %5  Function
-%9 = OpLoad  %10  %4
-OpStore %8 %9
+OpLine %9 7 37
+%10 = OpLoad  %11  %4
+OpLine %12 1012 17
+OpStore %8 %10
+OpLine %13 886 8
 OpCopyMemory %6 %8
+OpLine %9 8 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/unroll_loops.stderr
+++ b/tests/ui/dis/unroll_loops.stderr
@@ -2,31 +2,39 @@
 %4 = OpFunctionParameter  %2
 %5 = OpFunctionParameter  %2
 %6 = OpLabel
-OpBranch %7
-%7 = OpLabel
+OpLine %7 9 4
 OpBranch %8
 %8 = OpLabel
-%9 = OpPhi  %10  %11 %7 %12 %13
-%14 = OpPhi  %2  %4 %7 %15 %13
-%16 = OpPhi  %17  %18 %7 %19 %13
-OpLoopMerge %20 %13 Unroll
-OpBranchConditional %16 %21 %20
-%21 = OpLabel
-%22 = OpSLessThan  %17  %9 %23
-OpSelectionMerge %24 None
-OpBranchConditional %22 %25 %26
-%25 = OpLabel
-%27 = OpIMul  %2  %28 %14
-%15 = OpIAdd  %2  %27 %5
-%12 = OpIAdd  %10  %9 %29
-OpBranch %24
+OpBranch %9
+%9 = OpLabel
+%10 = OpPhi  %11  %12 %8 %13 %14
+%15 = OpPhi  %2  %4 %8 %16 %14
+%17 = OpPhi  %18  %19 %8 %20 %14
+OpLoopMerge %21 %14 Unroll
+OpBranchConditional %17 %22 %21
+%22 = OpLabel
+OpLine %7 9 10
+%23 = OpSLessThan  %18  %10 %24
+OpLine %7 9 4
+OpSelectionMerge %25 None
+OpBranchConditional %23 %26 %27
 %26 = OpLabel
-OpReturnValue %14
-%24 = OpLabel
-%19 = OpPhi  %17  %18 %25
-OpBranch %13
-%13 = OpLabel
-OpBranch %8
-%20 = OpLabel
+OpLine %7 10 12
+%28 = OpIMul  %2  %29 %15
+OpLine %7 10 8
+%16 = OpIAdd  %2  %28 %5
+OpLine %7 11 8
+%13 = OpIAdd  %11  %10 %30
+OpLine %7 9 4
+OpBranch %25
+%27 = OpLabel
+OpLine %7 14 1
+OpReturnValue %15
+%25 = OpLabel
+%20 = OpPhi  %18  %19 %26
+OpBranch %14
+%14 = OpLabel
+OpBranch %9
+%21 = OpLabel
 OpUnreachable
 OpFunctionEnd

--- a/tests/ui/lang/consts/nested-ref-in-composite.stderr
+++ b/tests/ui/lang/consts/nested-ref-in-composite.stderr
@@ -16,9 +16,9 @@ error: constant arrays/structs cannot contain pointers to other constants
    |
    = note: Stack:
            nested_ref_in_composite::main_array3
-           Unnamed function ID %33
+           Unnamed function ID %34
 
-error: invalid binary:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
+error: error:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |
   = note: spirv-val failed
   = note: module `$TEST_BUILD_DIR/lang/consts/nested-ref-in-composite.stage-id.spv`

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -4,7 +4,7 @@ error: pointer has non-null integer address
           allocate_const_scalar::main
           Unnamed function ID %4
 
-error: invalid binary:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
+error: error:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |
   = note: spirv-val failed
   = note: module `$TEST_BUILD_DIR/lang/core/ptr/allocate_const_scalar.stage-id.spv`


### PR DESCRIPTION
Update dependencies (both rspirv and spirv-tools-rs) to be able to use OpLine, and do so.

The `remove_duplicate_lines` for loop is absolute garbage, `O(n^2)` terribleness, so if someone wants to hack up a clever thing, please do so~