### PR TITLE
asm: implicit label after return or abort terminator

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -70,8 +70,13 @@ impl<'a, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'tcx> {
         options: InlineAsmOptions,
         _line_spans: &[Span],
     ) {
-        if !options.is_empty() {
-            self.err(&format!("asm flags not supported: {:?}", options));
+        const SUPPORTED_OPTIONS: InlineAsmOptions = InlineAsmOptions::NORETURN;
+        let unsupported_options = options & !SUPPORTED_OPTIONS;
+        if !unsupported_options.is_empty() {
+            self.err(&format!(
+                "asm flags not supported: {:?}",
+                unsupported_options
+            ));
         }
         // vec of lines, and each line is vec of tokens
         let mut tokens = vec![vec![]];

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -148,8 +148,5 @@ pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
 #[doc(alias = "OpKill", alias = "discard")]
 #[allow(clippy::empty_loop)]
 pub fn kill() -> ! {
-    unsafe {
-        asm!("OpKill", "%unused = OpLabel");
-    }
-    loop {}
+    unsafe { asm!("OpKill", "%unused = OpLabel", options(noreturn)) }
 }

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -148,5 +148,5 @@ pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
 #[doc(alias = "OpKill", alias = "discard")]
 #[allow(clippy::empty_loop)]
 pub fn kill() -> ! {
-    unsafe { asm!("OpKill", "%unused = OpLabel", options(noreturn)) }
+    unsafe { asm!("OpKill", options(noreturn)) }
 }

--- a/crates/spirv-std/src/arch/ray_tracing.rs
+++ b/crates/spirv-std/src/arch/ray_tracing.rs
@@ -44,8 +44,11 @@ pub unsafe fn report_intersection(hit: f32, hit_kind: u32) -> bool {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn ignore_intersection() -> ! {
-    asm!("OpIgnoreIntersectionKHR", "%unused = OpLabel");
-    loop {}
+    asm!(
+        "OpIgnoreIntersectionKHR",
+        "%unused = OpLabel",
+        options(noreturn)
+    );
 }
 
 /// Terminates the invocation that executes it, stops the ray traversal, accepts
@@ -57,8 +60,7 @@ pub unsafe fn ignore_intersection() -> ! {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn terminate_ray() -> ! {
-    asm!("OpTerminateRayKHR", "%unused = OpLabel");
-    loop {}
+    asm!("OpTerminateRayKHR", "%unused = OpLabel", options(noreturn));
 }
 
 /// Invoke a callable shader.

--- a/crates/spirv-std/src/arch/ray_tracing.rs
+++ b/crates/spirv-std/src/arch/ray_tracing.rs
@@ -44,11 +44,7 @@ pub unsafe fn report_intersection(hit: f32, hit_kind: u32) -> bool {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn ignore_intersection() -> ! {
-    asm!(
-        "OpIgnoreIntersectionKHR",
-        "%unused = OpLabel",
-        options(noreturn)
-    );
+    asm!("OpIgnoreIntersectionKHR", options(noreturn));
 }
 
 /// Terminates the invocation that executes it, stops the ray traversal, accepts
@@ -60,7 +56,7 @@ pub unsafe fn ignore_intersection() -> ! {
 #[inline]
 #[allow(clippy::empty_loop)]
 pub unsafe fn terminate_ray() -> ! {
-    asm!("OpTerminateRayKHR", "%unused = OpLabel", options(noreturn));
+    asm!("OpTerminateRayKHR", options(noreturn));
 }
 
 /// Invoke a callable shader.

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -118,7 +118,7 @@ pub use glam;
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
-    loop {}
+    unsafe { asm!("", options(noreturn)) }
 }
 
 #[cfg(all(not(test), target_arch = "spirv"))]

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -25,7 +25,6 @@ impl AccelerationStructure {
             "%ret = OpTypeAccelerationStructureKHR",
             "%result = OpConvertUToAccelerationStructureKHR %ret {id}",
             "OpReturnValue %result",
-            "%blah = OpLabel",
             id = in(reg) id,
             options(noreturn)
         }
@@ -47,7 +46,6 @@ impl AccelerationStructure {
             "%id = OpLoad _ {id}",
             "%result = OpConvertUToAccelerationStructureKHR %ret %id",
             "OpReturnValue %result",
-            "%blah = OpLabel",
             id = in(reg) &id,
             options(noreturn),
         }

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -27,8 +27,8 @@ impl AccelerationStructure {
             "OpReturnValue %result",
             "%blah = OpLabel",
             id = in(reg) id,
+            options(noreturn)
         }
-        loop {}
     }
 
     /// Converts a vector of two 32 bit integers into an [`AccelerationStructure`].
@@ -49,8 +49,8 @@ impl AccelerationStructure {
             "OpReturnValue %result",
             "%blah = OpLabel",
             id = in(reg) &id,
+            options(noreturn),
         }
-        loop {}
     }
 
     #[spirv_std_macros::gpu_only]

--- a/crates/spirv-std/src/runtime_array.rs
+++ b/crates/spirv-std/src/runtime_array.rs
@@ -17,7 +17,6 @@ impl<T> RuntimeArray<T> {
         asm! {
             "%result = OpAccessChain _ {arr} {index}",
             "OpReturnValue %result",
-            "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
             options(noreturn),
@@ -30,7 +29,6 @@ impl<T> RuntimeArray<T> {
         asm! {
             "%result = OpAccessChain _ {arr} {index}",
             "OpReturnValue %result",
-            "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
             options(noreturn),

--- a/crates/spirv-std/src/runtime_array.rs
+++ b/crates/spirv-std/src/runtime_array.rs
@@ -20,8 +20,8 @@ impl<T> RuntimeArray<T> {
             "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
+            options(noreturn),
         }
-        loop {}
     }
 
     #[spirv_std_macros::gpu_only]
@@ -33,7 +33,7 @@ impl<T> RuntimeArray<T> {
             "%unused = OpLabel",
             arr = in(reg) self,
             index = in(reg) index,
+            options(noreturn),
         }
-        loop {}
     }
 }


### PR DESCRIPTION
Implicitly add an `OpLabel` once a return or abort terminator is found in the asm line stream. This allows to remove the `%unused = OpLabel` workaround.

Internally, it creates an explicit label instruction and skips the begin_block/end_block mechanism of the rspirv builder due to how the cursor works. I hope handling this transparently is fine, asumming there will be no reference to this label.

Depends on #717
Fixes #564 