### PR TITLE
Introduce `remove_unused_params` pass, to run just before zombie removal.

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/ipo.rs
+++ b/crates/rustc_codegen_spirv/src/linker/ipo.rs
@@ -1,0 +1,90 @@
+//! Tools for interprocedural optimizations (aka "IPO"s).
+
+// FIXME(eddyb) perhaps make all IPOs sub-modules of this module?
+
+use indexmap::IndexSet;
+use rspirv::dr::Module;
+use rspirv::spirv::Op;
+use rustc_data_structures::fx::FxHashMap;
+
+// FIXME(eddyb) use newtyped indices and `IndexVec`.
+type FuncIdx = usize;
+
+pub struct CallGraph {
+    entry_points: IndexSet<FuncIdx>,
+
+    /// `callees[i].contains(j)` implies `functions[i]` calls `functions[j]`.
+    callees: Vec<IndexSet<FuncIdx>>,
+}
+
+impl CallGraph {
+    pub fn collect(module: &Module) -> Self {
+        let func_id_to_idx: FxHashMap<_, _> = module
+            .functions
+            .iter()
+            .enumerate()
+            .map(|(i, func)| (func.def_id().unwrap(), i))
+            .collect();
+        let entry_points = module
+            .entry_points
+            .iter()
+            .map(|entry| {
+                assert_eq!(entry.class.opcode, Op::EntryPoint);
+                func_id_to_idx[&entry.operands[1].unwrap_id_ref()]
+            })
+            .collect();
+        let callees = module
+            .functions
+            .iter()
+            .map(|func| {
+                func.all_inst_iter()
+                    .filter(|inst| inst.class.opcode == Op::FunctionCall)
+                    .map(|inst| func_id_to_idx[&inst.operands[0].unwrap_id_ref()])
+                    .collect()
+            })
+            .collect();
+        Self {
+            entry_points,
+            callees,
+        }
+    }
+
+    /// Order functions using a post-order traversal, i.e. callees before callers.
+    // FIXME(eddyb) replace this with `rustc_data_structures::graph::iterate`
+    // (or similar).
+    pub fn post_order(&self) -> Vec<FuncIdx> {
+        let num_funcs = self.callees.len();
+
+        // FIXME(eddyb) use a proper bitset.
+        let mut visited = vec![false; num_funcs];
+        let mut post_order = Vec::with_capacity(num_funcs);
+
+        // Visit the call graph with entry points as roots.
+        for &entry in &self.entry_points {
+            self.post_order_step(entry, &mut visited, &mut post_order);
+        }
+
+        // Also visit any functions that were not reached from entry points
+        // (they might be dead but they should be processed nonetheless).
+        for func in 0..num_funcs {
+            if !visited[func] {
+                self.post_order_step(func, &mut visited, &mut post_order);
+            }
+        }
+
+        post_order
+    }
+
+    fn post_order_step(&self, func: FuncIdx, visited: &mut [bool], post_order: &mut Vec<FuncIdx>) {
+        if visited[func] {
+            return;
+        }
+        visited[func] = true;
+
+        for &callee in &self.callees[func] {
+            self.post_order_step(callee, visited, post_order);
+        }
+
+        post_order.push(func);
+    }
+}

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -6,6 +6,7 @@ mod destructure_composites;
 mod duplicates;
 mod import_export_link;
 mod inline;
+mod ipo;
 mod mem2reg;
 mod peephole_opts;
 mod simple_passes;

--- a/crates/rustc_codegen_spirv/src/linker/param_weakening.rs
+++ b/crates/rustc_codegen_spirv/src/linker/param_weakening.rs
@@ -1,0 +1,114 @@
+//! Interprocedural optimizations that "weaken" function parameters, i.e. they
+//! replace parameter types with "simpler" ones, or outright remove parameters,
+//! based on how those parameters are used in the function and/or what arguments
+//! get passed from callers.
+//!
+use crate::linker::ipo::CallGraph;
+use indexmap::IndexMap;
+use rspirv::dr::{Builder, Module, Operand};
+use rspirv::spirv::{Op, Word};
+use rustc_data_structures::fx::FxHashMap;
+use rustc_index::bit_set::BitSet;
+use std::mem;
+
+pub fn remove_unused_params(module: Module) -> Module {
+    let call_graph = CallGraph::collect(&module);
+
+    // Gather all of the unused parameters for each function, transitively.
+    // (i.e. parameters which are passed, as call arguments, to functions that
+    // won't use them, are also considered unused, through any number of calls)
+    let mut unused_params_per_func_id: IndexMap<Word, BitSet<usize>> = IndexMap::new();
+    for func_idx in call_graph.post_order() {
+        // Skip entry points, as they're the only "exported" functions, at least
+        // at link-time (likely only relevant to `Kernel`s, but not `Shader`s).
+        if call_graph.entry_points.contains(&func_idx) {
+            continue;
+        }
+
+        let func = &module.functions[func_idx];
+
+        let params_id_to_idx: FxHashMap<Word, usize> = func
+            .parameters
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (p.result_id.unwrap(), i))
+            .collect();
+        let mut unused_params = BitSet::new_filled(func.parameters.len());
+        for inst in func.all_inst_iter() {
+            // If this is a call, we can ignore the arguments passed to the
+            // callee parameters we already determined to be unused, because
+            // those parameters (and matching arguments) will get removed later.
+            let (operands, ignore_operands) = if inst.class.opcode == Op::FunctionCall {
+                (
+                    &inst.operands[1..],
+                    unused_params_per_func_id.get(&inst.operands[0].unwrap_id_ref()),
+                )
+            } else {
+                (&inst.operands[..], None)
+            };
+
+            for (i, operand) in operands.iter().enumerate() {
+                if let Some(ignore_operands) = ignore_operands {
+                    if ignore_operands.contains(i) {
+                        continue;
+                    }
+                }
+
+                if let Operand::IdRef(id) = operand {
+                    if let Some(&param_idx) = params_id_to_idx.get(id) {
+                        unused_params.remove(param_idx);
+                    }
+                }
+            }
+        }
+
+        if !unused_params.is_empty() {
+            unused_params_per_func_id.insert(func.def_id().unwrap(), unused_params);
+        }
+    }
+
+    // Remove unused parameters and call arguments for unused parameters.
+    let mut builder = Builder::new_from_module(module);
+    for func_idx in 0..builder.module_ref().functions.len() {
+        let func = &mut builder.module_mut().functions[func_idx];
+        let unused_params = unused_params_per_func_id.get(&func.def_id().unwrap());
+        if let Some(unused_params) = unused_params {
+            func.parameters = mem::take(&mut func.parameters)
+                .into_iter()
+                .enumerate()
+                .filter(|&(i, _)| !unused_params.contains(i))
+                .map(|(_, p)| p)
+                .collect();
+        }
+
+        for inst in func.all_inst_iter_mut() {
+            if inst.class.opcode == Op::FunctionCall {
+                if let Some(unused_callee_params) =
+                    unused_params_per_func_id.get(&inst.operands[0].unwrap_id_ref())
+                {
+                    inst.operands = mem::take(&mut inst.operands)
+                        .into_iter()
+                        .enumerate()
+                        .filter(|&(i, _)| i == 0 || !unused_callee_params.contains(i - 1))
+                        .map(|(_, o)| o)
+                        .collect();
+                }
+            }
+        }
+
+        // Regenerate the function type from remaining parameters, if necessary.
+        if unused_params.is_some() {
+            let return_type = func.def.as_mut().unwrap().result_type.unwrap();
+            let new_param_types: Vec<_> = func
+                .parameters
+                .iter()
+                .map(|inst| inst.result_type.unwrap())
+                .collect();
+            let new_func_type = builder.type_function(return_type, new_param_types);
+            let func = &mut builder.module_mut().functions[func_idx];
+            func.def.as_mut().unwrap().operands[1] = Operand::IdRef(new_func_type);
+        }
+    }
+
+    builder.module()
+}

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -129,11 +129,11 @@ fn without_header_eq(mut result: Module, expected: &str) {
     if result != expected {
         println!("{}", &result);
         panic!(
-            "assertion failed: `(left.contains(right))`\
+            "assertion failed: `left == right`\
             \n\
             \n{}\
             \n",
-            pretty_assertions::Comparison::new(&PrettyString(&result), &PrettyString(&expected))
+            pretty_assertions::Comparison::new(&PrettyString(&expected), &PrettyString(&result))
         );
     }
 }
@@ -378,6 +378,7 @@ fn use_exported_func_param_attr() {
             %8 = OpFunction %5 None %7
             %4 = OpFunctionParameter %6
             %9 = OpLabel
+            %10 = OpLoad %6 %4
             OpReturn
             OpFunctionEnd
             "#,
@@ -394,6 +395,7 @@ fn use_exported_func_param_attr() {
             %1 = OpFunction %3 None %5
             %2 = OpFunctionParameter %4
             %6 = OpLabel
+            %7 = OpLoad %4 %2
             OpReturn
             OpFunctionEnd
             "#,
@@ -412,11 +414,13 @@ fn use_exported_func_param_attr() {
         %7 = OpFunction %4 None %6
         %2 = OpFunctionParameter %5
         %8 = OpLabel
+        %9 = OpLoad %5 %2
         OpReturn
         OpFunctionEnd
-        %9 = OpFunction %4 None %6
+        %10 = OpFunction %4 None %6
         %3 = OpFunctionParameter %5
-        %10 = OpLabel
+        %11 = OpLabel
+        %12 = OpLoad %5 %3
         OpReturn
         OpFunctionEnd"#;
 
@@ -445,6 +449,7 @@ fn names_and_decorations() {
             %8 = OpFunction %5 None %7
             %4 = OpFunctionParameter %9
             %10 = OpLabel
+            %11 = OpLoad %6 %4
             OpReturn
             OpFunctionEnd
             "#,
@@ -464,6 +469,7 @@ fn names_and_decorations() {
             %1 = OpFunction %3 None %5
             %2 = OpFunctionParameter %7
             %6 = OpLabel
+            %8 = OpLoad %4 %2
             OpReturn
             OpFunctionEnd
             "#,
@@ -486,11 +492,13 @@ fn names_and_decorations() {
         %9 = OpFunction %5 None %8
         %4 = OpFunctionParameter %7
         %10 = OpLabel
+        %11 = OpLoad %6 %4
         OpReturn
         OpFunctionEnd
         %1 = OpFunction %5 None %8
         %2 = OpFunctionParameter %7
-        %11 = OpLabel
+        %12 = OpLabel
+        %13 = OpLoad %6 %2
         OpReturn
         OpFunctionEnd"#;
 

--- a/tests/ui/lang/panic/track_caller.rs
+++ b/tests/ui/lang/panic/track_caller.rs
@@ -1,0 +1,17 @@
+// Test that propagating `#[track_caller]` doesn't cause constant-related errors.
+
+// build-pass
+
+use spirv_std as _;
+
+#[track_caller]
+fn track_caller_maybe_panic(x: u32) {
+    if x > 0 {
+        panic!();
+    }
+}
+
+#[spirv(fragment)]
+pub fn main(x: u32) {
+    track_caller_maybe_panic(x);
+}


### PR DESCRIPTION
By removing (transitively) dead `fn` parameters, this PR also removes their matching *arguments*, which could be invalid (i.e. zombies).

The main usecase is `#[track_caller]`, which is becoming more prevalent in `core`.
The added test fails before this PR with:
```
error: constant arrays/structs cannot contain pointers to other constants
  --> $DIR/track_caller.rs:16:5
   |
16 |     track_caller_maybe_panic(x);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: Stack:
           track_caller::main
           Unnamed function ID %17
```

This allows updating past https://github.com/rust-lang/rust/pull/86664 (which gets transitively called from `mem::replace`).

Also, I tried using this to remove our hardcoded panic hacks, but it's not compatible with `-C debuginfo=2` (even if the `%x.dbg.spill` stack slots have no debuginfo attached, they're still created and `store`d to, so they get in the way).