### PR TITLE
Invert glam dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,6 @@ dependencies = [
 name = "compiletests-deps-helper"
 version = "0.4.0-alpha.6"
 dependencies = [
- "glam",
  "spirv-std",
 ]
 
@@ -1112,12 +1111,11 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.14.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
 dependencies = [
  "num-traits",
- "spirv-std",
 ]
 
 [[package]]
@@ -2272,7 +2270,6 @@ dependencies = [
 name = "shared"
 version = "0.4.0-alpha.6"
 dependencies = [
- "glam",
  "spirv-std",
 ]
 
@@ -2351,6 +2348,7 @@ name = "spirv-std"
 version = "0.4.0-alpha.7"
 dependencies = [
  "bitflags",
+ "glam",
  "num-traits",
  "spirv-std-macros",
  "spirv-types",

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -12,6 +12,7 @@ bitflags = "1.2.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
 spirv-types = { path = "./shared", version = "0.4.0-alpha.3" }
 spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.3" }
+glam = { version = "0.15.2", default-features = false, features = ["libm"], optional = true }
 
 [features]
 default = []

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -103,6 +103,9 @@ pub use num_traits;
 pub use runtime_array::*;
 pub use textures::*;
 
+#[cfg(feature = "glam")]
+pub use glam;
+
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo<'_>) -> ! {

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -1,2 +1,39 @@
 /// Abstract trait representing a SPIR-V vector type.
 pub unsafe trait Vector<T: crate::scalar::Scalar, const N: usize>: Default {}
+
+#[cfg(feature = "glam")]
+unsafe impl Vector<bool, 2> for glam::BVec2 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<bool, 3> for glam::BVec3 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<bool, 4> for glam::BVec4 {}
+
+#[cfg(feature = "glam")]
+unsafe impl Vector<f32, 2> for glam::Vec2 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<f32, 3> for glam::Vec3 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<f32, 3> for glam::Vec3A {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<f32, 4> for glam::Vec4 {}
+
+#[cfg(feature = "glam")]
+unsafe impl Vector<f64, 2> for glam::DVec2 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<f64, 3> for glam::DVec3 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<f64, 4> for glam::DVec4 {}
+
+#[cfg(feature = "glam")]
+unsafe impl Vector<u32, 2> for glam::UVec2 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<u32, 3> for glam::UVec3 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<u32, 4> for glam::UVec4 {}
+
+#[cfg(feature = "glam")]
+unsafe impl Vector<i32, 2> for glam::IVec2 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<i32, 3> for glam::IVec3 {}
+#[cfg(feature = "glam")]
+unsafe impl Vector<i32, 4> for glam::IVec4 {}

--- a/examples/shaders/compute-shader/Cargo.toml
+++ b/examples/shaders/compute-shader/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 crate-type = ["dylib"]
 
 [dependencies]
-spirv-std = { path = "../../../crates/spirv-std" }
+spirv-std = { path = "../../../crates/spirv-std", features = ["glam"] }

--- a/examples/shaders/mouse-shader/Cargo.toml
+++ b/examples/shaders/mouse-shader/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["dylib"]
 
 [dependencies]
 shared = { path = "../../shaders/shared" }
-spirv-std = { path = "../../../crates/spirv-std" }
+spirv-std = { path = "../../../crates/spirv-std", features = ["glam"] }

--- a/examples/shaders/shared/Cargo.toml
+++ b/examples/shaders/shared/Cargo.toml
@@ -7,5 +7,4 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-spirv-std = { path = "../../../crates/spirv-std" }
-glam = { version = "0.14", default-features = false, features = ["libm", "scalar-math", "spirv-std"] }
+spirv-std = { path = "../../../crates/spirv-std", features = ["glam"] }

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -5,7 +5,7 @@
 use core::f32::consts::PI;
 use glam::{vec3, Vec3};
 
-pub use glam;
+pub use spirv_std::glam;
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.

--- a/examples/shaders/simplest-shader/Cargo.toml
+++ b/examples/shaders/simplest-shader/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 crate-type = ["dylib"]
 
 [dependencies]
-spirv-std = { path = "../../../crates/spirv-std" }
+spirv-std = { path = "../../../crates/spirv-std", features = ["glam"] }
 shared = { path = "../shared" }

--- a/examples/shaders/sky-shader/Cargo.toml
+++ b/examples/shaders/sky-shader/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["lib", "dylib"]
 
 [dependencies]
 shared = { path = "../../shaders/shared" }
-spirv-std = { path = "../../../crates/spirv-std" }
+spirv-std = { path = "../../../crates/spirv-std", features = ["glam"] }

--- a/tests/deps-helper/Cargo.toml
+++ b/tests/deps-helper/Cargo.toml
@@ -8,9 +8,4 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-spirv-std = { path = "../../crates/spirv-std", features = ["const-generics"] }
-
-[dependencies.glam]
-version = "0.14"
-default-features = false
-features = ["libm", "scalar-math", "spirv-std"]
+spirv-std = { path = "../../crates/spirv-std", features = ["const-generics", "glam"] }

--- a/tests/ui/lang/control_flow/issue_283.rs
+++ b/tests/ui/lang/control_flow/issue_283.rs
@@ -1,4 +1,5 @@
 // build-pass
+#![feature(lang_items)]
 
 use glam::*;
 
@@ -46,3 +47,13 @@ pub fn main() {
     let v = Vec3::new(1.0, 1.0, 1.0);
     render(v, v, 1.0, 2.0);
 }
+
+// TODO: Figure out why these are needed and remove them (it should pick up the ones in spirv_std)
+// https://github.com/EmbarkStudios/rust-gpu/issues/640
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[lang = "eh_personality"]
+extern "C" fn rust_eh_personality() {}


### PR DESCRIPTION
As discussed a couple weeks ago in the rust-gpu weekly meeting, invert the glam dependency back to spirv-std depending on glam.

Going forward, we'll want to keep spirv-std completely agnostic other than specifically these trait impls, so it stays a fully generic library. The trait impls are also behind a feature flag, so someone can swap out glam for another vector library and not even compile glam at all (although they'll have to either impl the traits in that vector library and make it depend on spirv-std, or submit a PR adding another set of trait impls behind a feature flag like glam is here)

The complementary PR to glam is here https://github.com/bitshifter/glam-rs/pull/189 but thankfully, we don't need to wait for that to go through and get into a glam release, since we can simply remove the `spirv-std` feature flag of glam and cargo is happy with that.