### PR TITLE
fix trace ray acceleration structure type

### DIFF
--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -98,10 +98,11 @@ impl AccelerationStructure {
         payload: &mut T,
     ) {
         asm! {
+            "%acceleration_structure = OpLoad _ {acceleration_structure}",
             "%ray_origin = OpLoad _ {ray_origin}",
             "%ray_direction = OpLoad _ {ray_direction}",
             "OpTraceRayKHR \
-            {acceleration_structure} \
+            %acceleration_structure \
             {ray_flags} \
             {cull_mask} \
             {sbt_offset} \


### PR DESCRIPTION
Looks like `TraceRayKHR` accepts acceleration structure as a handle not a pointer. Previously the generated spirv didn't do `OpLoad` for AS param and crashed `vkCreateGraphicsPipelines` with `ERROR_INITIALIZATION_FAILED`.

In SPIRV specs, they use `descriptor` for AS param and `pointer` to describe `payload` param. It's confusing. But I guess they are not the same. It's the first time that I write any SPIRV assembly, so prove me wrong. 


