### PR TITLE
Clean up the interface of the watching support

### DIFF
--- a/crates/spirv-builder/src/watch.rs
+++ b/crates/spirv-builder/src/watch.rs
@@ -107,6 +107,6 @@ impl SpirvBuilder {
             }
         });
         std::mem::forget(thread);
-        return Ok(first_result);
+        Ok(first_result)
     }
 }

--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -15,8 +15,7 @@ fn block_on<T>(future: impl Future<Output = T>) -> T {
 }
 
 pub fn start(options: &Options) {
-    let rx = crate::maybe_watch(options.shader, true);
-    let shader_binary = rx.recv().expect("Should send one binary");
+    let shader_binary = crate::maybe_watch(options.shader, None);
 
     block_on(start_internal(options, shader_binary))
 }

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -43,7 +43,6 @@
 )]
 
 use clap::Clap;
-use spirv_builder::CompileResult;
 use strum::{Display, EnumString};
 
 mod compute;
@@ -65,7 +64,7 @@ fn maybe_watch(
     // we send the value directly in the same thread. This avoids deadlocking in those cases.
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
-        use spirv_builder::{Capability, MetadataPrintout, SpirvBuilder};
+        use spirv_builder::{Capability, MetadataPrintout, SpirvBuilder, CompileResult};
         use std::borrow::Cow;
         use std::path::PathBuf;
         // Hack: spirv_builder builds into a custom directory if running under cargo, to not

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -60,8 +60,6 @@ fn maybe_watch(
     shader: RustGPUShader,
     on_watch: Option<Box<dyn FnMut(wgpu::ShaderModuleDescriptor<'static>) + Send + 'static>>,
 ) -> wgpu::ShaderModuleDescriptor<'static> {
-    // This bound needs to be 1, because in cases where this function is used for direct building (e.g. for the compute example or on android)
-    // we send the value directly in the same thread. This avoids deadlocking in those cases.
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
         use spirv_builder::{Capability, CompileResult, MetadataPrintout, SpirvBuilder};

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -64,7 +64,7 @@ fn maybe_watch(
     // we send the value directly in the same thread. This avoids deadlocking in those cases.
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
-        use spirv_builder::{Capability, MetadataPrintout, SpirvBuilder, CompileResult};
+        use spirv_builder::{Capability, CompileResult, MetadataPrintout, SpirvBuilder};
         use std::borrow::Cow;
         use std::path::PathBuf;
         // Hack: spirv_builder builds into a custom directory if running under cargo, to not

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -42,9 +42,8 @@
     rust_2018_idioms
 )]
 
-use std::sync::mpsc::{self, Receiver};
-
 use clap::Clap;
+use spirv_builder::CompileResult;
 use strum::{Display, EnumString};
 
 mod compute;
@@ -60,14 +59,13 @@ pub enum RustGPUShader {
 
 fn maybe_watch(
     shader: RustGPUShader,
-    force_no_watch: bool,
-) -> Receiver<wgpu::ShaderModuleDescriptor<'static>> {
+    on_watch: Option<Box<dyn FnMut(wgpu::ShaderModuleDescriptor<'static>) + Send + 'static>>,
+) -> wgpu::ShaderModuleDescriptor<'static> {
     // This bound needs to be 1, because in cases where this function is used for direct building (e.g. for the compute example or on android)
     // we send the value directly in the same thread. This avoids deadlocking in those cases.
-    let (tx, rx) = mpsc::sync_channel(1);
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
-        use spirv_builder::{Capability, CompileResult, MetadataPrintout, SpirvBuilder};
+        use spirv_builder::{Capability, MetadataPrintout, SpirvBuilder};
         use std::borrow::Cow;
         use std::path::PathBuf;
         // Hack: spirv_builder builds into a custom directory if running under cargo, to not
@@ -94,23 +92,16 @@ fn maybe_watch(
         for &cap in capabilities {
             builder = builder.capability(cap);
         }
-        if force_no_watch {
-            let compile_result = builder.build().unwrap();
-            handle_builder_result(compile_result, &tx);
+        let initial_result = if let Some(mut f) = on_watch {
+            builder
+                .watch(move |compile_result| f(handle_compile_result(compile_result)))
+                .expect("Configuration is correct for watching")
         } else {
-            let thread = std::thread::spawn(move || {
-                builder
-                    .watch(|compile_result| {
-                        handle_builder_result(compile_result, &tx);
-                    })
-                    .expect("Configuration is correct for watching")
-            });
-            std::mem::forget(thread);
-        }
-        fn handle_builder_result(
+            builder.build().unwrap()
+        };
+        fn handle_compile_result(
             compile_result: CompileResult,
-            tx: &mpsc::SyncSender<wgpu::ShaderModuleDescriptor<'static>>,
-        ) {
+        ) -> wgpu::ShaderModuleDescriptor<'static> {
             let module_path = compile_result.module.unwrap_single();
             let data = std::fs::read(module_path).unwrap();
             let spirv = wgpu::util::make_spirv(&data);
@@ -122,25 +113,23 @@ fn maybe_watch(
                     wgpu::ShaderSource::SpirV(Cow::Owned(cow.into_owned()))
                 }
             };
-            tx.send(wgpu::ShaderModuleDescriptor {
+            wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: spirv,
                 flags: wgpu::ShaderFlags::default(),
-            })
-            .expect("Rx is still alive");
+            }
         }
+        handle_compile_result(initial_result)
     }
     #[cfg(any(target_os = "android", target_arch = "wasm32"))]
     {
-        tx.send(match shader {
+        match shader {
             RustGPUShader::Simplest => wgpu::include_spirv!(env!("simplest_shader.spv")),
             RustGPUShader::Sky => wgpu::include_spirv!(env!("sky_shader.spv")),
             RustGPUShader::Compute => wgpu::include_spirv!(env!("compute_shader.spv")),
             RustGPUShader::Mouse => wgpu::include_spirv!(env!("mouse_shader.spv")),
-        })
-        .expect("rx to be alive")
+        }
     }
-    rx
 }
 
 fn is_compute_shader(shader: RustGPUShader) -> bool {


### PR DESCRIPTION
This allows us to avoid the seperate thread just for looping the graphics `rx` to the eventloop, for example.

In almost all cases, initial results are blocked on the first shader, but subsequent changes require notification.