### PR TITLE
Handle booleans *slightly* hackily without `Int8`

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -419,7 +419,7 @@ fn trans_scalar<'tcx>(
     index: Option<usize>,
     is_immediate: bool,
 ) -> Word {
-    if is_immediate && scalar.is_bool() {
+    if (!cx.builder.has_capability(Capability::Int8) || is_immediate) && scalar.is_bool() {
         return SpirvType::Bool.def(span, cx);
     }
 

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -801,7 +801,9 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     }
 
     fn from_immediate(&mut self, val: Self::Value) -> Self::Value {
-        if self.lookup_type(val.ty) == SpirvType::Bool {
+        if self.lookup_type(val.ty) == SpirvType::Bool
+            && self.builder.has_capability(Capability::Int8)
+        {
             let i8 = SpirvType::Integer(8, false).def(self.span(), self);
             self.zext(val, i8)
         } else {

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -804,8 +804,8 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         if self.lookup_type(val.ty) == SpirvType::Bool
             && self.builder.has_capability(Capability::Int8)
         {
-            let i8 = SpirvType::Integer(8, false).def(self.span(), self);
-            self.zext(val, i8)
+            let u8 = SpirvType::Integer(8, false).def(self.span(), self);
+            self.zext(val, u8)
         } else {
             val
         }

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -124,12 +124,13 @@ extern crate rustc_target;
 
 macro_rules! assert_ty_eq {
     ($codegen_cx:expr, $left:expr, $right:expr) => {
-        assert!(
-            $left == $right,
-            "Expected types to be equal:\n{}\n==\n{}",
-            $codegen_cx.debug_type($left),
-            $codegen_cx.debug_type($right)
-        )
+        if !$left == $right {
+            $codegen_cx.tcx.sess.fatal(&format!(
+                "Expected types to be equal:\n{}\n==\n{}",
+                $codegen_cx.debug_type($left),
+                $codegen_cx.debug_type($right)
+            ));
+        }
     };
 }
 

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -104,7 +104,7 @@ fn maybe_watch(
         let (crate_name, capabilities): (_, &[Capability]) = match shader {
             RustGPUShader::Simplest => ("simplest-shader", &[]),
             RustGPUShader::Sky => ("sky-shader", &[]),
-            RustGPUShader::Compute => ("compute-shader", &[Capability::Int8]),
+            RustGPUShader::Compute => ("compute-shader", &[]),
             RustGPUShader::Mouse => ("mouse-shader", &[]),
         };
         let manifest_dir = env!("CARGO_MANIFEST_DIR");


### PR DESCRIPTION
Unlocks use of `unwrap_or` in all shaders

This is obviously a massive hack, and I'm sure this opens up the ability to meet spir-v val errors.

This is also a proof of concept that a solution to #677 might be possible without resorting to codegenning all booleans as u32

It's not clear to me what the precise rules where using booleans causes trouble are, but I've kept the existing codegen for the cases where u8 can be used

~~*ducks*~~