### PR TITLE
Support `#[spirv(object_to_world)]` and `#[spirv(world_to_object)]`

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -218,6 +218,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 )
                 .def(self)
             }
+            SpirvType::Matrix { .. } => todo!(),
             SpirvType::Array { element, count } => {
                 let elem_pat = self.memset_const_pattern(&self.lookup_type(element), fill_byte);
                 let count = self.builder.lookup_const_u64(count).unwrap() as usize;
@@ -287,6 +288,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     )
                     .unwrap()
             }
+            SpirvType::Matrix { .. } => todo!(),
             SpirvType::RuntimeArray { .. } => {
                 self.fatal("memset on runtime arrays not implemented yet")
             }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -482,6 +482,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 *offset = final_offset;
                 result
             }
+            SpirvType::Matrix { .. } => todo!(),
             SpirvType::RuntimeArray { element } => {
                 let mut values = Vec::new();
                 while offset.bytes_usize() != alloc.len() {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -174,6 +174,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
                 TypeKind::Struct
             }
             SpirvType::Vector { .. } => TypeKind::Vector,
+            SpirvType::Matrix { .. } => todo!(),
             SpirvType::Array { .. } | SpirvType::RuntimeArray { .. } => TypeKind::Array,
             SpirvType::Pointer { .. } => TypeKind::Pointer,
             SpirvType::Function { .. } => TypeKind::Function,

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -47,6 +47,11 @@ pub enum SpirvType {
         /// Note: vector count is literal.
         count: u32,
     },
+    Matrix {
+        element: Word,
+        /// Note: matrix count is literal.
+        count: u32,
+    },
     Array {
         element: Word,
         /// Note: array count is ref to constant.
@@ -174,6 +179,7 @@ impl SpirvType {
                 result
             }
             Self::Vector { element, count } => cx.emit_global().type_vector_id(id, element, count),
+            Self::Matrix { element, count } => cx.emit_global().type_matrix_id(id, element, count),
             Self::Array { element, count } => {
                 // ArrayStride decoration wants in *bytes*
                 let element_size = cx
@@ -347,6 +353,7 @@ impl SpirvType {
             Self::Vector { element, count } => {
                 cx.lookup_type(element).sizeof(cx)? * count.next_power_of_two() as u64
             }
+            Self::Matrix { .. } => todo!(),
             Self::Array { element, count } => {
                 cx.lookup_type(element).sizeof(cx)? * cx.builder.lookup_const_u64(count).unwrap()
             }
@@ -377,6 +384,7 @@ impl SpirvType {
                     .bytes(),
             )
             .expect("alignof: Vectors must have power-of-2 size"),
+            Self::Matrix { .. } => todo!(),
             Self::Array { element, .. } | Self::RuntimeArray { element } => {
                 cx.lookup_type(element).alignof(cx)
             }
@@ -455,6 +463,7 @@ impl fmt::Debug for SpirvTypePrinter<'_, '_> {
                 .field("element", &self.cx.debug_type(element))
                 .field("count", &count)
                 .finish(),
+            SpirvType::Matrix { .. } => todo!(),
             SpirvType::Array { element, count } => f
                 .debug_struct("Array")
                 .field("id", &self.id)
@@ -616,6 +625,7 @@ impl SpirvTypePrinter<'_, '_> {
                 ty(self.cx, stack, f, element)?;
                 write!(f, "x{}", count)
             }
+            SpirvType::Matrix { .. } => todo!(),
             SpirvType::Array { element, count } => {
                 let len = self.cx.builder.lookup_const_u64(count);
                 let len = len.expect("Array type has invalid count value");

--- a/tests/ui/spirv-attr/raytracing_matrix.rs
+++ b/tests/ui/spirv-attr/raytracing_matrix.rs
@@ -1,0 +1,11 @@
+// build-pass
+// compile-flags: -Ctarget-feature=+RayTracingKHR,+ext:SPV_KHR_ray_tracing
+
+use spirv_std as _;
+
+#[spirv(closest_hit)]
+pub fn main(
+    #[spirv(object_to_world)] _object_to_world: [glam::Vec3; 4],
+    #[spirv(world_to_object)] _world_to_object: [glam::Vec3; 4],
+) {
+}


### PR DESCRIPTION
Fixes https://github.com/EmbarkStudios/rust-gpu/issues/723#issuecomment-900967671.

This PR supports `#[spirv(object_to_world)]` and `#[spirv(world_to_object)]`.
This decrares `ObjectToWorldKHR`/`WorldToObjectKHR` builtins as `OpMatrix` type and unpack it to function local variable.

I added `SpirvType::Matrix` variant but some of the other codes left `todo!` because I don't know how to test it when implemented.

I've confirmed that it works in my project.