### PR TITLE
Remove stale roadmap link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ The scope of this overall project is quite broad, but is in multiple stages
 - [Cargo](https://github.com/rust-lang/cargo/) and [crates.io](https://crates.io) support to develop and publish SPIR-V crates
 - High-level render graph to take advantage of this, make it easy for users to develop and use rendering effects.
 
-An in-depth exploration of our roadmap and milestones can be found [here](https://github.com/EmbarkStudios/rust-gpu/issues/47).
-
 ## Process
 
 We use this repo as a monorepo for everything related to the project: crates, tools, shaders, examples, tests, and design documents. This way, we can use issues and PRs covering everything in the same place, cross-reference stuff within the repo, as well as with other GitHub repos such as [rspirv](https://github.com/gfx-rs/rspirv) and [Rust](https://github.com/rust-lang/rust) itself.


### PR DESCRIPTION
Removing the link to the roadmap because it doesn't reflect the current roadmap. (see [this comment](https://github.com/EmbarkStudios/rust-gpu/issues/47#issuecomment-811897789))