### PR TITLE
Preserve function abi in `gpu_only` macro

### DIFF
--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -160,7 +160,10 @@ pub fn gpu_only(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let fn_name = sig.ident.clone();
 
-    let sig_cpu = syn::Signature { abi: None, ..sig.clone() };
+    let sig_cpu = syn::Signature {
+        abi: None,
+        ..sig.clone()
+    };
 
     let output = quote::quote! {
         // Don't warn on unused arguments on the CPU side.


### PR DESCRIPTION
Fixes https://github.com/EmbarkStudios/rust-gpu/issues/615

Applying `gpu_only` on a function with non-standard ABI (ie "unadjusted" for the structured buffer loading instrinsics) resulting in silently dropping the ABI annotation. I tried to preseve it for the gpu implementation and drop if for the host side in this PR to not require the `abi_unadjusted` feature on the host side as well.