### PR TITLE
Use target `spirv-unknown-webgpu0` for wgpu runner

### DIFF
--- a/examples/runners/wgpu/builder/src/main.rs
+++ b/examples/runners/wgpu/builder/src/main.rs
@@ -11,7 +11,7 @@ fn build_shader(
 ) -> Result<(), Box<dyn Error>> {
     let builder_dir = &Path::new(env!("CARGO_MANIFEST_DIR"));
     let path_to_crate = builder_dir.join(path_to_crate);
-    let mut builder = SpirvBuilder::new(path_to_crate, "spirv-unknown-vulkan1.1");
+    let mut builder = SpirvBuilder::new(path_to_crate, "spirv-unknown-webgpu0");
     for &cap in caps {
         builder = builder.capability(cap);
     }

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -112,7 +112,7 @@ fn maybe_watch(
             .iter()
             .copied()
             .collect::<PathBuf>();
-        let mut builder = SpirvBuilder::new(crate_path, "spirv-unknown-vulkan1.1")
+        let mut builder = SpirvBuilder::new(crate_path, "spirv-unknown-webgpu0")
             .print_metadata(MetadataPrintout::None);
         for &cap in capabilities {
             builder = builder.capability(cap);


### PR DESCRIPTION
Looks like spirv-tools optimizer crashes on it though.