### PR TITLE
👀 hot shader reloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e564d24da983c053beff1bb7178e237501206840a3e6bf4e267b9e8ae734a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1237,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b031475cb1b103ee221afb806a23d35e0570bf7271d7588762ceba8127ed43b3"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inplace_it"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1515,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.7",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,7 +1535,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log",
- "mio",
+ "mio 0.6.23",
  "slab",
 ]
 
@@ -1647,6 +1689,32 @@ checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f18203a26893ca1d3526cf58084025d5639f91c44f8b70ab3b724f60e819a0"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.7.11",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2338,6 +2406,7 @@ name = "spirv-builder"
 version = "0.4.0-alpha.9"
 dependencies = [
  "memchr",
+ "notify",
  "raw-string",
  "rustc_codegen_spirv",
  "serde",
@@ -3074,7 +3143,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "mio",
+ "mio 0.6.23",
  "mio-extras",
  "ndk",
  "ndk-glue",

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 default = ["use-compiled-tools"]
 use-installed-tools = ["rustc_codegen_spirv/use-installed-tools"]
 use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
+watch = ["notify"]
 
 [dependencies]
 memchr = "2.3"
@@ -18,3 +19,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # See comment in lib.rs invoke_rustc for why this is here
 rustc_codegen_spirv = { path = "../rustc_codegen_spirv", default-features = false }
+
+notify = { version = "5.0.0-pre.10", optional = true }

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -455,9 +455,8 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
     // we do that even in case of an error, to let through any useful messages
     // that ended up on stdout instead of stderr.
     let stdout = String::from_utf8(build.stdout).unwrap();
-    let artifact = get_last_artifact(&stdout);
-
     if build.status.success() {
+        let artifact = get_last_artifact(&stdout);
         Ok(artifact)
     } else {
         Err(SpirvBuilderError::BuildFailed)

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -71,10 +71,12 @@ pub use rustc_codegen_spirv::rspirv::spirv::Capability;
 pub use rustc_codegen_spirv::{CompileResult, ModuleResult};
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SpirvBuilderError {
     CratePathDoesntExist(PathBuf),
     BuildFailed,
     MultiModuleWithPrintMetadata,
+    WatchWithPrintMetadata,
     MetadataFileMissing(std::io::Error),
     MetadataFileMalformed(serde_json::Error),
 }
@@ -89,6 +91,9 @@ impl fmt::Display for SpirvBuilderError {
             SpirvBuilderError::MultiModuleWithPrintMetadata => f.write_str(
                 "Multi-module build cannot be used with print_metadata = MetadataPrintout::Full",
             ),
+            SpirvBuilderError::WatchWithPrintMetadata => {
+                f.write_str("Watching within build scripts will prevent build completion")
+            }
             SpirvBuilderError::MetadataFileMissing(_) => {
                 f.write_str("Multi-module metadata file missing")
             }

--- a/crates/spirv-builder/src/watch.rs
+++ b/crates/spirv-builder/src/watch.rs
@@ -1,0 +1,106 @@
+use std::{collections::HashSet, sync::mpsc::sync_channel};
+
+use notify::{Event, RecursiveMode, Watcher};
+use rustc_codegen_spirv::CompileResult;
+
+use crate::{leaf_deps, SpirvBuilder, SpirvBuilderError};
+
+impl SpirvBuilder {
+    /// Watches the module for changes using [`notify`](https://crates.io/crates/notify).
+    ///
+    /// This is a blocking operation, wand should never return in the happy path
+    pub fn watch(
+        mut self,
+        on_compilation_finishes: impl Fn(CompileResult),
+    ) -> Result<(), SpirvBuilderError> {
+        self.validate_running_conditions()?;
+        if !matches!(self.print_metadata, crate::MetadataPrintout::None) {
+            return Err(SpirvBuilderError::WatchWithPrintMetadata);
+        }
+        let metadata_result = crate::invoke_rustc(&self);
+        // Load the dependencies of the thing
+        let metadata_file = match metadata_result {
+            Ok(path) => path,
+            Err(_) => {
+                let (tx, rx) = sync_channel(0);
+                // Fall back to watching from the crate root if the inital compilation fails
+                let mut watcher =
+                    notify::immediate_watcher(move |event: notify::Result<Event>| match event {
+                        Ok(e) => match e.kind {
+                            notify::EventKind::Access(_) => (),
+                            notify::EventKind::Any
+                            | notify::EventKind::Create(_)
+                            | notify::EventKind::Modify(_)
+                            | notify::EventKind::Remove(_)
+                            | notify::EventKind::Other => {
+                                let _ = tx.try_send(());
+                            }
+                        },
+                        Err(e) => println!("notify error: {:?}", e),
+                    })
+                    .expect("Could create watcher");
+                // This is likely to notice changes in the `target` dir, however, given that `cargo watch` doesn't seem to handle that,
+                watcher
+                    .watch(&self.path_to_crate, RecursiveMode::Recursive)
+                    .expect("Could watch crate root");
+                loop {
+                    rx.recv().expect("Watcher still alive");
+                    let metadata_file = crate::invoke_rustc(&self);
+                    match metadata_file {
+                        Ok(f) => break f,
+                        Err(_) => (), // Continue the loop until compilation succeeds
+                    }
+                }
+            }
+        };
+        let metadata = self.parse_metadata_file(&metadata_file)?;
+        on_compilation_finishes(metadata);
+        let mut watched_paths = HashSet::new();
+        let (tx, rx) = sync_channel(0);
+        let mut watcher =
+            notify::immediate_watcher(move |event: notify::Result<Event>| match event {
+                Ok(e) => match e.kind {
+                    notify::EventKind::Access(_) => (),
+                    notify::EventKind::Any
+                    | notify::EventKind::Create(_)
+                    | notify::EventKind::Modify(_)
+                    | notify::EventKind::Remove(_)
+                    | notify::EventKind::Other => {
+                        let _ = tx.try_send(());
+                    }
+                },
+                Err(e) => println!("notify error: {:?}", e),
+            })
+            .expect("Could create watcher");
+        leaf_deps(&metadata_file, |it| {
+            let path = it.to_path().unwrap();
+            if watched_paths.insert(path.to_owned()) {
+                watcher
+                    .watch(it.to_path().unwrap(), RecursiveMode::NonRecursive)
+                    .expect("Cargo dependencies are valid files");
+            }
+        })
+        .expect("Could read dependencies file");
+        loop {
+            rx.recv().expect("Watcher still alive");
+            let metadata_result = crate::invoke_rustc(&self);
+            match metadata_result {
+                Ok(file) => {
+                    // We can bubble this error up because it's an internal error  (e.g. rustc_codegen_spirv's version of CompileResult is somehow out of sync)
+                    let metadata = self.parse_metadata_file(&file)?;
+                    leaf_deps(&file, |it| {
+                        let path = it.to_path().unwrap();
+                        if watched_paths.insert(path.to_owned()) {
+                            watcher
+                                .watch(it.to_path().unwrap(), RecursiveMode::NonRecursive)
+                                .expect("Cargo dependencies are valid files");
+                        }
+                    })
+                    .expect("Could read dependencies file");
+                    on_compilation_finishes(metadata);
+                }
+                Err(_) => (), // Continue until compilation succeeds
+            }
+        }
+    }
+}

--- a/crates/spirv-builder/src/watch.rs
+++ b/crates/spirv-builder/src/watch.rs
@@ -88,6 +88,7 @@ impl SpirvBuilder {
                 Ok(file) => {
                     // We can bubble this error up because it's an internal error  (e.g. rustc_codegen_spirv's version of CompileResult is somehow out of sync)
                     let metadata = self.parse_metadata_file(&file)?;
+
                     leaf_deps(&file, |it| {
                         let path = it.to_path().unwrap();
                         if watched_paths.insert(path.to_owned()) {
@@ -97,6 +98,7 @@ impl SpirvBuilder {
                         }
                     })
                     .expect("Could read dependencies file");
+
                     on_compilation_finishes(metadata);
                 }
                 Err(_) => (), // Continue until compilation succeeds

--- a/deny.toml
+++ b/deny.toml
@@ -69,6 +69,11 @@ exceptions = [
     # https://tldrlegal.com/license/do-what-the-f*ck-you-want-to-public-license-(wtfpl)
     { allow = ["WTFPL"], name = "xkb" },
     { allow = ["WTFPL"], name = "xkbcommon-sys" },
+
+    # CC0 is a permissive license but somewhat unclear status for source code
+    # so we prefer to not have dependencies using it
+    # https://tldrlegal.com/license/creative-commons-cc0-1.0-universal
+    { allow = ["CC0-1.0"], name = "notify" },
 ]
 copyleft = "deny"
 

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -25,7 +25,7 @@ clap = "3.0.0-beta.2"
 strum = { version = "0.20", default_features = false, features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_arch = "wasm32")))'.dependencies]
-spirv-builder = { path = "../../../crates/spirv-builder", default-features = false }
+spirv-builder = { path = "../../../crates/spirv-builder", default-features = false, features = ["watch"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-glue = "0.2"

--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -1,6 +1,6 @@
 use wgpu::util::DeviceExt;
 
-use super::{shader_module, Options};
+use super::Options;
 use futures::future::join;
 use std::{convert::TryInto, future::Future, num::NonZeroU64, time::Duration};
 
@@ -15,7 +15,8 @@ fn block_on<T>(future: impl Future<Output = T>) -> T {
 }
 
 pub fn start(options: &Options) {
-    let shader_binary = shader_module(options.shader);
+    let rx = crate::maybe_watch(options.shader, true);
+    let shader_binary = rx.recv().expect("Should send one binary");
 
     block_on(start_internal(options, shader_binary))
 }

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -42,7 +42,10 @@
     rust_2018_idioms
 )]
 
+use std::sync::mpsc::{self, Receiver, SyncSender};
+
 use clap::Clap;
+use spirv_builder::CompileResult;
 use strum::{Display, EnumString};
 
 mod compute;
@@ -56,7 +59,12 @@ pub enum RustGPUShader {
     Mouse,
 }
 
-fn shader_module(shader: RustGPUShader) -> wgpu::ShaderModuleDescriptor<'static> {
+fn maybe_watch(
+    shader: RustGPUShader,
+    force_no_watch: bool,
+) -> Receiver<wgpu::ShaderModuleDescriptor<'static>> {
+    // This bound needs to be 1, because when we don't watch, we
+    let (tx, rx) = mpsc::sync_channel(1);
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
         use spirv_builder::{Capability, MetadataPrintout, SpirvBuilder};
@@ -86,29 +94,53 @@ fn shader_module(shader: RustGPUShader) -> wgpu::ShaderModuleDescriptor<'static>
         for &cap in capabilities {
             builder = builder.capability(cap);
         }
-        let compile_result = builder.build().unwrap();
-        let module_path = compile_result.module.unwrap_single();
-        let data = std::fs::read(module_path).unwrap();
-        let spirv = wgpu::util::make_spirv(&data);
-        let spirv = match spirv {
-            wgpu::ShaderSource::Wgsl(cow) => wgpu::ShaderSource::Wgsl(Cow::Owned(cow.into_owned())),
-            wgpu::ShaderSource::SpirV(cow) => {
-                wgpu::ShaderSource::SpirV(Cow::Owned(cow.into_owned()))
-            }
-        };
-        wgpu::ShaderModuleDescriptor {
-            label: None,
-            source: spirv,
-            flags: wgpu::ShaderFlags::default(),
+        if force_no_watch {
+            let compile_result = builder.build().unwrap();
+            handle_builder_result(compile_result, &tx);
+        } else {
+            let thread = std::thread::spawn(move || {
+                builder
+                    .watch(|compile_result| {
+                        handle_builder_result(compile_result, &tx);
+                    })
+                    .expect("Configuration is correct for watching")
+            });
+            std::mem::forget(thread);
+        }
+        fn handle_builder_result(
+            compile_result: CompileResult,
+            tx: &SyncSender<wgpu::ShaderModuleDescriptor<'static>>,
+        ) {
+            let module_path = compile_result.module.unwrap_single();
+            let data = std::fs::read(module_path).unwrap();
+            let spirv = wgpu::util::make_spirv(&data);
+            let spirv = match spirv {
+                wgpu::ShaderSource::Wgsl(cow) => {
+                    wgpu::ShaderSource::Wgsl(Cow::Owned(cow.into_owned()))
+                }
+                wgpu::ShaderSource::SpirV(cow) => {
+                    wgpu::ShaderSource::SpirV(Cow::Owned(cow.into_owned()))
+                }
+            };
+            tx.send(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: spirv,
+                flags: wgpu::ShaderFlags::default(),
+            })
+            .expect("Rx is still alive");
         }
     }
     #[cfg(any(target_os = "android", target_arch = "wasm32"))]
-    match shader {
-        RustGPUShader::Simplest => wgpu::include_spirv!(env!("simplest_shader.spv")),
-        RustGPUShader::Sky => wgpu::include_spirv!(env!("sky_shader.spv")),
-        RustGPUShader::Compute => wgpu::include_spirv!(env!("compute_shader.spv")),
-        RustGPUShader::Mouse => wgpu::include_spirv!(env!("mouse_shader.spv")),
+    {
+        tx.send(match shader {
+            RustGPUShader::Simplest => wgpu::include_spirv!(env!("simplest_shader.spv")),
+            RustGPUShader::Sky => wgpu::include_spirv!(env!("sky_shader.spv")),
+            RustGPUShader::Compute => wgpu::include_spirv!(env!("compute_shader.spv")),
+            RustGPUShader::Mouse => wgpu::include_spirv!(env!("mouse_shader.spv")),
+        })
+        .expect("rx to be alive")
     }
+    rx
 }
 
 fn is_compute_shader(shader: RustGPUShader) -> bool {

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -42,10 +42,9 @@
     rust_2018_idioms
 )]
 
-use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::sync::mpsc::{self, Receiver};
 
 use clap::Clap;
-use spirv_builder::CompileResult;
 use strum::{Display, EnumString};
 
 mod compute;
@@ -67,7 +66,7 @@ fn maybe_watch(
     let (tx, rx) = mpsc::sync_channel(1);
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
-        use spirv_builder::{Capability, MetadataPrintout, SpirvBuilder};
+        use spirv_builder::{Capability, CompileResult, MetadataPrintout, SpirvBuilder};
         use std::borrow::Cow;
         use std::path::PathBuf;
         // Hack: spirv_builder builds into a custom directory if running under cargo, to not
@@ -109,7 +108,7 @@ fn maybe_watch(
         }
         fn handle_builder_result(
             compile_result: CompileResult,
-            tx: &SyncSender<wgpu::ShaderModuleDescriptor<'static>>,
+            tx: &mpsc::SyncSender<wgpu::ShaderModuleDescriptor<'static>>,
         ) {
             let module_path = compile_result.module.unwrap_single();
             let data = std::fs::read(module_path).unwrap();

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -62,7 +62,8 @@ fn maybe_watch(
     shader: RustGPUShader,
     force_no_watch: bool,
 ) -> Receiver<wgpu::ShaderModuleDescriptor<'static>> {
-    // This bound needs to be 1, because when we don't watch, we
+    // This bound needs to be 1, because in cases where this function is used for direct building (e.g. for the compute example or on android)
+    // we send the value directly in the same thread. This avoids deadlocking in those cases.
     let (tx, rx) = mpsc::sync_channel(1);
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {


### PR DESCRIPTION
Add a (feature gated) implementation of hot shader reloading to SpirvBuilder

This attempts to handle initial compilation gracefully by watching the shader crate root recursively until we have more detailed dependency information

Unfortunately, notify uses a non-standard license (CC0) so we fail the cargo deny check. I will defer adding a commit which changes `deny.toml` to allow this to pass to the suitable Embarker (@XAMPPRocky ?)

It appears that if there was sufficient demand for it, notify would be willing to update their license ( https://github.com/notify-rs/notify/issues/243#issuecomment-792078532)

In theory, the CC0 license they are under is probably already MIT/Apache compatible, so `notify` could avoid getting new permissions from the contributors, but it would still be wise to notify (ha) them.

(See e.g. [this stackoverflow post](https://webcache.googleusercontent.com/search?q=cache:fophIpDX5Z0J:https://opensource.stackexchange.com/questions/4235/how-do-i-turn-a-public-domain-project-into-a-mit-project+&cd=10&hl=en&ct=clnk&gl=uk&client=firefox-b-d) (this is google's webcache since stackoverflow is down at the time of posting))

I'm also planning to integrate this into the example runner, but want to get the ball rolling on the license issues