### PR TITLE
Add a spirv-builder option to include all debug info

### DIFF
--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -1,4 +1,4 @@
-use crate::codegen_cx::{CodegenArgs, ModuleOutputType};
+use crate::codegen_cx::{CodegenArgs, ModuleOutputType, SpirvMetadata};
 use crate::{
     linker, CompileResult, ModuleResult, SpirvCodegenBackend, SpirvModuleBuffer, SpirvThinBuffer,
 };
@@ -210,7 +210,7 @@ fn post_link_single_module(
     };
 
     let spv_binary = if sess.opts.optimize != OptLevel::No
-        || (sess.opts.debuginfo == DebugInfo::None && !cg_args.name_variables)
+        || (sess.opts.debuginfo == DebugInfo::None && cg_args.spirv_metadata == SpirvMetadata::None)
     {
         if env::var("NO_SPIRV_OPT").is_err() {
             let _timer = sess.timer("link_spirv_opt");
@@ -273,7 +273,7 @@ fn do_spirv_opt(
         }
     }
 
-    if sess.opts.debuginfo == DebugInfo::None && !cg_args.name_variables {
+    if sess.opts.debuginfo == DebugInfo::None && cg_args.spirv_metadata == SpirvMetadata::None {
         optimizer
             .register_pass(opt::Passes::EliminateDeadConstant)
             .register_pass(opt::Passes::StripDebugInfo);
@@ -528,7 +528,7 @@ fn do_link(
         compact_ids: env::var("NO_COMPACT_IDS").is_err(),
         structurize: env::var("NO_STRUCTURIZE").is_err(),
         emit_multiple_modules: cg_args.module_output_type == ModuleOutputType::Multiple,
-        name_variables: cg_args.name_variables,
+        spirv_metadata: cg_args.spirv_metadata,
     };
 
     let link_result = linker::link(sess, modules, &options);

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -15,6 +15,7 @@ mod specializer;
 mod structurizer;
 mod zombies;
 
+use crate::codegen_cx::SpirvMetadata;
 use crate::decorations::{CustomDecoration, UnrollLoopsDecoration};
 use rspirv::binary::{Assemble, Consumer};
 use rspirv::dr::{Block, Instruction, Loader, Module, ModuleHeader, Operand};
@@ -30,7 +31,7 @@ pub struct Options {
     pub dce: bool,
     pub structurize: bool,
     pub emit_multiple_modules: bool,
-    pub name_variables: bool,
+    pub spirv_metadata: SpirvMetadata,
 }
 
 pub enum LinkResult {
@@ -246,7 +247,7 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
         }
     }
 
-    if opts.name_variables {
+    if opts.spirv_metadata == SpirvMetadata::NameVariables {
         let _timer = sess.timer("link_name_variables");
         simple_passes::name_variables_pass(&mut output);
     }

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -1,4 +1,5 @@
 use super::{link, LinkResult, Options};
+use crate::codegen_cx::SpirvMetadata;
 use pipe::pipe;
 use rspirv::dr::{Loader, Module};
 use rustc_driver::handle_options;
@@ -93,7 +94,7 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, String> {
                 dce: false,
                 structurize: false,
                 emit_multiple_modules: false,
-                name_variables: false,
+                spirv_metadata: SpirvMetadata::None,
             },
         );
         assert_eq!(compiler.session().has_errors(), res.is_err());

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -402,12 +402,10 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
     if builder.multimodule {
         llvm_args.push("--module-output=multiple");
     }
-    if builder.spirv_metadata != SpirvMetadata::None {
-        if builder.spirv_metadata == SpirvMetadata::Full {
-            llvm_args.push("--spirv-metadata=full");
-        } else {
-            llvm_args.push("--spirv-metadata=name-variables");
-        }
+    match builder.spirv_metadata {
+        SpirvMetadata::None => (),
+        SpirvMetadata::NameVariables => llvm_args.push("--spirv-metadata=name-variables"),
+        SpirvMetadata::Full => llvm_args.push("--spirv-metadata=full"),
     }
     if builder.relax_struct_store {
         llvm_args.push("--relax-struct-store");

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -215,7 +215,7 @@ impl SpirvBuilder {
         self
     }
 
-    /// Sets the level of metadata (primarily OpName and OpLine) included in the SPIR-V binary.
+    /// Sets the level of metadata (primarily `OpName` and `OpLine`) included in the SPIR-V binary.
     /// Including metadata significantly increases binary size.
     pub fn spirv_metadata(mut self, v: SpirvMetadata) -> Self {
         self.spirv_metadata = v;


### PR DESCRIPTION
This is in addition to the cargo debug information option doing the same thing. Fixes #736