### PR TITLE
Use `legacy` mangling instead of `v0`.

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -264,6 +264,7 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         format!(" -C target-feature={}", target_features.join(","))
     };
 
+    //FIXME: reintroduce v0 mangling, see issue #642
     let rustflags = format!(
         "-Z codegen-backend={} -Zsymbol-mangling-version=legacy{}{}",
         rustc_codegen_spirv.display(),

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -265,7 +265,7 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
     };
 
     let rustflags = format!(
-        "-Z codegen-backend={} -Zsymbol-mangling-version=v0{}{}",
+        "-Z codegen-backend={} -Zsymbol-mangling-version=legacy{}{}",
         rustc_codegen_spirv.display(),
         feature_flag,
         llvm_args,


### PR DESCRIPTION
`v0` mangling mangles generics, but can only handle const generic
arguments of simple types. As `Image!` types use const generic enums,
things break horribly and compiler panics.
`legacy` doesn't even attempt to mangle generics, which is probably
fine.