### PR TITLE
link: switch from `tar` to `ar` for `.rlib`s.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
+name = "ar"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "450575f58f7bee32816abbff470cbc47797397c2a81e0eaced4b98436daf52e1"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,6 +2240,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 name = "rustc_codegen_spirv"
 version = "0.4.0-alpha.12"
 dependencies = [
+ "ar",
  "bimap",
  "hashbrown 0.11.2",
  "indexmap",
@@ -2249,7 +2256,6 @@ dependencies = [
  "smallvec",
  "spirv-tools",
  "syn",
- "tar",
  "tempfile",
  "topological-sort",
 ]

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -35,6 +35,7 @@ num-traits = { version = "0.2", features = ["libm"] }
 syn = { version = "1", features = ["visit", "visit-mut"] }
 
 # Normal dependencies.
+ar = "0.8.0"
 bimap = "0.6"
 indexmap = "1.6.0"
 rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "c2a11ba7961fa7c675800f50c1903f0e96c633f8" }
@@ -44,7 +45,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"
 spirv-tools = { version = "0.6.1", default-features = false }
-tar = "0.4.30"
 topological-sort = "0.1"
 
 [dev-dependencies]

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -167,10 +167,9 @@ use rustc_codegen_ssa::traits::{
 };
 use rustc_codegen_ssa::{CodegenResults, CompiledModule, ModuleCodegen, ModuleKind};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::sync::MetadataRef;
 use rustc_errors::{ErrorReported, FatalError, Handler};
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
-use rustc_middle::middle::cstore::{EncodedMetadata, MetadataLoader, MetadataLoaderDyn};
+use rustc_middle::middle::cstore::EncodedMetadata;
 use rustc_middle::mir::mono::{Linkage, MonoItem, Visibility};
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, query, DefIdTree, Instance, InstanceDef, TyCtxt};
@@ -262,18 +261,6 @@ impl ThinBufferMethods for SpirvThinBuffer {
     }
 }
 
-struct SpirvMetadataLoader;
-
-impl MetadataLoader for SpirvMetadataLoader {
-    fn get_rlib_metadata(&self, _: &Target, path: &Path) -> Result<MetadataRef, String> {
-        link::read_metadata(path)
-    }
-
-    fn get_dylib_metadata(&self, target: &Target, path: &Path) -> Result<MetadataRef, String> {
-        rustc_codegen_ssa::back::metadata::DefaultMetadataLoader.get_dylib_metadata(target, path)
-    }
-}
-
 #[derive(Clone)]
 struct SpirvCodegenBackend;
 
@@ -297,10 +284,6 @@ impl CodegenBackend for SpirvCodegenBackend {
                 .ok(),
             TargetTriple::TargetPath(_) => None,
         }
-    }
-
-    fn metadata_loader(&self) -> Box<MetadataLoaderDyn> {
-        Box::new(SpirvMetadataLoader)
     }
 
     fn provide(&self, providers: &mut query::Providers) {

--- a/deny.toml
+++ b/deny.toml
@@ -6,12 +6,7 @@ vulnerability = "deny"
 unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
-ignore = [
-    # The tar crate allows creating directories outside dst when unpacking.
-    # Safe to ignore: we both create/control all input tar files, and we do not unpack them.
-    # https://github.com/alexcrichton/tar-rs/issues/238
-    "RUSTSEC-2021-0080",
-]
+ignore = []
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
@@ -32,8 +27,8 @@ deny = [
 skip = [
     #{ name = "ansi_term", version = "=0.11.0" },
 ]
-# Similarly to `skip` allows you to skip certain crates during duplicate 
-# detection. Unlike skip, it also includes the entire tree of transitive 
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
@@ -60,7 +55,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    
+
     "Zlib",
 ]
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses


### PR DESCRIPTION
Fixes #711 by an almost-`1:1` replacement of the [`tar`](https://docs.rs/tar/0.4.37/tar/) crate with the [`ar`](https://docs.rs/ar/0.8.0/ar/) crate. The documentation for those crates points to more information on the formats, but in short:
* [`ar` dates from 1971](https://en.wikipedia.org/wiki/Ar_(Unix)), holds a flat list of files, and is only used for `.a` static libraries (which contain the `.o` files they were created from, and optionally a symbol table) and `.deb` packages (for some reason)
  * it also has a BSD vs GNU split, but based on the GNU variant being used on Linux and Windows, I chose that, as it likely means better support
* [`tar` dates from 1979](https://en.wikipedia.org/wiki/Tar_(computing)), understands directory trees, and has been used for pretty much any archive purpose on UNIX systems (often compressed as e.g. `.tar.gz` or `.tar.xz`)

While using `tar` (or anything else, like, say, `zip`) doesn't really cause any issues, since we don't need to interop with any tools (for now), switching to `ar` does let us deduplicate some code (sadly for now only the part that finds the `rmeta` file inside the `.rlib`).

For future reference, the `rustc_codegen_cranelift` code for handling archives, which could eventually be moved into `rustc_codegen_ssa` (or in some other crate, more dedicated to linking) can be found in its [`src/archive.rs`](https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_codegen_cranelift/src/archive.rs) (cc @bjorn3).

**EDIT**: there is some precedent for what we're doing, and also the reason for why "just" having a `.rmeta` file inside the `.rlib` works - on most platforms we actually wrap the `.rmeta` in an `.o`, but [WebAssembly doesn't need that](https://github.com/rust-lang/rust/blob/2fc3c69e5419292e92663a5f1e39203478925661/compiler/rustc_codegen_ssa/src/back/link.rs#L345-L348), which means the default "get `.rmeta` from `.rlib`" implementation in `rustc_codegen_ssa` can handle a plain `.rmeta` file.