### PR TITLE
Add 'SampledImage::sample_by_lod'

### DIFF
--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -1010,7 +1010,7 @@ impl<
         >,
     >
 {
-    /// Sample texels at `coord` from the sampled image.
+    /// Sample texels at `coord` from the sampled image with an implicit lod.
     ///
     /// # Safety
     /// Sampling with a type (`S`) that doesn't match the image's image format
@@ -1030,6 +1030,36 @@ impl<
             in(reg) &mut result,
             in(reg) self,
             in(reg) &coord
+        );
+        result
+    }
+
+    /// Sample texels at `coord` from the sampled image with an explicit lod.
+    ///
+    /// # Safety
+    /// Sampling with a type (`S`) that doesn't match the image's image format
+    /// will result in undefined behaviour.
+    #[crate::macros::gpu_only]
+    pub unsafe fn sample_by_lod<F, V>(
+        &self,
+        coord: impl ImageCoordinate<F, DIM, ARRAYED>,
+        lod: f32,
+    ) -> V
+    where
+        F: Float,
+        V: Vector<SampledType, 4>,
+    {
+        let mut result = Default::default();
+        asm!(
+            "%sampledImage = OpLoad typeof*{1} {1}",
+            "%coord = OpLoad typeof*{2} {2}",
+            "%lod = OpLoad typeof*{3} {3}",
+            "%result = OpImageSampleExplicitLod typeof*{0} %sampledImage %coord Lod %lod",
+            "OpStore {0} %result",
+            in(reg) &mut result,
+            in(reg) self,
+            in(reg) &coord,
+            in(reg) &lod,
         );
         result
     }


### PR DESCRIPTION
This resolves the issue I was having in https://github.com/EmbarkStudios/rust-gpu/issues/754. I'd be good to get all the other sampling functions implemented for `SampledImage` as well, but let's start with this one.