### PR TITLE
asm: add support for noreturn option

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -70,8 +70,13 @@ impl<'a, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'tcx> {
         options: InlineAsmOptions,
         _line_spans: &[Span],
     ) {
-        if !options.is_empty() {
-            self.err(&format!("asm flags not supported: {:?}", options));
+        const SUPPORTED_OPTIONS: InlineAsmOptions = InlineAsmOptions::NORETURN;
+        let unsupported_options = options & !SUPPORTED_OPTIONS;
+        if !unsupported_options.is_empty() {
+            self.err(&format!(
+                "asm flags not supported: {:?}",
+                unsupported_options
+            ));
         }
         // vec of lines, and each line is vec of tokens
         let mut tokens = vec![vec![]];

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -163,6 +163,8 @@ impl<'a, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'tcx> {
                 self.err("`noreturn` requires a terminator at the end");
             }
             (true, AsmBlock::End(_)) => {
+                // `noreturn` appends an `OpUnreachable` after the asm block.
+                // This requires starting a new block for this.
                 let label = self.emit().id();
                 self.emit()
                     .insert_into_block(
@@ -173,7 +175,10 @@ impl<'a, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'tcx> {
             }
             (false, AsmBlock::Open) => (),
             (false, AsmBlock::End(terminator)) => {
-                self.err(&format!("trailing terminator {:?} requires `options(noreturn)`", terminator));
+                self.err(&format!(
+                    "trailing terminator {:?} requires `options(noreturn)`",
+                    terminator
+                ));
             }
         }
         for (id, num) in id_map {
@@ -377,7 +382,10 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                     }
                     AsmBlock::End(terminator) => {
                         if op != Op::Label {
-                            self.err(&format!("expected OpLabel after terminator {:?}", terminator));
+                            self.err(&format!(
+                                "expected OpLabel after terminator {:?}",
+                                terminator
+                            ));
                         }
 
                         AsmBlock::Open

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -148,8 +148,5 @@ pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
 #[doc(alias = "OpKill", alias = "discard")]
 #[allow(clippy::empty_loop)]
 pub fn kill() -> ! {
-    unsafe {
-        asm!("OpKill", "%unused = OpLabel");
-    }
-    loop {}
+    unsafe { asm!("OpKill", "%unused = OpLabel", options(noreturn)) }
 }

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -148,5 +148,5 @@ pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
 #[doc(alias = "OpKill", alias = "discard")]
 #[allow(clippy::empty_loop)]
 pub fn kill() -> ! {
-    unsafe { asm!("OpKill", "%unused = OpLabel", options(noreturn)) }
+    unsafe { asm!("OpKill", options(noreturn)) }
 }

--- a/crates/spirv-std/src/arch/ray_tracing.rs
+++ b/crates/spirv-std/src/arch/ray_tracing.rs
@@ -44,8 +44,11 @@ pub unsafe fn report_intersection(hit: f32, hit_kind: u32) -> bool {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn ignore_intersection() -> ! {
-    asm!("OpIgnoreIntersectionKHR", "%unused = OpLabel");
-    loop {}
+    asm!(
+        "OpIgnoreIntersectionKHR",
+        "%unused = OpLabel",
+        options(noreturn)
+    );
 }
 
 /// Terminates the invocation that executes it, stops the ray traversal, accepts
@@ -57,8 +60,7 @@ pub unsafe fn ignore_intersection() -> ! {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn terminate_ray() -> ! {
-    asm!("OpTerminateRayKHR", "%unused = OpLabel");
-    loop {}
+    asm!("OpTerminateRayKHR", "%unused = OpLabel", options(noreturn));
 }
 
 /// Invoke a callable shader.

--- a/crates/spirv-std/src/arch/ray_tracing.rs
+++ b/crates/spirv-std/src/arch/ray_tracing.rs
@@ -44,11 +44,7 @@ pub unsafe fn report_intersection(hit: f32, hit_kind: u32) -> bool {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn ignore_intersection() -> ! {
-    asm!(
-        "OpIgnoreIntersectionKHR",
-        "%unused = OpLabel",
-        options(noreturn)
-    );
+    asm!("OpIgnoreIntersectionKHR", options(noreturn));
 }
 
 /// Terminates the invocation that executes it, stops the ray traversal, accepts
@@ -60,7 +56,7 @@ pub unsafe fn ignore_intersection() -> ! {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn terminate_ray() -> ! {
-    asm!("OpTerminateRayKHR", "%unused = OpLabel", options(noreturn));
+    asm!("OpTerminateRayKHR", options(noreturn));
 }
 
 /// Invoke a callable shader.

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -118,7 +118,7 @@ pub use glam;
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
-    unsafe { asm!("", options(noreturn)) }
+    loop { }
 }
 
 #[cfg(all(not(test), target_arch = "spirv"))]

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -118,7 +118,7 @@ pub use glam;
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
-    loop {}
+    unsafe { asm!("", options(noreturn)) }
 }
 
 #[cfg(all(not(test), target_arch = "spirv"))]

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -118,7 +118,7 @@ pub use glam;
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
-    loop { }
+    loop {}
 }
 
 #[cfg(all(not(test), target_arch = "spirv"))]

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -25,7 +25,6 @@ impl AccelerationStructure {
             "%ret = OpTypeAccelerationStructureKHR",
             "%result = OpConvertUToAccelerationStructureKHR %ret {id}",
             "OpReturnValue %result",
-            "%blah = OpLabel",
             id = in(reg) id,
             options(noreturn)
         }
@@ -47,7 +46,6 @@ impl AccelerationStructure {
             "%id = OpLoad _ {id}",
             "%result = OpConvertUToAccelerationStructureKHR %ret %id",
             "OpReturnValue %result",
-            "%blah = OpLabel",
             id = in(reg) &id,
             options(noreturn),
         }

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -27,8 +27,8 @@ impl AccelerationStructure {
             "OpReturnValue %result",
             "%blah = OpLabel",
             id = in(reg) id,
+            options(noreturn)
         }
-        loop {}
     }
 
     /// Converts a vector of two 32 bit integers into an [`AccelerationStructure`].
@@ -49,8 +49,8 @@ impl AccelerationStructure {
             "OpReturnValue %result",
             "%blah = OpLabel",
             id = in(reg) &id,
+            options(noreturn),
         }
-        loop {}
     }
 
     #[spirv_std_macros::gpu_only]

--- a/crates/spirv-std/src/runtime_array.rs
+++ b/crates/spirv-std/src/runtime_array.rs
@@ -17,7 +17,6 @@ impl<T> RuntimeArray<T> {
         asm! {
             "%result = OpAccessChain _ {arr} {index}",
             "OpReturnValue %result",
-            "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
             options(noreturn),
@@ -30,7 +29,6 @@ impl<T> RuntimeArray<T> {
         asm! {
             "%result = OpAccessChain _ {arr} {index}",
             "OpReturnValue %result",
-            "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
             options(noreturn),

--- a/crates/spirv-std/src/runtime_array.rs
+++ b/crates/spirv-std/src/runtime_array.rs
@@ -20,8 +20,8 @@ impl<T> RuntimeArray<T> {
             "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
+            options(noreturn),
         }
-        loop {}
     }
 
     #[spirv_std_macros::gpu_only]
@@ -33,7 +33,7 @@ impl<T> RuntimeArray<T> {
             "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
+            options(noreturn),
         }
-        loop {}
     }
 }

--- a/tests/ui/lang/asm/block_tracking_fail.rs
+++ b/tests/ui/lang/asm/block_tracking_fail.rs
@@ -1,0 +1,41 @@
+// Tests validating tracking of basic blocks
+// within the `asm!` macro.
+// build-fail
+
+use spirv_std as _;
+
+// Active basic block with `noreturn`.
+fn asm_noreturn_open() {
+    unsafe {
+        asm!(
+            options(noreturn)
+        );
+    }
+}
+
+// No active basic block without `noreturn`.
+fn asm_closed() {
+    unsafe {
+        asm!(
+            "OpUnreachable",
+        );
+    }
+}
+
+// Invalid op after terminator
+fn asm_invalid_op_terminator(x: f32) {
+    unsafe {
+        asm!(
+            "OpKill",
+            "%sum = OpFAdd _ {x} {x}",
+            x = in(reg) x,
+        );
+    }
+}
+
+#[spirv(fragment)]
+pub fn main() {
+    asm_closed();
+    asm_noreturn_open();
+    asm_invalid_op_terminator(1.0);
+}

--- a/tests/ui/lang/asm/block_tracking_fail.rs
+++ b/tests/ui/lang/asm/block_tracking_fail.rs
@@ -7,9 +7,7 @@ use spirv_std as _;
 // Active basic block with `noreturn`.
 fn asm_noreturn_open() {
     unsafe {
-        asm!(
-            options(noreturn)
-        );
+        asm!("", options(noreturn));
     }
 }
 

--- a/tests/ui/lang/asm/block_tracking_fail.stderr
+++ b/tests/ui/lang/asm/block_tracking_fail.stderr
@@ -1,0 +1,29 @@
+error: `noreturn` requires a terminator at the end
+  --> $DIR/block_tracking_fail.rs:10:9
+   |
+10 | /         asm!(
+11 | |             "%unused = OpLabel",
+12 | |             options(noreturn),
+13 | |         );
+   | |__________^
+
+error: trailing terminator Unreachable requires `options(noreturn)`
+  --> $DIR/block_tracking_fail.rs:20:9
+   |
+20 | /         asm!(
+21 | |             "OpUnreachable",
+22 | |         );
+   | |__________^
+
+error: expected OpLabel after terminator Kill
+  --> $DIR/block_tracking_fail.rs:29:9
+   |
+29 | /         asm!(
+30 | |             "OpKill",
+31 | |             "%sum = OpFAdd _ {x} {x}",
+32 | |             x = in(reg) x,
+33 | |         );
+   | |__________^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lang/asm/block_tracking_fail.stderr
+++ b/tests/ui/lang/asm/block_tracking_fail.stderr
@@ -1,28 +1,25 @@
 error: `noreturn` requires a terminator at the end
   --> $DIR/block_tracking_fail.rs:10:9
    |
-10 | /         asm!(
-11 | |             "%unused = OpLabel",
-12 | |             options(noreturn),
-13 | |         );
-   | |__________^
+10 |         asm!("", options(noreturn));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trailing terminator Unreachable requires `options(noreturn)`
-  --> $DIR/block_tracking_fail.rs:20:9
+  --> $DIR/block_tracking_fail.rs:17:9
    |
-20 | /         asm!(
-21 | |             "OpUnreachable",
-22 | |         );
+17 | /         asm!(
+18 | |             "OpUnreachable",
+19 | |         );
    | |__________^
 
 error: expected OpLabel after terminator Kill
-  --> $DIR/block_tracking_fail.rs:29:9
+  --> $DIR/block_tracking_fail.rs:26:9
    |
-29 | /         asm!(
-30 | |             "OpKill",
-31 | |             "%sum = OpFAdd _ {x} {x}",
-32 | |             x = in(reg) x,
-33 | |         );
+26 | /         asm!(
+27 | |             "OpKill",
+28 | |             "%sum = OpFAdd _ {x} {x}",
+29 | |             x = in(reg) x,
+30 | |         );
    | |__________^
 
 error: aborting due to 3 previous errors

--- a/tests/ui/lang/asm/block_tracking_pass.rs
+++ b/tests/ui/lang/asm/block_tracking_pass.rs
@@ -7,7 +7,8 @@ use spirv_std as _;
 fn asm_label() {
     unsafe {
         asm!(
-            "%unused = OpLabel",
+            "OpReturn", // close active block
+            "%unused = OpLabel", // open new block
         );
     }
 }
@@ -15,7 +16,7 @@ fn asm_label() {
 fn asm_noreturn_single() -> ! {
     unsafe {
         asm!(
-            "OpKill",
+            "OpKill", // close active block
             options(noreturn),
         );
     }
@@ -24,5 +25,5 @@ fn asm_noreturn_single() -> ! {
 #[spirv(fragment)]
 pub fn main() {
     asm_label();
-    // asm_noreturn_single();
+    asm_noreturn_single();
 }

--- a/tests/ui/lang/asm/block_tracking_pass.rs
+++ b/tests/ui/lang/asm/block_tracking_pass.rs
@@ -1,0 +1,28 @@
+// Tests validating tracking of basic blocks
+// within the `asm!` macro.
+// build-pass
+
+use spirv_std as _;
+
+fn asm_label() {
+    unsafe {
+        asm!(
+            "%unused = OpLabel",
+        );
+    }
+}
+
+fn asm_noreturn_single() -> ! {
+    unsafe {
+        asm!(
+            "OpKill",
+            options(noreturn),
+        );
+    }
+}
+
+#[spirv(fragment)]
+pub fn main() {
+    asm_label();
+    // asm_noreturn_single();
+}


### PR DESCRIPTION
`OpUnreachable` will be appended as terminator at the end of the asm block (done automatically by the rustc)

Fixes https://github.com/EmbarkStudios/rust-gpu/issues/570