### PR TITLE
link: remove workaround for mdsteele/rust-ar#19.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "ar"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450575f58f7bee32816abbff470cbc47797397c2a81e0eaced4b98436daf52e1"
+checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -35,7 +35,7 @@ num-traits = { version = "0.2", features = ["libm"] }
 syn = { version = "1", features = ["visit", "visit-mut"] }
 
 # Normal dependencies.
-ar = "0.8.0"
+ar = "0.9.0"
 bimap = "0.6"
 indexmap = "1.6.0"
 rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "c2a11ba7961fa7c675800f50c1903f0e96c633f8" }

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -469,11 +469,7 @@ fn create_archive(files: &[&Path], metadata: &[u8], out_filename: &Path) {
             "Duplicate filename in archive: {:?}",
             file.file_name().unwrap()
         );
-        // NOTE(eddyb) this could just be `builder.append_path(file)`, but we
-        // have to work around https://github.com/mdsteele/rust-ar/issues/19.
-        builder
-            .append_file(name.as_bytes(), &mut File::open(file).unwrap())
-            .unwrap();
+        builder.append_path(file).unwrap();
     }
     builder.into_inner().unwrap();
 }


### PR DESCRIPTION
The Windows fix landed in https://github.com/mdsteele/rust-ar/pull/20 and `ar` `0.9.0` was published with it.