### PR TITLE
std: fix ray query initialization and proceed result

### DIFF
--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -219,11 +219,12 @@ impl RayQuery {
         ray_tmax: f32,
     ) {
         asm! {
+            "%acceleration_structure = OpLoad _ {acceleration_structure}",
             "%origin = OpLoad _ {ray_origin}",
             "%direction = OpLoad _ {ray_direction}",
             "OpRayQueryInitializeKHR \
                 {ray_query} \
-                {acceleration_structure} \
+                %acceleration_structure \
                 {ray_flags} \
                 {cull_mask} \
                 %origin \
@@ -256,7 +257,7 @@ impl RayQuery {
             "%u32_0 = OpConstant %u32 0",
             "%u32_1 = OpConstant %u32 1",
             "%result = OpRayQueryProceedKHR %bool {ray_query}",
-            "{result} = OpSelect %u32 %result %u32_0 %u32_1",
+            "{result} = OpSelect %u32 %result %u32_1 %u32_0",
             ray_query = in(reg) self,
             result = out(reg) result,
         }


### PR DESCRIPTION
- `OpRayQueryInitializeKHR`: the acceleration structure parameters requires an additional `OpLoad`. The extension spec is not really clear here (https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_ray_query.asciidoc) imo, speaking of 'descriptor'. Looking at the glslang reference compiler shows that it requires the additional load operation. On nvidia drivers this leads to a crash on compute pipeline creation without it.

- `OpRayQueryProceedKHR` has the conversion logic inverted from `bool` -> `uint`, the 1st object should refer to the `true` case and the 2nd to `false`.