### PR TITLE
compiletests: add missing `use spirv_std as _;` imports.

### DIFF
--- a/tests/ui/lang/control_flow/issue_283.rs
+++ b/tests/ui/lang/control_flow/issue_283.rs
@@ -1,5 +1,6 @@
 // build-pass
-#![feature(lang_items)]
+
+use spirv_std as _;
 
 use glam::*;
 
@@ -47,13 +48,3 @@ pub fn main() {
     let v = Vec3::new(1.0, 1.0, 1.0);
     render(v, v, 1.0, 2.0);
 }
-
-// TODO: Figure out why these are needed and remove them (it should pick up the ones in spirv_std)
-// https://github.com/EmbarkStudios/rust-gpu/issues/640
-#[panic_handler]
-fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
-    loop {}
-}
-
-#[lang = "eh_personality"]
-extern "C" fn rust_eh_personality() {}

--- a/tests/ui/spirv-attr/invalid-storage-class.rs
+++ b/tests/ui/spirv-attr/invalid-storage-class.rs
@@ -2,6 +2,8 @@
 
 // build-fail
 
+use spirv_std as _;
+
 #[spirv(vertex)]
 fn _entry(
     #[spirv(input)] _: (),

--- a/tests/ui/spirv-attr/invalid-storage-class.stderr
+++ b/tests/ui/spirv-attr/invalid-storage-class.stderr
@@ -1,34 +1,32 @@
-error: `#[panic_handler]` function required, but not found
-
 error: `Input` storage class is the default and should not be explicitly specified
- --> $DIR/invalid-storage-class.rs:7:13
+ --> $DIR/invalid-storage-class.rs:9:13
   |
-7 |     #[spirv(input)] _: (),
+9 |     #[spirv(input)] _: (),
   |             ^^^^^
 
 error: `Output` storage class is the default and should not be explicitly specified
- --> $DIR/invalid-storage-class.rs:8:13
-  |
-8 |     #[spirv(output)] _: (),
-  |             ^^^^^^
-
-error: `Private` storage class can not be used as part of an entry's interface
- --> $DIR/invalid-storage-class.rs:9:13
-  |
-9 |     #[spirv(private)] _: (),
-  |             ^^^^^^^
-
-error: `Function` storage class can not be used as part of an entry's interface
   --> $DIR/invalid-storage-class.rs:10:13
    |
-10 |     #[spirv(function)] _: (),
+10 |     #[spirv(output)] _: (),
+   |             ^^^^^^
+
+error: `Private` storage class can not be used as part of an entry's interface
+  --> $DIR/invalid-storage-class.rs:11:13
+   |
+11 |     #[spirv(private)] _: (),
+   |             ^^^^^^^
+
+error: `Function` storage class can not be used as part of an entry's interface
+  --> $DIR/invalid-storage-class.rs:12:13
+   |
+12 |     #[spirv(function)] _: (),
    |             ^^^^^^^^
 
 error: `Generic` storage class can not be used as part of an entry's interface
-  --> $DIR/invalid-storage-class.rs:11:13
+  --> $DIR/invalid-storage-class.rs:13:13
    |
-11 |     #[spirv(generic)] _: (),
+13 |     #[spirv(generic)] _: (),
    |             ^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes #640 by making the couple tests affected by it explicitly `use spriv_std as _;`.

See also https://github.com/EmbarkStudios/rust-gpu/issues/640#issuecomment-859365825 for a bit more context.