### PR TITLE
Add name_variables option to spirv-builder

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -277,6 +277,8 @@ pub struct CodegenArgs {
     pub disassemble_entry: Option<String>,
     pub disassemble_globals: bool,
 
+    pub name_variables: bool,
+
     // spirv-val flags
     pub relax_struct_store: bool,
     pub relax_logical_pointer: bool,
@@ -313,6 +315,13 @@ impl CodegenArgs {
         );
         opts.optflagopt("", "disassemble-globals", "print globals to stderr", "");
 
+        opts.optflagopt(
+            "",
+            "name-variables",
+            "Keep OpName for OpVariables, strip all others.",
+            "",
+        );
+
         opts.optflagopt("", "relax-struct-store", "Allow store from one struct type to a different type with compatible layout and members.", "");
         opts.optflagopt("", "relax-logical-pointer", "Allow allocating an object of a pointer type and returning a pointer value from a function in logical addressing mode", "");
         opts.optflagopt("", "relax-block-layout", "Enable VK_KHR_relaxed_block_layout when checking standard uniform, storage buffer, and push constant layouts. This is the default when targeting Vulkan 1.1 or later.", "");
@@ -327,6 +336,8 @@ impl CodegenArgs {
         let disassemble_fn = matches.opt_str("disassemble-fn");
         let disassemble_entry = matches.opt_str("disassemble-entry");
         let disassemble_globals = matches.opt_present("disassemble-globals");
+
+        let name_variables = matches.opt_present("name-variables");
 
         let relax_struct_store = matches.opt_present("relax-struct-store");
         let relax_logical_pointer = matches.opt_present("relax-logical-pointer");
@@ -343,6 +354,8 @@ impl CodegenArgs {
             disassemble_fn,
             disassemble_entry,
             disassemble_globals,
+
+            name_variables,
 
             relax_struct_store,
             relax_logical_pointer,

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -29,6 +29,7 @@ pub struct Options {
     pub mem2reg: bool,
     pub structurize: bool,
     pub emit_multiple_modules: bool,
+    pub name_variables: bool,
 }
 
 pub enum LinkResult {
@@ -249,6 +250,11 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
     {
         let _timer = sess.timer("link_remove_duplicate_lines");
         duplicates::remove_duplicate_lines(&mut output);
+    }
+
+    if opts.name_variables {
+        let _timer = sess.timer("link_name_variables");
+        simple_passes::name_variables_pass(&mut output);
     }
 
     {

--- a/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
+++ b/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
@@ -129,3 +129,25 @@ pub fn sort_globals(module: &mut Module) {
     // have a function declaration without a body in a fully linked module?
     module.functions.sort_by_key(|f| !f.blocks.is_empty());
 }
+
+pub fn name_variables_pass(module: &mut Module) {
+    let variables = module
+        .types_global_values
+        .iter()
+        .filter(|inst| inst.class.opcode == Op::Variable)
+        .map(|inst| inst.result_id.unwrap())
+        .collect::<FxHashSet<Word>>();
+    module
+        .debug_names
+        .retain(|inst| variables.contains(&inst.operands[0].unwrap_id_ref()));
+    module
+        .types_global_values
+        .retain(|inst| inst.class.opcode != Op::Line);
+    for func in &mut module.functions {
+        for block in &mut func.blocks {
+            block
+                .instructions
+                .retain(|inst| inst.class.opcode != Op::Line);
+        }
+    }
+}

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -95,6 +95,7 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, String> {
                 mem2reg: false,
                 structurize: false,
                 emit_multiple_modules: false,
+                name_variables: false,
             },
         );
         assert_eq!(compiler.session().has_errors(), res.is_err());

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -133,6 +133,7 @@ pub struct SpirvBuilder {
     target: String,
     bindless: bool,
     multimodule: bool,
+    name_variables: bool,
     capabilities: Vec<Capability>,
     extensions: Vec<String>,
 
@@ -154,6 +155,7 @@ impl SpirvBuilder {
             target: target.into(),
             bindless: false,
             multimodule: false,
+            name_variables: false,
             capabilities: Vec::new(),
             extensions: Vec::new(),
 
@@ -190,6 +192,15 @@ impl SpirvBuilder {
     /// points bundled into a single file is the preferred system.
     pub fn multimodule(mut self, v: bool) -> Self {
         self.multimodule = v;
+        self
+    }
+
+    /// Keep `OpName` reflection information for global `OpVariable`s (which means things like
+    /// uniforms and shader input/outputs) but strip `OpName`s for everything else (functions,
+    /// types, and so on). This is useful if you want a small binary size without debugging
+    /// information, but need variable name reflection to work.
+    pub fn name_variables(mut self, v: bool) -> Self {
+        self.name_variables = v;
         self
     }
 
@@ -351,6 +362,9 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
     let mut llvm_args = Vec::new();
     if builder.multimodule {
         llvm_args.push("--module-output=multiple");
+    }
+    if builder.name_variables {
+        llvm_args.push("--name-variables");
     }
     if builder.relax_struct_store {
         llvm_args.push("--relax-struct-store");


### PR DESCRIPTION
Fixes #657

I opted for the simpler approach of "just keep names for _all_ global OpVariables", to cover the use case of maybe wanting input/output names too, as including those don't bloat the binary much at all (the real issue is all the type/function names, AFAIK)