### PR TITLE
asm: support sampler and as types

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -312,7 +312,9 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             }
             .def(self.span(), self),
             Op::TypeSampler => SpirvType::Sampler.def(self.span(), self),
-            Op::TypeAccelerationStructureKHR => SpirvType::AccelerationStructureKhr.def(self.span(), self),
+            Op::TypeAccelerationStructureKHR => {
+                SpirvType::AccelerationStructureKhr.def(self.span(), self)
+            }
             Op::TypeRayQueryKHR => SpirvType::RayQueryKhr.def(self.span(), self),
             Op::Variable => {
                 // OpVariable with Function storage class should be emitted inside the function,

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -311,6 +311,8 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                 image_type: inst.operands[0].unwrap_id_ref(),
             }
             .def(self.span(), self),
+            Op::TypeSampler => SpirvType::Sampler.def(self.span(), self),
+            Op::TypeAccelerationStructureKHR => SpirvType::AccelerationStructureKhr.def(self.span(), self),
             Op::TypeRayQueryKHR => SpirvType::RayQueryKhr.def(self.span(), self),
             Op::Variable => {
                 // OpVariable with Function storage class should be emitted inside the function,


### PR DESCRIPTION
Sampler and Acceleration Structure types should get a definition as well when used in an `asm!` block.
Otherwise, it triggers an ICE down the line e.g as element type of a runtime array:
```
thread 'rustc' panicked at 'Tried to lookup value that wasn't a type, or has no definition',
E:\Desktop\rust-gpu\crates\rustc_codegen_spirv\src\spirv_type.rs:199:22
```