### PR TITLE
Fix example-runner-ash

### DIFF
--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -211,8 +211,20 @@ pub fn compile_shaders() -> Vec<SpvFile> {
         ];
     let mut spv_files = Vec::<SpvFile>::with_capacity(spv_paths.len());
     for path in spv_paths.iter() {
+        let name = path
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .split('.')
+            .next()
+            .unwrap()
+            .to_owned();
+
         spv_files.push(SpvFile {
-            name: path.file_stem().unwrap().to_str().unwrap().to_owned(),
+            name,
             data: read_spv(&mut File::open(path).unwrap()).unwrap(),
         });
     }

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -89,7 +89,6 @@ use std::{
     ffi::{CStr, CString},
     fs::File,
     ops::Drop,
-    path::PathBuf,
     sync::mpsc::{sync_channel, TryRecvError, TrySendError},
     thread,
 };
@@ -199,36 +198,19 @@ pub fn main() {
 }
 
 pub fn compile_shaders() -> Vec<SpvFile> {
-    let spv_paths: Vec<PathBuf> =
-        vec![
-            SpirvBuilder::new("examples/shaders/sky-shader", "spirv-unknown-vulkan1.1")
-                .print_metadata(MetadataPrintout::None)
-                .build()
-                .unwrap()
-                .module
-                .unwrap_single()
-                .to_path_buf(),
-        ];
-    let mut spv_files = Vec::<SpvFile>::with_capacity(spv_paths.len());
-    for path in spv_paths.iter() {
-        let name = path
-            .parent()
+    let sky_shader_path =
+        SpirvBuilder::new("examples/shaders/sky-shader", "spirv-unknown-vulkan1.1")
+            .print_metadata(MetadataPrintout::None)
+            .build()
             .unwrap()
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .split('.')
-            .next()
-            .unwrap()
-            .to_owned();
-
-        spv_files.push(SpvFile {
-            name,
-            data: read_spv(&mut File::open(path).unwrap()).unwrap(),
-        });
-    }
-    spv_files
+            .module
+            .unwrap_single()
+            .to_path_buf();
+    let sky_shader = SpvFile {
+        name: "sky_shader".to_string(),
+        data: read_spv(&mut File::open(sky_shader_path).unwrap()).unwrap(),
+    };
+    vec![sky_shader]
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
`example-runner-ash` fails to run because it fails to get `sky_shader`.

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', examples\runners\ash\src\main.rs:706:74
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\example-runner-ash.exe` (exit code: 101)
```

`compile_shaders()` had obtained shader name from `path.file_stem()` but path is
```
[examples\runners\ash\src\main.rs:212] &spv_paths = [
    "C:\\Users\\hato2\\Desktop\\rust-gpu\\target\\spirv-unknown-vulkan1.1\\release\\deps\\sky_shader.spv.dir\\module",
]
```
in my environment (Windows11).

I've fixed `compile_shaders()` to return corrent shader name from path.
Sorry if this fix is incompatioble for other environments.