### PR TITLE
specializer: allow unused fully-constrained interface variables.

### DIFF
--- a/tests/ui/dis/issue-723-indirect-input.rs
+++ b/tests/ui/dis/issue-723-indirect-input.rs
@@ -1,0 +1,17 @@
+// Test that interface (global) `OpVariable`s mentioned by `OpEntryPoint` don't
+// have to be used by the shader, for storage class inference to succeed.
+
+// NOTE(eddyb) this test will likely become useless (won't fail without the fix)
+// once we start doing the copy out of the `Input` and into a `Function`-scoped
+// `OpVariable` (see #731), that's why there is another `issue-723-*` test.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std as _;
+
+#[spirv(fragment)]
+pub fn main(/* unused Input */ _: [f32; 3]) {}

--- a/tests/ui/dis/issue-723-indirect-input.stderr
+++ b/tests/ui/dis/issue-723-indirect-input.stderr
@@ -1,0 +1,20 @@
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/issue-723-indirect-input.rs"
+OpName %4 "issue_723_indirect_input::main"
+OpDecorate %5 ArrayStride 4
+OpDecorate %2 Location 0
+%6 = OpTypeVoid
+%7 = OpTypeFloat 32
+%8 = OpTypeInt 32 0
+%9 = OpConstant  %8  3
+%5 = OpTypeArray %7 %9
+%10 = OpTypePointer Input %5
+%11 = OpTypeFunction %6
+%2 = OpVariable  %10  Input

--- a/tests/ui/dis/issue-723-output.rs
+++ b/tests/ui/dis/issue-723-output.rs
@@ -1,0 +1,22 @@
+// Test that interface (global) `OpVariable`s mentioned by `OpEntryPoint` don't
+// have to be used by the shader, for storage class inference to succeed.
+
+// NOTE(eddyb) this relies on two subtleties (in order to fail without the fix):
+// * disabling debuginfo (to prevent `%x.dbg.spill` stack slot generation)
+//   * this could be alleviated in the future if we clean up how debuginfo
+//     is handled in `rustc_codegen_ssa`, to not assume LLVM limitations
+//   * it probably needs to stay like this, to ensure the parameter is unused
+// * `Output`s being handled with `&mut`, instead of by-value returns
+//   * if this changes, this test will likely need >=1.4 SPIR-V, which supports
+//     all interface `OpVariables` in `OpEntryPoint`, not just `Input`/`Output`
+
+// build-pass
+// compile-flags: -C debuginfo=0 -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std as _;
+
+#[spirv(fragment)]
+pub fn main(/* unused Output */ _: &mut glam::Vec4) {}

--- a/tests/ui/dis/issue-723-output.stderr
+++ b/tests/ui/dis/issue-723-output.stderr
@@ -1,0 +1,17 @@
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/issue-723-output.rs"
+OpName %4 "issue_723_output::main"
+OpDecorate %2 Location 0
+%5 = OpTypeVoid
+%6 = OpTypeFloat 32
+%7 = OpTypeVector %6 4
+%8 = OpTypePointer Output %7
+%9 = OpTypeFunction %5
+%2 = OpVariable  %8  Output


### PR DESCRIPTION
Fixes #723.

For a bit of background, this is what happens for e.g. an `Input` interface variable `x: f32`, during inference/specialization of `OpTypePointer` by storage class:
```
%f32_ptr<SC0: StorageClass> = OpTypePointer SC0 %f32
```
```
%x<SC0: StorageClass>: %f32_ptr<SC0> = OpVariable Input
    where SC0 = Input
```
```
OpEntryPoint ... %x
```

We're in a weird situation, where `%x` is fully determined to always be `%x<Input>`, because of the typing rule of `OpVariable S: (OpTypePointer S _)` (i.e. the redundancy of the storage class), *but* it still started out as "generic", and its type is an application of a "generic", so we have to treat it as such for consistency.

This isn't normally a problem, as any use of `%x` will be forced to instantiate `%x<Input>`, and so the `OpEntryPoint` will rely on that instance to replace its use of `%x` with `%x<Input>`.

However, if `%x` happens to be unused in the actual entry-point *function*, we would've panicked, before this PR, as the `OpEntryPoint` couldn't use any existing instances.

This PR works around that by "simply" instantiating any interface variables listed in `OpEntryPoint`, that have all of their "storage class parameters" fully constrained to concrete storage classes (and therefore require no inference/specialization).