### PR TITLE
Use `ControlFlow::Poll` for the Mouse shader

### DIFF
--- a/examples/runners/wgpu/src/graphics.rs
+++ b/examples/runners/wgpu/src/graphics.rs
@@ -43,6 +43,7 @@ async fn run(
     window: Window,
     swapchain_format: wgpu::TextureFormat,
     shader_binary: wgpu::ShaderModuleDescriptor<'static>,
+    shader_target_flow: ControlFlow,
 ) {
     let size = window.inner_size();
     let instance = wgpu::Instance::new(wgpu::BackendBit::VULKAN | wgpu::BackendBit::METAL);
@@ -125,7 +126,7 @@ async fn run(
         let _ = (&instance, &adapter, &pipeline_layout);
         let render_pipeline = &mut render_pipeline;
 
-        *control_flow = ControlFlow::Wait;
+        *control_flow = shader_target_flow;
         match event {
             Event::MainEventsCleared => {
                 window.request_redraw();
@@ -309,6 +310,10 @@ fn create_pipeline(
 }
 
 pub fn start(options: &Options) {
+    let control_flow = options
+        .shader
+        .expected_control_flow()
+        .expect("Graphics runner should be used for graphics shaders only");
     // Build the shader before we pop open a window, since it might take a while.
     let rx = maybe_watch(options.shader, false);
     let initial_shader = rx.recv().expect("Initial shader is required");
@@ -351,6 +356,7 @@ pub fn start(options: &Options) {
                 window,
                 wgpu::TextureFormat::Bgra8Unorm,
                 initial_shader,
+                control_flow
             ));
         } else {
             wgpu_subscriber::initialize_default_subscriber(None);
@@ -363,7 +369,7 @@ pub fn start(options: &Options) {
                     wgpu::TextureFormat::Bgra8UnormSrgb
                 },
                 initial_shader,
-
+                control_flow
             ));
         }
     }

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -46,6 +46,7 @@ use std::sync::mpsc::{self, Receiver};
 
 use clap::Clap;
 use strum::{Display, EnumString};
+use winit::event_loop::ControlFlow;
 
 mod compute;
 mod graphics;
@@ -56,6 +57,20 @@ pub enum RustGPUShader {
     Sky,
     Compute,
     Mouse,
+}
+
+impl RustGPUShader {
+    /// Returns the [`ControlFlow`] this shader should use
+    ///
+    /// Returns [`None`] if this shader should not be used for graphics
+    fn expected_control_flow(self) -> Option<ControlFlow> {
+        match self {
+            RustGPUShader::Compute => None,
+            // The mouse shader updates based on how long the shader has been running for
+            RustGPUShader::Mouse => Some(ControlFlow::Poll),
+            RustGPUShader::Simplest | RustGPUShader::Sky => Some(ControlFlow::Wait),
+        }
+    }
 }
 
 fn maybe_watch(


### PR DESCRIPTION
I thought that the mouse shader was extremely resource
intensive because it was so laggy

However, it turns out that it was just because it was using `Wait`