### PR TITLE
Release v0.4.0-alpha.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "compiletests"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "compiletest_rs",
  "rustc_codegen_spirv",
@@ -392,14 +392,14 @@ dependencies = [
 
 [[package]]
 name = "compiletests-deps-helper"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "spirv-std",
 ]
 
 [[package]]
 name = "compute-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "spirv-std",
 ]
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-ash"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "ash 0.32.1",
  "ash-molten",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-cpu"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "minifb",
  "rayon",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-wgpu"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "cfg-if 1.0.0",
  "clap 3.0.0-beta.2",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-wgpu-builder"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "spirv-builder",
 ]
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "mouse-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "shared",
  "spirv-std",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "multibuilder"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "spirv-builder",
 ]
@@ -2105,7 +2105,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "bimap",
  "hashbrown",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "spirv-std",
 ]
@@ -2281,7 +2281,7 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simplest-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "shared",
  "spirv-std",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "sky-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "shared",
  "spirv-std",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-builder"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "memchr",
  "raw-string",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "bitflags",
  "glam",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-types"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 
 [[package]]
 name = "spirv_cross"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-builder"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,8 +10,8 @@ description = "Standard functions and types for SPIR-V"
 [dependencies]
 bitflags = "1.2.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
-spirv-types = { path = "./shared", version = "0.4.0-alpha.8" }
-spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.8" }
+spirv-types = { path = "./shared", version = "0.4.0-alpha.9" }
+spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.9" }
 glam = { version = "0.15.2", default-features = false, features = ["libm"], optional = true }
 
 [features]

--- a/crates/spirv-std/macros/Cargo.toml
+++ b/crates/spirv-std/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ description = "Macros for spirv-std"
 proc-macro = true
 
 [dependencies]
-spirv-types = { path = "../shared", version = "0.4.0-alpha.8" }
+spirv-types = { path = "../shared", version = "0.4.0-alpha.9" }
 heck = "0.3.2"
 proc-macro2 = "1.0.24"
 quote = "1.0.8"

--- a/crates/spirv-std/shared/Cargo.toml
+++ b/crates/spirv-std/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spirv-types"
 description = "SPIR-V types shared between spirv-std and spirv-std-macros"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/multibuilder/Cargo.toml
+++ b/examples/multibuilder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multibuilder"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-ash"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/cpu/Cargo.toml
+++ b/examples/runners/cpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-cpu"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-wgpu"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/wgpu/builder/Cargo.toml
+++ b/examples/runners/wgpu/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-wgpu-builder"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/compute-shader/Cargo.toml
+++ b/examples/shaders/compute-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/mouse-shader/Cargo.toml
+++ b/examples/shaders/mouse-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mouse-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/shared/Cargo.toml
+++ b/examples/shaders/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/simplest-shader/Cargo.toml
+++ b/examples/shaders/simplest-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplest-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/sky-shader/Cargo.toml
+++ b/examples/shaders/sky-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky-shader"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletests"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/tests/deps-helper/Cargo.toml
+++ b/tests/deps-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletests-deps-helper"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 description = "Shared dependencies of all the compiletest tests"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"


### PR DESCRIPTION
For miscompilation hotfix https://github.com/EmbarkStudios/rust-gpu/commit/a5e9fe751b5d2108e22d6b06e0662d0c1d939839

(I won't be publishing spirv-std on crates.io for this, as alpha.8 is identical, but I still want to keep the versions consistent so I bumped it)