### PR TITLE
rustup: update to nightly-2021-08-27 and re-add `-Zsymbol-mangling-version=v0`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -39,7 +39,7 @@ ar = "0.9.0"
 bimap = "0.6"
 indexmap = "1.6.0"
 rspirv = "0.10"
-rustc-demangle = "0.1.18"
+rustc-demangle = "0.1.21"
 sanitize-filename = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -341,14 +341,17 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
 }
 
 impl<'tcx> CodegenCx<'tcx> {
-    // This function comes from https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_middle/ty/layout.rs.html,
-    // and is a lambda in the `layout_raw_uncached` function in Version 1.50.0-nightly (eb4fc71dc 2020-12-17)
+    // This function comes from `ty::layout`'s `layout_of_uncached`,
+    // where it's named `scalar_unit`.
     pub fn primitive_to_scalar(&self, value: Primitive) -> abi::Scalar {
         let bits = value.size(self.data_layout()).bits();
         assert!(bits <= 128);
         abi::Scalar {
             value,
-            valid_range: 0..=(!0 >> (128 - bits)),
+            valid_range: abi::WrappingRange {
+                start: 0,
+                end: (!0 >> (128 - bits)),
+            },
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -294,12 +294,17 @@ impl<'tcx> StaticMethods for CodegenCx<'tcx> {
             .set_global_initializer(g.def_cx(self), v.def_cx(self));
     }
 
-    /// Mark the given global value as "used", to prevent a backend from potentially removing a
-    /// static variable that may otherwise appear unused.
-    ///
-    /// Static variables in Rust can be annotated with the `#[used]` attribute to direct the `rustc`
-    /// compiler to mark the variable as a "used global".
+    /// Mark the given global value as "used", to prevent the compiler and linker from potentially
+    /// removing a static variable that may otherwise appear unused.
     fn add_used_global(&self, _global: Self::Value) {
+        // TODO: Ignore for now.
+    }
+
+    /// Same as `add_used_global`, but only prevent the compiler from potentially removing an
+    /// otherwise unused symbol. The linker is still permitted to drop it.
+    ///
+    /// This corresponds to the semantics of the `#[used]` attribute.
+    fn add_compiler_used_global(&self, _global: Self::Value) {
         // TODO: Ignore for now.
     }
 }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -562,6 +562,10 @@ impl<'tcx> MiscMethods<'tcx> for CodegenCx<'tcx> {
         todo!()
     }
 
+    fn compiler_used_statics(&self) -> &RefCell<Vec<Self::Value>> {
+        todo!()
+    }
+
     fn set_frame_pointer_type(&self, _llfn: Self::Function) {
         todo!()
     }
@@ -571,6 +575,10 @@ impl<'tcx> MiscMethods<'tcx> for CodegenCx<'tcx> {
     }
 
     fn create_used_variable(&self) {
+        todo!()
+    }
+
+    fn create_compiler_used_variable(&self) {
         todo!()
     }
 

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -394,8 +394,7 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
 
     let mut rustflags = vec![
         format!("-Zcodegen-backend={}", rustc_codegen_spirv.display()),
-        //FIXME: reintroduce v0 mangling, see issue #642
-        "-Zsymbol-mangling-version=legacy".to_string(),
+        "-Zsymbol-mangling-version=v0".to_string(),
     ];
 
     let mut llvm_args = vec![];

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-08-10"
+channel = "nightly-2021-08-27"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -292,6 +292,7 @@ struct TestDeps {
 }
 
 /// The RUSTFLAGS passed to all SPIR-V builds.
+// FIXME(eddyb) expose most of these from `spirv-builder`.
 fn rust_flags(codegen_backend_path: &Path) -> String {
     [
         &*format!("-Zcodegen-backend={}", codegen_backend_path.display()),
@@ -300,6 +301,7 @@ fn rust_flags(codegen_backend_path: &Path) -> String {
         "-Cdebuginfo=2",
         "-Cembed-bitcode=no",
         "-Ctarget-feature=+Int8,+Int16,+Int64,+Float64",
+        "-Zsymbol-mangling-version=v0",
     ]
     .join(" ")
 }

--- a/tests/ui/dis/generic-fn-op-name.rs
+++ b/tests/ui/dis/generic-fn-op-name.rs
@@ -1,0 +1,19 @@
+// Test that generic functions' `OpName` correctly include generic arguments.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use spirv_std::image::Dimensionality;
+
+fn generic<T, const DIM: Dimensionality>() {}
+
+#[spirv(fragment)]
+pub fn main() {
+    generic::<f32, { Dimensionality::TwoD }>();
+}

--- a/tests/ui/dis/generic-fn-op-name.stderr
+++ b/tests/ui/dis/generic-fn-op-name.stderr
@@ -7,7 +7,7 @@ OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
 %2 = OpString "$OPSTRING_FILENAME/generic-fn-op-name.rs"
-OpName %3 "generic_fn_op_name::generic"
+OpName %3 "generic_fn_op_name::generic::<f32, {spirv_types::image_params::Dimensionality::TwoD}>"
 OpName %4 "generic_fn_op_name::main"
 %5 = OpTypeVoid
 %6 = OpTypeFunction %5

--- a/tests/ui/dis/generic-fn-op-name.stderr
+++ b/tests/ui/dis/generic-fn-op-name.stderr
@@ -1,0 +1,13 @@
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/generic-fn-op-name.rs"
+OpName %3 "generic_fn_op_name::generic"
+OpName %4 "generic_fn_op_name::main"
+%5 = OpTypeVoid
+%6 = OpTypeFunction %5

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,7 +1,7 @@
 error: Cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2132:14
+    --> $CORE_SRC/intrinsics.rs:2138:14
      |
-2132 |     unsafe { copy(src, dst, count) }
+2138 |     unsafe { copy(src, dst, count) }
      |              ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error


### PR DESCRIPTION
Fixes #642 by switching back to `v0`, as it can now handle our (user-typed) `const` generics (used for `Image`) - for more information, see:
* https://github.com/rust-lang/rfcs/pull/3161
* https://github.com/alexcrichton/rustc-demangle/pull/55
* https://github.com/rust-lang/rust/pull/87194
  * this is what lets us switch back, as it landed yesterday