### PR TITLE
rustup: update to nightly-2021-05-24.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -6,7 +6,7 @@ use rspirv::spirv::Word;
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::traits::{BaseTypeMethods, ConstMethods, MiscMethods, StaticMethods};
 use rustc_middle::bug;
-use rustc_middle::mir::interpret::{AllocId, Allocation, GlobalAlloc, Pointer, ScalarMaybeUninit};
+use rustc_middle::mir::interpret::{alloc_range, Allocation, GlobalAlloc, ScalarMaybeUninit};
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_mir::interpret::Scalar;
 use rustc_span::symbol::Symbol;
@@ -415,10 +415,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 // only uses the input alloc_id in the case that the scalar is uninitilized
                 // as part of the error output
                 // tldr, the pointer here is only needed for the offset
-                let value = match alloc
-                    .read_scalar(self, Pointer::new(AllocId(0), *offset), size)
-                    .unwrap()
-                {
+                let value = match alloc.read_scalar(self, alloc_range(*offset, size)).unwrap() {
                     ScalarMaybeUninit::Scalar(scalar) => {
                         self.scalar_to_backend(scalar, &self.primitive_to_scalar(primitive), ty)
                     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -292,7 +292,7 @@ impl<'tcx> CodegenCx<'tcx> {
 
         let mut op_entry_point_interface_operands = vec![];
 
-        let mut bx = Builder::new_block(self, stub_fn, "");
+        let mut bx = Builder::build(self, Builder::append_block(self, stub_fn, ""));
         let mut call_args = vec![];
         let mut decoration_locations = FxHashMap::default();
         for (entry_arg_abi, hir_param) in arg_abis.iter().zip(hir_params) {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-05-17"
+channel = "nightly-2021-05-24"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -5,9 +5,9 @@
 %8 = OpVariable  %5  Function
 OpLine %9 319 5
 OpStore %8 %10
-OpLine %11 694 8
+OpLine %11 696 8
 OpCopyMemory %8 %4
-OpLine %11 695 8
+OpLine %11 697 8
 %12 = OpLoad  %13  %8
 OpLine %14 7 13
 OpStore %6 %12

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -5,9 +5,9 @@
 %8 = OpVariable  %5  Function
 OpLine %9 319 5
 OpStore %8 %10
-OpLine %11 694 8
+OpLine %11 696 8
 OpCopyMemory %8 %4
-OpLine %11 695 8
+OpLine %11 697 8
 %12 = OpLoad  %13  %8
 OpLine %14 7 13
 OpStore %6 %12

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -7,7 +7,7 @@ OpLine %9 7 35
 %10 = OpLoad  %11  %4
 OpLine %9 7 13
 OpStore %8 %10
-OpLine %12 878 8
+OpLine %12 880 8
 OpCopyMemory %6 %8
 OpLine %9 8 1
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -7,7 +7,7 @@ OpLine %9 7 37
 %10 = OpLoad  %11  %4
 OpLine %12 1012 17
 OpStore %8 %10
-OpLine %13 878 8
+OpLine %13 880 8
 OpCopyMemory %6 %8
 OpLine %9 8 1
 OpReturn


### PR DESCRIPTION
Most of the changes are for https://github.com/rust-lang/rust/pull/84993, with the `alloc_range` one being for https://github.com/rust-lang/rust/pull/85376.