### PR TITLE
mcp: dynamic bindless resource access

### DIFF
--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -102,6 +102,7 @@ pub enum SpirvAttribute {
     UnrollLoops,
     InternalBufferLoad,
     InternalBufferStore,
+    ResourceAccess,
 }
 
 // HACK(eddyb) this is similar to `rustc_span::Spanned` but with `value` as the
@@ -137,6 +138,7 @@ pub struct AggregatedSpirvAttributes {
     pub unroll_loops: Option<Spanned<()>>,
     pub internal_buffer_load: Option<Spanned<()>>,
     pub internal_buffer_store: Option<Spanned<()>>,
+    pub resource_access: Option<Spanned<()>>,
 }
 
 struct MultipleAttrs {
@@ -235,6 +237,12 @@ impl AggregatedSpirvAttributes {
                 (),
                 span,
                 "#[spirv(internal_buffer_store)]",
+            ),
+            ResourceAccess => try_insert(
+                &mut self.resource_access,
+                (),
+                span,
+                "#[spirv(resource_access)]",
             ),
         }
     }
@@ -362,6 +370,7 @@ impl CheckSpirvAttrVisitor<'_> {
                 },
                 SpirvAttribute::InternalBufferLoad
                 | SpirvAttribute::InternalBufferStore
+                | SpirvAttribute::ResourceAccess
                 | SpirvAttribute::UnrollLoops => match target {
                     Target::Fn
                     | Target::Closure

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -2194,6 +2194,8 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 kind: SpirvValueKind::IllegalTypeUsed(void_ty),
                 ty: void_ty,
             }
+        } else if self.resource_access_id.borrow().contains(&callee_val) {
+            self.codegen_resource_access(result_type, args)
         } else {
             let args = args.iter().map(|arg| arg.def(self)).collect::<Vec<_>>();
             self.emit()

--- a/crates/rustc_codegen_spirv/src/builder/load_store.rs
+++ b/crates/rustc_codegen_spirv/src/builder/load_store.rs
@@ -1,3 +1,8 @@
+//! Templated raw buffer load/store.
+//!
+//! Generate load/store from a u32 runtime array converting to/from
+//! a requested input struct.
+
 use super::Builder;
 use crate::builder_spirv::{SpirvValue, SpirvValueExt};
 use crate::rustc_codegen_ssa::traits::BuilderMethods;

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -3,6 +3,7 @@ mod ext_inst;
 mod intrinsics;
 pub mod libm_intrinsics;
 mod load_store;
+mod resource_access;
 mod spirv_asm;
 
 pub use ext_inst::ExtInst;

--- a/crates/rustc_codegen_spirv/src/builder/resource_access.rs
+++ b/crates/rustc_codegen_spirv/src/builder/resource_access.rs
@@ -1,0 +1,56 @@
+use super::Builder;
+use crate::spirv_type::SpirvType;
+use crate::builder_spirv::{SpirvValue, SpirvValueExt};
+use rspirv::spirv::Word;
+
+impl<'a, 'tcx> Builder<'a, 'tcx> {
+    pub(crate) fn codegen_resource_access(
+        &mut self,
+        result_type: Word,
+        args: &[SpirvValue],
+    ) -> SpirvValue {
+        if !self.bindless() {
+            self.fatal("Need to run the compiler with -Ctarget-feature=+bindless to be able to use the bindless features");
+        }
+
+        let bindless_idx = args[0].def(self);
+        let sets = self.bindless_descriptor_sets.borrow().unwrap();
+
+        let access = match self.lookup_type(result_type) {
+            SpirvType::Sampler => {
+                let result_ptr =
+                    SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
+
+                self.emit()
+                    .access_chain(result_ptr, None, sets.samplers, vec![bindless_idx])
+                    .unwrap()
+            }
+            SpirvType::Image { .. } => {
+                let result_ptr =
+                    SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
+
+                // todo: sampled 2d
+                self.emit()
+                    .access_chain(result_ptr, None, sets.sampled_image_2d, vec![bindless_idx])
+                    .unwrap()
+            }
+            SpirvType::RuntimeArray { .. } => {
+                let uint_ty = SpirvType::Integer(32, false).def(rustc_span::DUMMY_SP, self);
+                let zero = self.constant_int(uint_ty, 0).def(self);
+
+                let result_ptr =
+                    SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
+
+                self.emit()
+                    .access_chain(result_ptr, None, sets.buffers, vec![bindless_idx, zero])
+                    .unwrap()
+            }
+            ty => self.fatal(&format!("{:?} unsupported for resource access", ty)),
+        };
+
+        self.emit()
+            .load(result_type, None, access, None, std::iter::empty())
+            .unwrap()
+            .with_type(result_type)
+    }
+}

--- a/crates/rustc_codegen_spirv/src/builder/resource_access.rs
+++ b/crates/rustc_codegen_spirv/src/builder/resource_access.rs
@@ -1,3 +1,9 @@
+//! Bindless dynamic resource access.
+//!
+//! Indexed descriptor lookup from bindless runtime arrays. It will infer the
+//! requested descriptor type from the result type.
+//! Global bindless descriptor sets will be lazily constructed for the descriptor type.
+
 use super::Builder;
 use crate::builder_spirv::{SpirvValue, SpirvValueExt};
 use crate::spirv_type::SpirvType;

--- a/crates/rustc_codegen_spirv/src/builder/resource_access.rs
+++ b/crates/rustc_codegen_spirv/src/builder/resource_access.rs
@@ -16,41 +16,45 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let bindless_idx = args[0].def(self);
         let sets = self.bindless_descriptor_sets.borrow().unwrap();
 
-        let access = match self.lookup_type(result_type) {
+        match self.lookup_type(result_type) {
             SpirvType::Sampler => {
                 let result_ptr =
                     SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
 
-                self.emit()
+                let access = self.emit()
                     .access_chain(result_ptr, None, sets.samplers, vec![bindless_idx])
+                    .unwrap();
+                self.emit()
+                    .load(result_type, None, access, None, std::iter::empty())
                     .unwrap()
+                    .with_type(result_type)
             }
             SpirvType::Image { .. } => {
                 let result_ptr =
                     SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
 
                 // todo: sampled 2d
-                self.emit()
+                let access = self.emit()
                     .access_chain(result_ptr, None, sets.sampled_image_2d, vec![bindless_idx])
-                    .unwrap()
-            }
-            SpirvType::RuntimeArray { .. } => {
-                let uint_ty = SpirvType::Integer(32, false).def(rustc_span::DUMMY_SP, self);
-                let zero = self.constant_int(uint_ty, 0).def(self);
-
-                let result_ptr =
-                    SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
-
+                    .unwrap();
                 self.emit()
-                    .access_chain(result_ptr, None, sets.buffers, vec![bindless_idx, zero])
+                    .load(result_type, None, access, None, std::iter::empty())
                     .unwrap()
+                    .with_type(result_type)
+            }
+            SpirvType::Pointer { pointee } => match self.lookup_type(pointee) {
+                SpirvType::RuntimeArray { .. } => {
+                    let uint_ty = SpirvType::Integer(32, false).def(rustc_span::DUMMY_SP, self);
+                    let zero = self.constant_int(uint_ty, 0).def(self);
+
+                    self.emit()
+                        .access_chain(result_type, None, sets.buffers, vec![bindless_idx, zero])
+                        .unwrap()
+                        .with_type(result_type)
+                }
+                ty => self.fatal(&format!("Pointer({:?}) unsupported for resource access", ty)),
             }
             ty => self.fatal(&format!("{:?} unsupported for resource access", ty)),
-        };
-
-        self.emit()
-            .load(result_type, None, access, None, std::iter::empty())
-            .unwrap()
-            .with_type(result_type)
+        }
     }
 }

--- a/crates/rustc_codegen_spirv/src/builder/resource_access.rs
+++ b/crates/rustc_codegen_spirv/src/builder/resource_access.rs
@@ -1,6 +1,6 @@
 use super::Builder;
-use crate::spirv_type::SpirvType;
 use crate::builder_spirv::{SpirvValue, SpirvValueExt};
+use crate::spirv_type::SpirvType;
 use rspirv::spirv::Word;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
@@ -17,11 +17,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         match self.lookup_type(result_type) {
             SpirvType::Sampler => {
-                let result_ptr =
-                    SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
+                let result_ptr = SpirvType::Pointer {
+                    pointee: result_type,
+                }
+                .def(rustc_span::DUMMY_SP, self);
 
                 let set = self.cx.sampler_bindless_descriptor_set();
-                let access = self.emit()
+                let access = self
+                    .emit()
                     .access_chain(result_ptr, None, set, vec![bindless_idx])
                     .unwrap();
                 self.emit()
@@ -30,11 +33,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .with_type(result_type)
             }
             SpirvType::Image { .. } => {
-                let result_ptr =
-                    SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
+                let result_ptr = SpirvType::Pointer {
+                    pointee: result_type,
+                }
+                .def(rustc_span::DUMMY_SP, self);
 
                 let set = self.cx.texture_bindless_descriptor_set(result_type);
-                let access = self.emit()
+                let access = self
+                    .emit()
                     .access_chain(result_ptr, None, set, vec![bindless_idx])
                     .unwrap();
                 self.emit()
@@ -43,11 +49,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .with_type(result_type)
             }
             SpirvType::AccelerationStructureKhr => {
-                let result_ptr =
-                    SpirvType::Pointer { pointee: result_type }.def(rustc_span::DUMMY_SP, self);
+                let result_ptr = SpirvType::Pointer {
+                    pointee: result_type,
+                }
+                .def(rustc_span::DUMMY_SP, self);
 
                 let set = self.cx.acceleration_structure_bindless_descriptor_set();
-                let access = self.emit()
+                let access = self
+                    .emit()
                     .access_chain(result_ptr, None, set, vec![bindless_idx])
                     .unwrap();
                 self.emit()
@@ -66,8 +75,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         .unwrap()
                         .with_type(result_type)
                 }
-                ty => self.fatal(&format!("Pointer({:?}) unsupported for resource access", ty)),
-            }
+                ty => self.fatal(&format!(
+                    "Pointer({:?}) unsupported for resource access",
+                    ty
+                )),
+            },
             ty => self.fatal(&format!("{:?} unsupported for resource access", ty)),
         }
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -130,6 +130,9 @@ impl<'tcx> CodegenCx<'tcx> {
         if attrs.internal_buffer_store.is_some() {
             self.internal_buffer_store_id.borrow_mut().insert(fn_id);
         }
+        if attrs.resource_access.is_some() {
+            self.resource_access_id.borrow_mut().insert(fn_id);
+        }
 
         let instance_def_id = instance.def_id();
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -3,7 +3,6 @@ use crate::abi::ConvSpirvType;
 use crate::attr::{AggregatedSpirvAttributes, Entry};
 use crate::builder::Builder;
 use crate::builder_spirv::{SpirvValue, SpirvValueExt};
-use crate::codegen_cx::BindlessDescriptorSets;
 use crate::spirv_type::SpirvType;
 use rspirv::dr::Operand;
 use rspirv::spirv::{
@@ -19,6 +18,11 @@ use rustc_target::abi::{
     call::{ArgAbi, ArgAttribute, ArgAttributes, FnAbi, PassMode},
     Align, LayoutOf, Size,
 };
+
+const BINDLESS_BUFFER_SET: u32 = 0;
+const BINDLESS_TEXTURE_SET: u32 = 1;
+const BINDLESS_SAMPLER_SET: u32 = 2;
+const BINDLESS_TLAS_SET: u32 = 3;
 
 impl<'tcx> CodegenCx<'tcx> {
     // Entry points declare their "interface" (all uniforms, inputs, outputs, etc.) as parameters.
@@ -107,220 +111,173 @@ impl<'tcx> CodegenCx<'tcx> {
             });
     }
 
-    pub fn lazy_add_bindless_descriptor_sets(&self) {
-        self.bindless_descriptor_sets
-            .replace(Some(BindlessDescriptorSets {
-                // all storage buffers are compatible and go in set 0
-                buffers: self.buffer_descriptor_set(0),
+    pub fn buffer_bindless_descriptor_set(&self, ty: Word) -> Word {
+        self.bindless_descriptor_sets.borrow_mut().entry(ty).or_insert_with(|| {
+            let buffer_struct = SpirvType::Adt {
+                def_id: None,
+                size: Some(Size::from_bytes(4)),
+                align: Align::from_bytes(4).unwrap(),
+                field_types: vec![ty],
+                field_offsets: vec![],
+                field_names: None,
+            }
+            .def(rustc_span::DUMMY_SP, self);
 
-                // sampled images are all compatible in vulkan, so we can overlap them
-                sampled_image_1d: self.texture_bindless_descriptor_set(
-                    1,
-                    rspirv::spirv::Dim::Dim1D,
-                    true,
-                ),
-                sampled_image_2d: self.texture_bindless_descriptor_set(
-                    1,
-                    rspirv::spirv::Dim::Dim2D,
-                    true,
-                ),
-                sampled_image_3d: self.texture_bindless_descriptor_set(
-                    1,
-                    rspirv::spirv::Dim::Dim3D,
-                    true,
-                ),
-                samplers: self.sampler_descriptor_set(2),
-                acceleration_structures: self.acceleration_structure_descriptor_set(3),
-                // jb-todo: storage images are all compatible so they can live in the same descriptor set too
-            }));
+            let runtime_array_struct = SpirvType::RuntimeArray {
+                element: buffer_struct,
+            }
+            .def(rustc_span::DUMMY_SP, self);
+
+            let uniform_ptr_runtime_array = SpirvType::Pointer {
+                pointee: runtime_array_struct,
+            }
+            .def(rustc_span::DUMMY_SP, self);
+
+            let mut emit_global = self.emit_global();
+            let buffer = emit_global
+                .variable(
+                    uniform_ptr_runtime_array,
+                    None,
+                    if self.target.spirv_version() <= (1, 3) {
+                        StorageClass::Uniform
+                    } else {
+                        StorageClass::StorageBuffer
+                    },
+                    None,
+                )
+                .with_type(uniform_ptr_runtime_array)
+                .def_cx(self);
+
+            emit_global.decorate(
+                buffer,
+                rspirv::spirv::Decoration::DescriptorSet,
+                std::iter::once(Operand::LiteralInt32(BINDLESS_BUFFER_SET)),
+            );
+            emit_global.decorate(
+                buffer,
+                rspirv::spirv::Decoration::Binding,
+                std::iter::once(Operand::LiteralInt32(0)),
+            );
+
+            if self.target.spirv_version() <= (1, 3) {
+                emit_global.decorate(
+                    buffer_struct,
+                    rspirv::spirv::Decoration::BufferBlock,
+                    std::iter::empty(),
+                );
+            } else {
+                emit_global.decorate(
+                    buffer_struct,
+                    rspirv::spirv::Decoration::Block,
+                    std::iter::empty(),
+                );
+            }
+
+            emit_global.member_decorate(
+                buffer_struct,
+                0,
+                rspirv::spirv::Decoration::Offset,
+                std::iter::once(Operand::LiteralInt32(0)),
+            );
+
+            buffer
+        }).clone()
     }
 
-    fn buffer_descriptor_set(&self, descriptor_set: u32) -> Word {
-        let uint_ty = SpirvType::Integer(32, false).def(rustc_span::DUMMY_SP, self);
-
-        let runtime_array_uint =
-            SpirvType::RuntimeArray { element: uint_ty }.def(rustc_span::DUMMY_SP, self);
-
-        let buffer_struct = SpirvType::Adt {
-            def_id: None,
-            size: Some(Size::from_bytes(4)),
-            align: Align::from_bytes(4).unwrap(),
-            field_types: vec![runtime_array_uint],
-            field_offsets: vec![],
-            field_names: None,
-        }
-        .def(rustc_span::DUMMY_SP, self);
-
-        let runtime_array_struct = SpirvType::RuntimeArray {
-            element: buffer_struct,
-        }
-        .def(rustc_span::DUMMY_SP, self);
-
-        let uniform_ptr_runtime_array = SpirvType::Pointer {
-            pointee: runtime_array_struct,
-        }
-        .def(rustc_span::DUMMY_SP, self);
-
-        let mut emit_global = self.emit_global();
-        let buffer = emit_global
-            .variable(
-                uniform_ptr_runtime_array,
-                None,
-                if self.target.spirv_version() <= (1, 3) {
-                    StorageClass::Uniform
-                } else {
-                    StorageClass::StorageBuffer
-                },
-                None,
-            )
-            .with_type(uniform_ptr_runtime_array)
-            .def_cx(self);
-
-        emit_global.decorate(
-            buffer,
-            rspirv::spirv::Decoration::DescriptorSet,
-            std::iter::once(Operand::LiteralInt32(descriptor_set)),
-        );
-        emit_global.decorate(
-            buffer,
-            rspirv::spirv::Decoration::Binding,
-            std::iter::once(Operand::LiteralInt32(0)),
-        );
-
-        if self.target.spirv_version() <= (1, 3) {
-            emit_global.decorate(
-                buffer_struct,
-                rspirv::spirv::Decoration::BufferBlock,
-                std::iter::empty(),
-            );
-        } else {
-            emit_global.decorate(
-                buffer_struct,
-                rspirv::spirv::Decoration::Block,
-                std::iter::empty(),
-            );
-        }
-
-        emit_global.decorate(
-            runtime_array_uint,
-            rspirv::spirv::Decoration::ArrayStride,
-            std::iter::once(Operand::LiteralInt32(4)),
-        );
-
-        emit_global.member_decorate(
-            buffer_struct,
-            0,
-            rspirv::spirv::Decoration::Offset,
-            std::iter::once(Operand::LiteralInt32(0)),
-        );
-
-        buffer
-    }
-
-    fn texture_bindless_descriptor_set(
+    pub fn texture_bindless_descriptor_set(
         &self,
-        descriptor_set: u32,
-        dim: rspirv::spirv::Dim,
-        sampled: bool,
+        image: Word,
     ) -> Word {
-        let float_ty = SpirvType::Float(32).def(rustc_span::DUMMY_SP, self);
+        self.bindless_descriptor_sets.borrow_mut().entry(image).or_insert_with(|| {
+            let runtime_array_image = SpirvType::RuntimeArray {
+                element: image,
+            }
+            .def(rustc_span::DUMMY_SP, self);
 
-        let image = SpirvType::Image {
-            sampled_type: float_ty,
-            dim,
-            depth: 0,
-            arrayed: 0,
-            multisampled: 0,
-            sampled: if sampled { 1 } else { 0 },
-            image_format: rspirv::spirv::ImageFormat::Unknown,
-            access_qualifier: None,
-        }
-        .def(rustc_span::DUMMY_SP, self);
+            let uniform_ptr_runtime_array = SpirvType::Pointer {
+                pointee: runtime_array_image,
+            }
+            .def(rustc_span::DUMMY_SP, self);
 
-        let runtime_array_image = SpirvType::RuntimeArray {
-            element: image,
-        }
-        .def(rustc_span::DUMMY_SP, self);
+            let mut emit_global = self.emit_global();
+            let image_array = emit_global
+                .variable(uniform_ptr_runtime_array, None, StorageClass::UniformConstant, None)
+                .with_type(uniform_ptr_runtime_array)
+                .def_cx(self);
 
-        let uniform_ptr_runtime_array = SpirvType::Pointer {
-            pointee: runtime_array_image,
-        }
-        .def(rustc_span::DUMMY_SP, self);
+            emit_global.decorate(
+                image_array,
+                rspirv::spirv::Decoration::DescriptorSet,
+                std::iter::once(Operand::LiteralInt32(BINDLESS_TEXTURE_SET)),
+            );
+            emit_global.decorate(
+                image_array,
+                rspirv::spirv::Decoration::Binding,
+                std::iter::once(Operand::LiteralInt32(0)),
+            );
 
-        let mut emit_global = self.emit_global();
-        let image_array = emit_global
-            .variable(uniform_ptr_runtime_array, None, StorageClass::UniformConstant, None)
-            .with_type(uniform_ptr_runtime_array)
-            .def_cx(self);
-
-        emit_global.decorate(
-            image_array,
-            rspirv::spirv::Decoration::DescriptorSet,
-            std::iter::once(Operand::LiteralInt32(descriptor_set)),
-        );
-        emit_global.decorate(
-            image_array,
-            rspirv::spirv::Decoration::Binding,
-            std::iter::once(Operand::LiteralInt32(0)),
-        );
-
-        image_array
+            image_array
+        }).clone()
     }
 
-    fn sampler_descriptor_set(&self, descriptor_set: u32) -> Word {
+    pub fn sampler_bindless_descriptor_set(&self) -> Word {
         let sampler = SpirvType::Sampler.def(rustc_span::DUMMY_SP, self);
-        let runtime_array_sampler = SpirvType::RuntimeArray { element: sampler }.def(rustc_span::DUMMY_SP, self);
-        let uniform_ptr_runtime_array = SpirvType::Pointer {
-            pointee: runtime_array_sampler,
-        }
-        .def(rustc_span::DUMMY_SP, self);
+        self.bindless_descriptor_sets.borrow_mut().entry(sampler).or_insert_with(|| {
+            let runtime_array_sampler = SpirvType::RuntimeArray { element: sampler }.def(rustc_span::DUMMY_SP, self);
+            let uniform_ptr_runtime_array = SpirvType::Pointer {
+                pointee: runtime_array_sampler,
+            }
+            .def(rustc_span::DUMMY_SP, self);
 
-        let mut emit_global = self.emit_global();
-        let sampler_array = emit_global
-            .variable(uniform_ptr_runtime_array, None, StorageClass::UniformConstant, None)
-            .with_type(uniform_ptr_runtime_array)
-            .def_cx(self);
+            let mut emit_global = self.emit_global();
+            let sampler_array = emit_global
+                .variable(uniform_ptr_runtime_array, None, StorageClass::UniformConstant, None)
+                .with_type(uniform_ptr_runtime_array)
+                .def_cx(self);
 
-        emit_global.decorate(
-            sampler_array,
-            rspirv::spirv::Decoration::DescriptorSet,
-            std::iter::once(Operand::LiteralInt32(descriptor_set)),
-        );
-        emit_global.decorate(
-            sampler_array,
-            rspirv::spirv::Decoration::Binding,
-            std::iter::once(Operand::LiteralInt32(0)),
-        );
+            emit_global.decorate(
+                sampler_array,
+                rspirv::spirv::Decoration::DescriptorSet,
+                std::iter::once(Operand::LiteralInt32(BINDLESS_SAMPLER_SET)),
+            );
+            emit_global.decorate(
+                sampler_array,
+                rspirv::spirv::Decoration::Binding,
+                std::iter::once(Operand::LiteralInt32(0)),
+            );
 
-        sampler_array
+            sampler_array
+        }).clone()
     }
 
-    fn acceleration_structure_descriptor_set(&self, descriptor_set: u32) -> Word {
+    pub fn acceleration_structure_bindless_descriptor_set(&self) -> Word {
         let acceleration_structure = SpirvType::AccelerationStructureKhr.def(rustc_span::DUMMY_SP, self);
-        let runtime_array_as = SpirvType::RuntimeArray { element: acceleration_structure }.def(rustc_span::DUMMY_SP, self);
-        let uniform_ptr_runtime_array = SpirvType::Pointer {
-            pointee: runtime_array_as,
-        }
-        .def(rustc_span::DUMMY_SP, self);
+        self.bindless_descriptor_sets.borrow_mut().entry(acceleration_structure).or_insert_with(|| {
+            let runtime_array_as = SpirvType::RuntimeArray { element: acceleration_structure }.def(rustc_span::DUMMY_SP, self);
+            let uniform_ptr_runtime_array = SpirvType::Pointer {
+                pointee: runtime_array_as,
+            }
+            .def(rustc_span::DUMMY_SP, self);
 
-        let mut emit_global = self.emit_global();
-        let acceleration_structure_array = emit_global
-            .variable(uniform_ptr_runtime_array, None, StorageClass::UniformConstant, None)
-            .with_type(uniform_ptr_runtime_array)
-            .def_cx(self);
+            let mut emit_global = self.emit_global();
+            let acceleration_structure_array = emit_global
+                .variable(uniform_ptr_runtime_array, None, StorageClass::UniformConstant, None)
+                .with_type(uniform_ptr_runtime_array)
+                .def_cx(self);
 
-        emit_global.decorate(
-            acceleration_structure_array,
-            rspirv::spirv::Decoration::DescriptorSet,
-            std::iter::once(Operand::LiteralInt32(descriptor_set)),
-        );
-        emit_global.decorate(
-            acceleration_structure_array,
-            rspirv::spirv::Decoration::Binding,
-            std::iter::once(Operand::LiteralInt32(0)),
-        );
+            emit_global.decorate(
+                acceleration_structure_array,
+                rspirv::spirv::Decoration::DescriptorSet,
+                std::iter::once(Operand::LiteralInt32(BINDLESS_TLAS_SET)),
+            );
+            emit_global.decorate(
+                acceleration_structure_array,
+                rspirv::spirv::Decoration::Binding,
+                std::iter::once(Operand::LiteralInt32(0)),
+            );
 
-        acceleration_structure_array
+            acceleration_structure_array
+        }).clone()
     }
 
     fn shader_entry_stub(

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -347,8 +347,6 @@ impl<'tcx> CodegenCx<'tcx> {
             id.with_type(fn_void_void)
         };
 
-        let mut op_entry_point_interface_operands = vec![];
-
         let mut bx = Builder::build(self, Builder::append_block(self, stub_fn, ""));
         let mut call_args = vec![];
         let mut decoration_locations = FxHashMap::default();
@@ -357,7 +355,6 @@ impl<'tcx> CodegenCx<'tcx> {
             self.declare_shader_interface_for_param(
                 entry_arg_abi,
                 hir_param,
-                &mut op_entry_point_interface_operands,
                 &mut bx,
                 &mut call_args,
                 &mut decoration_locations,
@@ -371,21 +368,6 @@ impl<'tcx> CodegenCx<'tcx> {
             self.emit_global().extension("SPV_EXT_descriptor_indexing");
             self.emit_global()
                 .capability(Capability::RuntimeDescriptorArray);
-
-            if self.target.spirv_version() > (1, 3) {
-                let sets = self.bindless_descriptor_sets.borrow().unwrap();
-
-                op_entry_point_interface_operands.push(sets.buffers);
-
-                // op_entry_point_interface_operands
-                //     .push(sets.sampled_image_1d);
-                op_entry_point_interface_operands
-                    .push(sets.sampled_image_2d);
-                // op_entry_point_interface_operands
-                //     .push(sets.sampled_image_3d);
-                op_entry_point_interface_operands
-                    .push(sets.samplers);
-            }
         }
 
         let stub_fn_id = stub_fn.def_cx(self);
@@ -393,7 +375,7 @@ impl<'tcx> CodegenCx<'tcx> {
             execution_model,
             stub_fn_id,
             name,
-            op_entry_point_interface_operands,
+            vec![], // will be filled during linking, see [`interface::legalize_entrypoint`].
         );
         stub_fn_id
     }
@@ -519,7 +501,6 @@ impl<'tcx> CodegenCx<'tcx> {
         &self,
         entry_arg_abi: &ArgAbi<'tcx, Ty<'tcx>>,
         hir_param: &hir::Param<'tcx>,
-        op_entry_point_interface_operands: &mut Vec<Word>,
         bx: &mut Builder<'_, 'tcx>,
         call_args: &mut Vec<SpirvValue>,
         decoration_locations: &mut FxHashMap<StorageClass, u32>,
@@ -786,18 +767,6 @@ impl<'tcx> CodegenCx<'tcx> {
         // Emit the `OpVariable` with its *Result* ID set to `var`.
         self.emit_global()
             .variable(var_ptr_spirv_type, Some(var), storage_class, None);
-
-        // Record this `OpVariable` as needing to be added (if applicable),
-        // to the *Interface* operands of the `OpEntryPoint` instruction.
-        if self.emit_global().version().unwrap() > (1, 3) {
-            // SPIR-V >= v1.4 includes all OpVariables in the interface.
-            op_entry_point_interface_operands.push(var);
-        } else {
-            // SPIR-V <= v1.3 only includes Input and Output in the interface.
-            if storage_class == StorageClass::Input || storage_class == StorageClass::Output {
-                op_entry_point_interface_operands.push(var);
-            }
-        }
     }
 
     // Kernel mode takes its interface as function parameters(??)

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -131,7 +131,7 @@ impl<'tcx> CodegenCx<'tcx> {
         let codegen_args = CodegenArgs::from_session(tcx.sess);
         let target = tcx.sess.target.llvm_target.parse().unwrap();
 
-        let result = Self {
+        Self {
             tcx,
             codegen_unit,
             builder: BuilderSpirv::new(&target, &target_features),
@@ -155,9 +155,7 @@ impl<'tcx> CodegenCx<'tcx> {
             codegen_args,
             bindless_descriptor_sets: Default::default(),
             features,
-        };
-
-        result
+        }
     }
 
     /// Temporary toggle to see if bindless has been enabled in the compiler, should

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -44,6 +44,8 @@ pub struct BindlessDescriptorSets {
     pub sampled_image_1d: Word,
     pub sampled_image_2d: Word,
     pub sampled_image_3d: Word,
+    pub samplers: Word,
+    pub acceleration_structures: Word,
 }
 
 pub struct CodegenCx<'tcx> {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -78,6 +78,7 @@ pub struct CodegenCx<'tcx> {
     pub panic_fn_id: Cell<Option<Word>>,
     pub internal_buffer_load_id: RefCell<FxHashSet<Word>>,
     pub internal_buffer_store_id: RefCell<FxHashSet<Word>>,
+    pub resource_access_id: RefCell<FxHashSet<Word>>,
     /// Builtin bounds-checking panics (from MIR `Assert`s) call `#[lang = "panic_bounds_check"]`.
     pub panic_bounds_check_fn_id: Cell<Option<Word>>,
 
@@ -149,6 +150,7 @@ impl<'tcx> CodegenCx<'tcx> {
             panic_fn_id: Default::default(),
             internal_buffer_load_id: Default::default(),
             internal_buffer_store_id: Default::default(),
+            resource_access_id: Default::default(),
             panic_bounds_check_fn_id: Default::default(),
             i8_i16_atomics_allowed: false,
             codegen_args,

--- a/crates/rustc_codegen_spirv/src/linker/interface.rs
+++ b/crates/rustc_codegen_spirv/src/linker/interface.rs
@@ -1,0 +1,87 @@
+//! Entrypoint interface legalization.
+//!
+//! SPIR-V entrypoint definitions require a listing of the used interface variables.
+//! Features like `bindless` define global interface variables which may not be used and specialized.
+//!
+//! The entrypoint definition in the builder will not specify them ad-hoc but we infer in this
+//! legalization pass for every entrypoint the required variables and add them to the definitions.
+
+use rspirv::dr::{Module, Operand};
+use rspirv::spirv::{Op, StorageClass};
+use rustc_data_structures::fx::{FxHashSet, FxHashMap};
+
+pub fn legalize_entrypoint(module: &mut Module) {
+    let version = module.header.as_ref().unwrap().version();
+
+    // Map: Id -> Function Index
+    let mut functions = FxHashMap::default();
+    for (i, inst) in module.functions.iter().enumerate() {
+        let id = inst.def.as_ref().unwrap().result_id.unwrap();
+        functions.insert(id, i);
+    }
+
+    // Generate list of all global variables which could be
+    // used by an entrypoint, filtered according to SPIR-V version requirements.
+    let mut global_variables = FxHashSet::default();
+    for inst in &module.types_global_values {
+        if inst.class.opcode != Op::Variable {
+            continue;
+        }
+
+        let storage_class = if let Operand::StorageClass(storage_class) = inst.operands[0] {
+            storage_class
+        } else {
+            continue
+        };
+
+        let is_interface = if version >= (1, 4) {
+            // SPIR-V >= v1.4 includes all OpVariables in the interface.
+            storage_class != StorageClass::Function
+        } else {
+            // SPIR-V <= v1.3 only includes Input and Output in the interface.
+            storage_class == StorageClass::Input || storage_class == StorageClass::Output
+        };
+
+        if is_interface {
+            global_variables.insert(inst.result_id.unwrap());
+        }
+    }
+
+    // Walk the call graph of each entrypoint.
+    // For each instruction we will the operands if they use any global variable.
+    for entry in &mut module.entry_points {
+        let entry_point = entry.operands[1].id_ref_any().unwrap();
+
+        let mut interfaces = FxHashSet::default();
+        let mut visited = FxHashSet::default();
+        let mut frontier = vec![entry_point];
+        while let Some(fn_id) = frontier.pop() {
+            visited.insert(fn_id);
+
+            let fn_idx = functions[&fn_id];
+            let function = &module.functions[fn_idx];
+            for inst in function.all_inst_iter() {
+                if inst.class.opcode == Op::FunctionCall {
+                    let called_fn = inst.operands[0].id_ref_any().unwrap();
+                    if !visited.contains(&called_fn) {
+                        frontier.push(called_fn);
+                    }
+                }
+
+                // Check operands for global variable usage.
+                for op in &inst.operands {
+                    if let Operand::IdRef(id) = op {
+                        if global_variables.contains(id) {
+                            interfaces.insert(id);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Patch up the entrypoint definition by appending/replacing the operand list.
+        let mut operands = entry.operands[..3].to_vec();
+        operands.extend(interfaces.into_iter().map(|id| Operand::IdRef(*id)));
+        entry.operands = operands;
+    }
+}

--- a/crates/rustc_codegen_spirv/src/linker/interface.rs
+++ b/crates/rustc_codegen_spirv/src/linker/interface.rs
@@ -8,7 +8,7 @@
 
 use rspirv::dr::{Module, Operand};
 use rspirv::spirv::{Op, StorageClass};
-use rustc_data_structures::fx::{FxHashSet, FxHashMap};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 
 pub fn legalize_entrypoint(module: &mut Module) {
     let version = module.header.as_ref().unwrap().version();
@@ -31,7 +31,7 @@ pub fn legalize_entrypoint(module: &mut Module) {
         let storage_class = if let Operand::StorageClass(storage_class) = inst.operands[0] {
             storage_class
         } else {
-            continue
+            continue;
         };
 
         let is_interface = if version >= (1, 4) {

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -5,6 +5,7 @@ mod dce;
 mod duplicates;
 mod import_export_link;
 mod inline;
+mod interface;
 mod mem2reg;
 mod new_structurizer;
 mod peephole_opts;
@@ -301,6 +302,8 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
             let _timer = sess.timer("link_dce_2");
             dce::dce(output);
         }
+
+        interface::legalize_entrypoint(output);
 
         if opts.compact_ids {
             let _timer = sess.timer("link_compact_ids");

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -345,6 +345,7 @@ impl Symbols {
             ("unroll_loops", SpirvAttribute::UnrollLoops),
             ("internal_buffer_load", SpirvAttribute::InternalBufferLoad),
             ("internal_buffer_store", SpirvAttribute::InternalBufferStore),
+            ("resource_access", SpirvAttribute::ResourceAccess),
         ]
         .iter()
         .cloned();

--- a/crates/spirv-std/src/bindless.rs
+++ b/crates/spirv-std/src/bindless.rs
@@ -1,4 +1,4 @@
-use crate::{ray_tracing::{RayFlags, RayQuery}, vector::Vector};
+use crate::{RuntimeArray, ray_tracing::{RayFlags, RayQuery}, vector::Vector};
 
 /// A handle that points to a rendering related resource (TLAS, Sampler, Buffer, Texture etc)
 /// this handle can be uploaded directly to the GPU to refer to our resources in a bindless
@@ -79,6 +79,11 @@ impl RenderResourceHandle {
                 invalid_tag
             ),
         }
+    }
+
+    #[inline]
+    pub unsafe fn access<T>(self) -> T {
+        resource_access(self.index())
     }
 
     /// # Safety
@@ -185,14 +190,37 @@ impl<T> ArrayBuffer<T> {
     }
 }
 
-#[derive(Copy, Clone)]
-#[repr(transparent)]
-pub struct Texture2d(RenderResourceHandle);
+#[spirv(resource_access)]
+#[spirv_std_macros::gpu_only]
+pub extern "unadjusted" fn resource_access<T>(index: u32) -> T {
+    unimplemented!()
+}
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
-pub struct Sampler(RenderResourceHandle);
+pub struct Texture2d(pub RenderResourceHandle);
 
+// use core::ops::Deref;
+
+// impl Deref for Texture2d {
+//     type Target = super::Image2d;
+//     fn deref(&self) -> &Self::Target {
+//         &resource_access::<Self::Target>(unsafe { self.0.index() })
+//     }
+// }
+
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct Sampler(pub RenderResourceHandle);
+
+// impl Deref for Sampler {
+//     type Target = super::Sampler;
+//     fn deref(&self) -> &Self::Target {
+//         &resource_access::<Self::Target>(unsafe { self.0.index() })
+//     }
+// }
+
+/*
 impl Texture2d {
     #[spirv_std_macros::gpu_only]
     pub fn sample<V: Vector<f32, 4>>(self, sampler: Sampler, coord: impl Vector<f32, 2>) -> V {
@@ -290,7 +318,7 @@ impl Texture2d {
         }
     }
 }
-
+*/
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct AccelerationStructure(RenderResourceHandle);

--- a/crates/spirv-std/src/bindless.rs
+++ b/crates/spirv-std/src/bindless.rs
@@ -1,5 +1,3 @@
-use crate::{ray_tracing::{RayFlags, RayQuery}, vector::Vector};
-
 /// A handle that points to a rendering related resource (TLAS, Sampler, Buffer, Texture etc)
 /// this handle can be uploaded directly to the GPU to refer to our resources in a bindless
 /// fashion and can be plainly stored in buffers directly - even without the help of a `DescriptorSet`

--- a/crates/spirv-std/src/bindless.rs
+++ b/crates/spirv-std/src/bindless.rs
@@ -80,6 +80,7 @@ impl RenderResourceHandle {
     }
 
     #[inline]
+    #[spirv_std_macros::gpu_only]
     pub unsafe fn access<T>(self) -> T {
         resource_access(self.index())
     }
@@ -110,7 +111,6 @@ impl RenderResourceHandle {
 pub extern "unadjusted" fn resource_access<T>(index: u32) -> T {
     unimplemented!()
 }
-
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
@@ -173,13 +173,9 @@ impl<T> ArrayBuffer<T> {
     #[spirv_std_macros::gpu_only]
     pub unsafe extern "unadjusted" fn store(self, index: u32, value: T) {
         let buffer: &mut crate::RuntimeArray<u32> = resource_access(self.0.index());
-        buffer.store(
-            index * core::mem::size_of::<T>() as u32,
-            value,
-        )
+        buffer.store(index * core::mem::size_of::<T>() as u32, value)
     }
 }
-
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]

--- a/crates/spirv-std/src/runtime_array.rs
+++ b/crates/spirv-std/src/runtime_array.rs
@@ -37,3 +37,21 @@ impl<T> RuntimeArray<T> {
         loop {}
     }
 }
+
+impl RuntimeArray<u32> {
+    #[spirv(internal_buffer_load)]
+    #[spirv_std_macros::gpu_only]
+    pub extern "unadjusted" fn load<T>(&self, _offset: u32) -> T {
+        unimplemented!()
+    } // actually implemented in the compiler
+
+    #[spirv(internal_buffer_store)]
+    #[spirv_std_macros::gpu_only]
+    pub unsafe extern "unadjusted" fn store<T>(
+        &mut self,
+        _offset: u32,
+        _value: T,
+    ) {
+        unimplemented!()
+    } // actually implemented in the compiler
+}

--- a/crates/spirv-std/src/runtime_array.rs
+++ b/crates/spirv-std/src/runtime_array.rs
@@ -47,11 +47,7 @@ impl RuntimeArray<u32> {
 
     #[spirv(internal_buffer_store)]
     #[spirv_std_macros::gpu_only]
-    pub unsafe extern "unadjusted" fn store<T>(
-        &mut self,
-        _offset: u32,
-        _value: T,
-    ) {
+    pub unsafe extern "unadjusted" fn store<T>(&mut self, _offset: u32, _value: T) {
         unimplemented!()
     } // actually implemented in the compiler
 }


### PR DESCRIPTION
## Overview
- Add a `resource_access(idx) -> T` intrinsic which acquires a descriptor/resource from the global bindless runtime descriptor arrays.
- Support templated load/store for all `RuntimeArray<u32>`, not requiring the bindless feature for it anymore
- Support bindless TLAS and samplers
- Auto-generate entry point interface variables from callgraph

## Dynamic Resource Access
Inspired by https://devblogs.microsoft.com/directx/in-the-works-hlsl-shader-model-6-6/#dynamic-resource-binding

Currently, a lot of manual asm is required for adding support for texture types, samplers, tlas in case of bindless. It also fractures libraries as functions taking 'normal' resources as arguments would be not compatible with bindless.
It also allows to easily expand image support using the existing `Image!` macro for bindless allowing to keep the `spirv-std` footprint small.

Currently support types `T` for `resource_access`:
```rust
Image<..>
Sampler
AccelerationStructure

// Buffers
&RuntimeArray<u32>
&mut RuntimeArray<u32>
```

Example:
```rust
#[repr(C)]
#[derive(Copy, Clone)]
pub struct InstanceData {
    sampler: RenderResourceHandle,
    albedo_map: RenderResourceHandle,
}

#[spirv(fragment)]
pub unsafe fn mesh_fs(
    a_texcoord: f32x2,
    output: &mut f32x4,
    #[spirv(push_constant)] constants: &Constants,
) {
    let instance_data = constants.instance.load();
    let albedo: Image2d = instance_data.albedo_map.access();
    let sampler: Sampler = instance_data.sampler.access();

    let color: f32x4 = albedo.sample(sampler, a_texcoord);
    *output = vec4(color.x, color.y, color.z, 1.0);
}
```

##  Templated Store/Load
This feature existed beforehand but was quite intervowen with `bindless`. To couple it with the dynamic resource access functionality, I moved it out of the `bindless` feature and changed it to support it for `RuntimeArray<u32>` in general.

## Entrypoint interface variables

Depending on SPIR-V target version entrypoint need either Input/Output or all non-Function global variables accessed.
To make this a bit more of a non-brainer I added an extra pass at the end to patch up the entry point definitions based on the callgraph. One issue was that not using a specific bindless set could result in specialization errors as it gets not removed by DCE I guess.

Affects https://github.com/EmbarkStudios/rust-gpu/issues/614

_sry for the quite lenghty PR.. ):_