### PR TITLE
Release v0.4.0-alpha.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "compiletests"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "compiletest_rs",
  "rustc_codegen_spirv",
@@ -422,14 +422,14 @@ dependencies = [
 
 [[package]]
 name = "compiletests-deps-helper"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "spirv-std",
 ]
 
 [[package]]
 name = "compute-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "rayon",
  "spirv-std",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-ash"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "ash",
  "ash-molten",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-cpu"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "minifb",
  "rayon",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-wgpu"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "bytemuck",
  "cfg-if 1.0.0",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-wgpu-builder"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "spirv-builder",
 ]
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.16.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
 dependencies = [
  "num-traits",
 ]
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "mouse-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "shared",
  "spirv-std",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "multibuilder"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "spirv-builder",
 ]
@@ -2191,7 +2191,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "bimap",
  "hashbrown 0.11.2",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "bytemuck",
  "spirv-std",
@@ -2359,7 +2359,7 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simplest-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "shared",
  "spirv-std",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "sky-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "shared",
  "spirv-std",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-builder"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "memchr",
  "notify",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "bitflags",
  "glam",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-types"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 
 [[package]]
 name = "spirv_cross"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-builder"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,9 +10,9 @@ description = "Standard functions and types for SPIR-V"
 [dependencies]
 bitflags = "1.2.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
-spirv-types = { path = "./shared", version = "0.4.0-alpha.10" }
-spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.10" }
-glam = { version = "0.16.0", default-features = false, features = ["libm"], optional = true }
+spirv-types = { path = "./shared", version = "0.4.0-alpha.11" }
+spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.11" }
+glam = { version = "0.17.0", default-features = false, features = ["libm"], optional = true }
 
 [features]
 default = []

--- a/crates/spirv-std/macros/Cargo.toml
+++ b/crates/spirv-std/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ description = "Macros for spirv-std"
 proc-macro = true
 
 [dependencies]
-spirv-types = { path = "../shared", version = "0.4.0-alpha.10" }
+spirv-types = { path = "../shared", version = "0.4.0-alpha.11" }
 heck = "0.3.2"
 proc-macro2 = "1.0.24"
 quote = "1.0.8"

--- a/crates/spirv-std/shared/Cargo.toml
+++ b/crates/spirv-std/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spirv-types"
 description = "SPIR-V types shared between spirv-std and spirv-std-macros"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
     - [Testing](./testing.md)
     - [Environment variables Rust-GPU reads](./compiler-env-vars.md)
     - [Minimizing bugs in SPIR-V](./spirv-minimization.md)
+    - [Publishing rust-gpu on crates.io](./publishing-rust-gpu.md)
 - [Platform Support](./platform-support.md)
 - [Writing Shader Crates](./writing-shader-crates.md)
 - [Features]()

--- a/docs/src/publishing-rust-gpu.md
+++ b/docs/src/publishing-rust-gpu.md
@@ -1,0 +1,17 @@
+# Publishing rust-gpu on crates.io
+
+This is a task list for the maintainers of rust-gpu to remember to do when publishing a new version
+of rust-gpu (probably not useful for contributors without access to embark's crates.io account :P)
+
+1. Bump all the versions in rust-gpu to the next one. I've found this command to be useful:
+`rg --files-with-matches alpha | xargs sed -i 's/0.4.0-alpha.10/0.4.0-alpha.11/g'` (replacing with
+whatever versions are relevant)
+2. Create a PR with that change. Wait for CI and a review, and merge it.
+3. Pull the merged `main` branch.
+4. Tag `main` with the version: `git tag v0.4.0-alpha.11`
+5. Push the tag: `git push origin v0.4.0-alpha.11`
+6. Publish the crates: `cd [crate] && cargo publish` (make sure `.cargo/credentials` is set to
+embark's token) - crates to be published, in order:
+   1. crates/spirv-std/shared
+   2. crates/spirv-std/macros
+   3. crates/spirv-std

--- a/examples/multibuilder/Cargo.toml
+++ b/examples/multibuilder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multibuilder"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-ash"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/cpu/Cargo.toml
+++ b/examples/runners/cpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-cpu"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-wgpu"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/wgpu/builder/Cargo.toml
+++ b/examples/runners/wgpu/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-wgpu-builder"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/compute-shader/Cargo.toml
+++ b/examples/shaders/compute-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/mouse-shader/Cargo.toml
+++ b/examples/shaders/mouse-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mouse-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/shared/Cargo.toml
+++ b/examples/shaders/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/simplest-shader/Cargo.toml
+++ b/examples/shaders/simplest-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplest-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/sky-shader/Cargo.toml
+++ b/examples/shaders/sky-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky-shader"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletests"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/tests/deps-helper/Cargo.toml
+++ b/tests/deps-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletests-deps-helper"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 description = "Shared dependencies of all the compiletest tests"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"

--- a/tests/ui/image/sample.rs
+++ b/tests/ui/image/sample.rs
@@ -13,7 +13,8 @@ pub fn main(
 ) {
     let v2 = glam::Vec2::new(0.0, 1.0);
     let v3 = glam::Vec3::new(0.0, 1.0, 0.5);
-    *output = image2d.sample(*sampler, v2);
-    *output += image2d_array.sample(*sampler, v3);
-    *output += cubemap.sample(*sampler, v3);
+    let r1: glam::Vec4 = image2d.sample(*sampler, v2);
+    let r2: glam::Vec4 = image2d_array.sample(*sampler, v3);
+    let r3: glam::Vec4 = cubemap.sample(*sampler, v3);
+    *output = r1 + r2 + r3;
 }

--- a/tests/ui/image/sample_gradient.rs
+++ b/tests/ui/image/sample_gradient.rs
@@ -13,7 +13,8 @@ pub fn main(
 ) {
     let v2 = glam::Vec2::new(0.0, 1.0);
     let v3 = glam::Vec3::new(0.0, 1.0, 0.5);
-    *output = image2d.sample_by_gradient(*sampler, v2, v2, v2);
-    *output += image2d_array.sample_by_gradient(*sampler, v3, v2, v2);
-    *output += cubemap.sample_by_gradient(*sampler, v3, v3, v3);
+    let r1: glam::Vec4 = image2d.sample_by_gradient(*sampler, v2, v2, v2);
+    let r2: glam::Vec4 = image2d_array.sample_by_gradient(*sampler, v3, v2, v2);
+    let r3: glam::Vec4 = cubemap.sample_by_gradient(*sampler, v3, v3, v3);
+    *output = r1 + r2 + r3;
 }

--- a/tests/ui/image/sample_lod.rs
+++ b/tests/ui/image/sample_lod.rs
@@ -13,7 +13,8 @@ pub fn main(
 ) {
     let v2 = glam::Vec2::new(0.0, 1.0);
     let v3 = glam::Vec3::new(0.0, 1.0, 0.5);
-    *output = image2d.sample_by_lod(*sampler, v2, 0.0);
-    *output += image2d_array.sample_by_lod(*sampler, v3, 0.0);
-    *output += cubemap.sample_by_lod(*sampler, v3, 0.0);
+    let r1: glam::Vec4 = image2d.sample_by_lod(*sampler, v2, 0.0);
+    let r2: glam::Vec4 = image2d_array.sample_by_lod(*sampler, v3, 0.0);
+    let r3: glam::Vec4 = cubemap.sample_by_lod(*sampler, v3, 0.0);
+    *output = r1 + r2 + r3;
 }

--- a/tests/ui/storage_class/runtime_descriptor_array.rs
+++ b/tests/ui/storage_class/runtime_descriptor_array.rs
@@ -1,4 +1,6 @@
 // build-pass
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+ext:SPV_EXT_descriptor_indexing
+
 use spirv_std::{Image, RuntimeArray, Sampler};
 
 #[spirv(fragment)]
@@ -8,16 +10,12 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 2)] sized_slice: &[Image!(2D, type=f32, sampled); 5],
     output: &mut glam::Vec4,
 ) {
-    unsafe {
-        asm!(
-            "OpCapability RuntimeDescriptorArray",
-            "OpExtension \"SPV_EXT_descriptor_indexing\""
-        )
-    }
     let img = unsafe { slice.index(5) };
     let v2 = glam::Vec2::new(0.0, 1.0);
-    *output = img.sample(*sampler, v2);
+    let r1: glam::Vec4 = img.sample(*sampler, v2);
 
     let img_2 = &sized_slice[2];
-    *output += img_2.sample(*sampler, v2);
+    let r2: glam::Vec4 = img_2.sample(*sampler, v2);
+
+    *output = r1 + r2;
 }


### PR DESCRIPTION
Shoehorned in some other changes:

- Update glam from 0.16 to 0.17
- Fix breakages caused by glam update (due to https://github.com/bitshifter/glam-rs/pull/198)
- Fix a leftover use of `asm!(OpCapability)` and migrate it to the new system.
- Add some publishing docs so I don't have constant worry if I'm forgetting a step whenever I'm releasing rust-gpu