### PR TITLE
Actually set the SPIR-V generator magic number

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -338,6 +338,7 @@ impl BuilderSpirv {
 
         let mut builder = Builder::new();
         builder.set_version(version.0, version.1);
+        builder.module_mut().header.as_mut().unwrap().generator = 0x001B_0000;
 
         let mut enabled_capabilities = FxHashSet::default();
         let mut enabled_extensions = FxHashSet::default();

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -107,6 +107,7 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
         let mut output = loader.module();
         let mut header = ModuleHeader::new(bound + 1);
         header.set_version(version.0, version.1);
+        header.generator = 0x001B_0000;
         output.header = Some(header);
         output
     };


### PR DESCRIPTION
wow this took a while to do

```
> spirv-dis some/module
; SPIR-V
; Version: 1.3
; Generator: Embark Studios Rust GPU Compiler Backend; 0
; Bound: 63
; Schema: 0
               OpCapability Int8
               OpCapability Shader
               OpCapability VulkanMemoryModel
               OpExtension "SPV_KHR_vulkan_memory_model"
               OpMemoryModel Logical Vulkan
               blahblahblah
```