### PR TITLE
Fix example-runner-ash's validation layer errors

### DIFF
--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -286,7 +286,7 @@ impl RenderBase {
                 .application_version(0)
                 .engine_name(&app_name)
                 .engine_version(0)
-                .api_version(vk::make_version(1, 1, 0));
+                .api_version(vk::make_version(1, 2, 0));
 
             let instance_create_info = vk::InstanceCreateInfo::builder()
                 .application_info(&appinfo)
@@ -369,7 +369,14 @@ impl RenderBase {
                 .queue_family_index(queue_family_index)
                 .queue_priorities(&priorities)
                 .build()];
+
+            let mut vulkan_memory_model_features =
+                vk::PhysicalDeviceVulkanMemoryModelFeatures::builder()
+                    .vulkan_memory_model(true)
+                    .build();
+
             let device_create_info = vk::DeviceCreateInfo::builder()
+                .push_next(&mut vulkan_memory_model_features)
                 .queue_create_infos(&queue_info)
                 .enabled_extension_names(&device_extension_names_raw)
                 .enabled_features(&features);


### PR DESCRIPTION
This PR fixes example-runner-ash's errors which are displayed with `--debug-layer` option.

```
> cargo run --bin example-runner-ash -- --debug-layer
   Compiling example-runner-ash v0.4.0-alpha.10 (C:\Users\hato2\Desktop\fork\rust-gpu\examples\runners\ash)
    Finished dev [unoptimized + debuginfo] target(s) in 2.48s
     Running `target\debug\example-runner-ash.exe --debug-layer`
    Finished release [optimized] target(s) in 0.17s
INFO:
GENERAL [Loader Message (0)] : Inserted device layer VK_LAYER_KHRONOS_validation (C:\VulkanSDK\1.2.182.0\Bin\.\VkLayer_khronos_validation.dll)

INFO:
GENERAL [Loader Message (0)] : Inserted device layer VK_LAYER_NV_optimus (C:\WINDOWS\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_4a746d937e6a7240\.\nvoglv64.dll)

ERROR:
VALIDATION [VUID-VkShaderModuleCreateInfo-pCode-01091 (-1480880714)] : Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-01091 ] Object 0: handle = 0x20ea37c94d8, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xa7bb8db6 | vkCreateShaderModule(): The SPIR-V Capability (VulkanMemoryModel) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-01091)

ERROR:
VALIDATION [VUID-VkShaderModuleCreateInfo-pCode-04147 (1028204675)] : Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-04147 ] Object 0: handle = 0x20ea37c94d8, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x3d492883 | vkCreateShaderModule(): The SPIR-V Extension (SPV_KHR_vulkan_memory_model) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the SPIR-V extensions listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-04147)

ERROR:
VALIDATION [VUID-VkShaderModuleCreateInfo-pCode-01091 (-1480880714)] : Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-01091 ] Object 0: handle = 0x20ea37c94d8, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xa7bb8db6 | vkCreateShaderModule(): The SPIR-V Capability (VulkanMemoryModel) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-01091)

ERROR:
VALIDATION [VUID-VkShaderModuleCreateInfo-pCode-04147 (1028204675)] : Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-04147 ] Object 0: handle = 0x20ea37c94d8, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x3d492883 | vkCreateShaderModule(): The SPIR-V Extension (SPV_KHR_vulkan_memory_model) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the SPIR-V extensions listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-04147)
```

Although https://github.com/EmbarkStudios/rust-gpu/pull/693 is needed to run in my environment, it's not contained in this PR.