### PR TITLE
Ignore tar vulnerability

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,12 @@ vulnerability = "deny"
 unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
-ignore = []
+ignore = [
+    # The tar crate allows creating directories outside dst when unpacking.
+    # Safe to ignore: we both create/control all input tar files, and we do not unpack them.
+    # https://github.com/alexcrichton/tar-rs/issues/238
+    "RUSTSEC-2021-0080",
+]
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:


### PR DESCRIPTION
Although tbh we may want to switch from tar to ar as described [here](https://github.com/EmbarkStudios/rust-gpu/pull/698), but that's lower priority than fixing CI.