### PR TITLE
Use `rust-toolchain.toml` instead

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,9 +1,0 @@
-# If you see this, run `rustup self update` to get rustup 1.23 or newer.
-
-# NOTE: above comment is for older `rustup` (before TOML support was added),
-# which will treat the first line as the toolchain name, and therefore show it
-# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
-
-[toolchain]
-channel = "nightly-2021-05-24"
-components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2021-05-24"
+components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
Note: rustup 1.24.0 (which adds support for this) was released on 2021-04-27, i.e. 29 days ago

Unfortunately, I don't think this will degrade gracefully for those using older rustups, but I expect that should be rare.

Note also that we started to depend on the toml format in #284, on 2020-12-07, around 10 days after rustup 1.23 (2020-11-27) released.