### PR TITLE
Always emit cargo dependency information

### DIFF
--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -44,7 +44,7 @@ Paste the following into the `main` for your build script.
 ```rust,no_run
 SpirvBuilder::new(path_to_shader)
         .spirv_version(1, 0)
-        .print_metadata()
+        .print_metadata(MetadataPrintout::Full)
         .build()?;
 ```
 

--- a/examples/multibuilder/src/main.rs
+++ b/examples/multibuilder/src/main.rs
@@ -1,8 +1,8 @@
-use spirv_builder::SpirvBuilder;
+use spirv_builder::{MetadataPrintout, SpirvBuilder};
 
 fn main() {
     let result = SpirvBuilder::new("../shaders/sky-shader", "spirv-unknown-spv1.3")
-        .print_metadata(false)
+        .print_metadata(MetadataPrintout::DependencyOnly)
         .multimodule(true)
         .build()
         .unwrap();

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -68,7 +68,7 @@ use std::{
 
 use structopt::StructOpt;
 
-use spirv_builder::SpirvBuilder;
+use spirv_builder::{MetadataPrintout, SpirvBuilder};
 
 use shared::ShaderConstants;
 
@@ -174,7 +174,7 @@ pub fn compile_shaders() -> Vec<SpvFile> {
     let spv_paths: Vec<PathBuf> =
         vec![
             SpirvBuilder::new("examples/shaders/sky-shader", "spirv-unknown-vulkan1.1")
-                .print_metadata(false)
+                .print_metadata(MetadataPrintout::None)
                 .build()
                 .unwrap()
                 .module

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -78,9 +78,9 @@ fn shader_module(shader: RustGPUShader) -> wgpu::ShaderModuleDescriptor<'static>
         };
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
         let crate_path = [manifest_dir, "..", "..", "shaders", crate_name]
-        .iter()
-        .copied()
-        .collect::<PathBuf>();
+            .iter()
+            .copied()
+            .collect::<PathBuf>();
         let mut builder = SpirvBuilder::new(crate_path, "spirv-unknown-vulkan1.1")
             .print_metadata(MetadataPrintout::None);
         for &cap in capabilities {

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -59,7 +59,7 @@ pub enum RustGPUShader {
 fn shader_module(shader: RustGPUShader) -> wgpu::ShaderModuleDescriptor<'static> {
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
-        use spirv_builder::{Capability, SpirvBuilder};
+        use spirv_builder::{Capability, MetadataPrintout, SpirvBuilder};
         use std::borrow::Cow;
         use std::path::PathBuf;
         // Hack: spirv_builder builds into a custom directory if running under cargo, to not
@@ -78,11 +78,11 @@ fn shader_module(shader: RustGPUShader) -> wgpu::ShaderModuleDescriptor<'static>
         };
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
         let crate_path = [manifest_dir, "..", "..", "shaders", crate_name]
-            .iter()
-            .copied()
-            .collect::<PathBuf>();
-        let mut builder =
-            SpirvBuilder::new(crate_path, "spirv-unknown-vulkan1.1").print_metadata(false);
+        .iter()
+        .copied()
+        .collect::<PathBuf>();
+        let mut builder = SpirvBuilder::new(crate_path, "spirv-unknown-vulkan1.1")
+            .print_metadata(MetadataPrintout::None);
         for &cap in capabilities {
             builder = builder.capability(cap);
         }


### PR DESCRIPTION
When using the `multimodule` features in spirv-builder, the user currently has to disable `print_metadata`. This disable the spir-v module env variable but also emitting the cargo dependency information to correctly handle when the shader should be rebuilt.
Ideally, the second part shouldn't be affected.