### PR TITLE
Added NonWritable + NonReadable Decorations. Fixes  #689

### DIFF
--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -85,6 +85,8 @@ pub enum SpirvAttribute {
     Binding(u32),
     Flat,
     Invariant,
+    NonWritable,
+    NonReadable,
     InputAttachmentIndex(u32),
 
     // `fn`/closure attributes:
@@ -120,6 +122,8 @@ pub struct AggregatedSpirvAttributes {
     pub binding: Option<Spanned<u32>>,
     pub flat: Option<Spanned<()>>,
     pub invariant: Option<Spanned<()>>,
+    pub non_writable: Option<Spanned<()>>,
+    pub non_readable: Option<Spanned<()>>,
     pub input_attachment_index: Option<Spanned<u32>>,
 
     // `fn`/closure attributes:
@@ -206,6 +210,8 @@ impl AggregatedSpirvAttributes {
             Binding(value) => try_insert(&mut self.binding, value, span, "#[spirv(binding)]"),
             Flat => try_insert(&mut self.flat, (), span, "#[spirv(flat)]"),
             Invariant => try_insert(&mut self.invariant, (), span, "#[spirv(invariant)]"),
+            NonWritable => try_insert(&mut self.non_writable, (), span, "#[spirv(non_writable)]"),
+            NonReadable => try_insert(&mut self.non_readable, (), span, "#[spirv(non_readable)]"),
             InputAttachmentIndex(value) => try_insert(
                 &mut self.input_attachment_index,
                 value,
@@ -306,6 +312,8 @@ impl CheckSpirvAttrVisitor<'_> {
                 | SpirvAttribute::Binding(_)
                 | SpirvAttribute::Flat
                 | SpirvAttribute::Invariant
+                | SpirvAttribute::NonWritable
+                | SpirvAttribute::NonReadable
                 | SpirvAttribute::InputAttachmentIndex(_) => match target {
                     Target::Param => {
                         let parent_hir_id = self.tcx.hir().get_parent_node(hir_id);

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -1070,7 +1070,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             SpirvType::Array { element, .. }
             | SpirvType::RuntimeArray { element, .. }
             | SpirvType::Vector { element, .. } => element,
-            SpirvType::InterfaceBlock { inner_type } => {
+            SpirvType::InterfaceBlock { inner_type, .. } => {
                 assert_eq!(idx, 0);
                 inner_type
             }

--- a/crates/rustc_codegen_spirv/src/builder/load_store.rs
+++ b/crates/rustc_codegen_spirv/src/builder/load_store.rs
@@ -140,7 +140,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             } => self.err("Image type unsupported for bindless buffer stores (use a bindless Texture type instead)"),
             SpirvType::Sampler => self.err("Sampler type unsupported for bindless buffer stores"),
             SpirvType::SampledImage { image_type: _ }  => self.err("SampledImage type unsupported for bindless buffer stores"),
-            SpirvType::InterfaceBlock { inner_type: _ } => self.err("InterfaceBlock type unsupported for bindless buffer stores"),
+            SpirvType::InterfaceBlock { .. } => self.err("InterfaceBlock type unsupported for bindless buffer stores"),
             SpirvType::AccelerationStructureKhr => self.fatal("AccelerationStructureKhr type unsupported for bindless buffer stores"),
             SpirvType::RayQueryKhr => self.fatal("RayQueryKhr type unsupported for bindless buffer stores"),
         }
@@ -590,7 +590,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             } => self.fatal("Image type unsupported for bindless buffer loads (use a bindless Texture type instead)"),
             SpirvType::Sampler => self.fatal("Sampler type unsupported for bindless buffer loads"),
             SpirvType::SampledImage { image_type: _ }  => self.fatal("SampledImage type unsupported for bindless buffer loads"),
-            SpirvType::InterfaceBlock { inner_type: _ } => self.fatal("InterfaceBlock type unsupported for bindless buffer loads"),
+            SpirvType::InterfaceBlock { .. } => self.fatal("InterfaceBlock type unsupported for bindless buffer loads"),
             SpirvType::AccelerationStructureKhr => self.fatal("AccelerationStructureKhr type unsupported for bindless buffer loads"),
             SpirvType::RayQueryKhr => self.fatal("RayQueryKhr type unsupported for bindless buffer loads"),
         }

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -326,6 +326,8 @@ impl Symbols {
             ("block", SpirvAttribute::Block),
             ("flat", SpirvAttribute::Flat),
             ("invariant", SpirvAttribute::Invariant),
+            ("non_writable", SpirvAttribute::NonWritable),
+            ("non_readable", SpirvAttribute::NonReadable),
             (
                 "sampled_image",
                 SpirvAttribute::IntrinsicType(IntrinsicType::SampledImage),


### PR DESCRIPTION
Fixes  #689.

This PR allows adding NonWritable and NonReadable decorations to StorageBuffers. This can be added to other types, Images for example. This is an opt in via attributes `#[spirv(non_writable)]` and `#[spirv(non_readable)]`, and does not do any validation. Probably `non_writable` can be inferred from the function declaration but that can be addressed later. 

It looks like this:

    #![cfg_attr(
        target_arch = "spirv",
        no_std,
        feature(register_attr),
        register_attr(spirv)
    )]
    #![deny(warnings)]

    use spirv_std::glam::UVec3;

    #[repr(C)]
    pub struct PushConsts {
        n: u32,
    }

    #[allow(unused)]
    #[spirv(compute(threads(64)))]
    pub fn add(
        #[spirv(global_invocation_id)] global_id: UVec3,
        #[spirv(storage_buffer, descriptor_set = 0, binding = 0, non_writable)] a: &[u32],
        #[spirv(storage_buffer, descriptor_set = 0, binding = 1, non_writable)] b: &[u32],
        #[spirv(storage_buffer, descriptor_set = 0, binding = 2, non_readable)] y: &mut [u32],
        #[spirv(push_constant)] push_consts: &PushConsts,
    ) {
        let gid = global_id.x as usize;
        if global_id.x < push_consts.n {
            y[gid] = a[gid] + b[gid];
        }
    }

As far as validation, this could be done in the validation pass or through the type system, by adding a trait bound to the argument. But the former is probably the most robust way, but it has to do a recursive check against all the access chains as well. It would be nice if immutable arguments were declared non_writable automatically for known types at the very least. For example, `&[T] where T: Copy` should be able to be marked non_writable. 
