### PR TITLE
Fix issue with --disassemble-entry

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -427,7 +427,8 @@ impl CodegenArgs {
             let id = module
                 .entry_points
                 .iter()
-                .find(|inst| inst.operands.last().unwrap().unwrap_literal_string() == entry)
+                .filter(|inst| inst.class.opcode == rspirv::spirv::Op::EntryPoint)
+                .find(|inst| inst.operands[2].unwrap_literal_string() == entry)
                 .unwrap_or_else(|| {
                     panic!(
                         "no entry point with the name `{}` found in:\n{}\n",


### PR DESCRIPTION
When testing some other stuff, I hit this really silly issue - OpEntryPoint has the interface variables tacked onto its operands, so operands.last is only going to be the name if there's no interface variables :|