### PR TITLE
Add an `read_clock_khr` function that calls `OpReadClockKHR`

### DIFF
--- a/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
@@ -745,7 +745,7 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         // SPV_AMD_shader_fragment_mask
         Op::FragmentMaskFetchAMD | Op::FragmentFetchAMD => reserved!(SPV_AMD_shader_fragment_mask),
         // SPV_KHR_shader_clock
-        Op::ReadClockKHR => reserved!(SPV_KHR_shader_clock),
+        Op::ReadClockKHR => {}
         // SPV_NV_mesh_shader
         Op::WritePackedPrimitiveIndices4x8NV => reserved!(SPV_NV_mesh_shader),
         // SPV_NV_ray_tracing

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -150,3 +150,25 @@ pub unsafe fn vector_insert_dynamic<T: Scalar, V: Vector<T, N>, const N: usize>(
 pub fn kill() -> ! {
     unsafe { asm!("OpKill", options(noreturn)) }
 }
+
+/// Read from the shader clock.
+///
+/// Requires the `SPV_KHR_shader_clock` extension and the `ShaderClockKHR` capability.
+///
+/// See:
+/// <https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_shader_clock.html>
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpReadClockKHR")]
+pub unsafe fn read_clock_khr() -> u64 {
+    let mut result: u64 = 0;
+
+    asm! {
+        "%uint = OpTypeInt 32 0",
+        "%uint_3 = OpConstant %uint 3",
+        "%result = OpReadClockKHR typeof*{result} %uint_3",
+        "OpStore {result} %result",
+        result = in(reg) &mut result,
+    };
+
+    result
+}


### PR DESCRIPTION
Reading from the shader clock lets us create heatmaps for ray tracing as seen here: https://developer.nvidia.com/blog/profiling-dxr-shaders-with-timer-instrumentation/.

![heatmap](https://user-images.githubusercontent.com/13566135/134957946-54dbca33-3ef0-4a9d-9697-f6c083f75d70.png)
