### PR TITLE
rustup: update to nightly-2021-09-29.

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -9,18 +9,17 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::ErrorReported;
 use rustc_index::vec::Idx;
 use rustc_middle::bug;
-use rustc_middle::ty::layout::{FnAbiExt, TyAndLayout};
+use rustc_middle::ty::layout::{FnAbiOf, LayoutOf, TyAndLayout};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{
-    Const, FloatTy, GeneratorSubsts, IntTy, ParamEnv, PolyFnSig, Ty, TyKind, TypeAndMut, UintTy,
+    self, Const, FloatTy, GeneratorSubsts, IntTy, ParamEnv, PolyFnSig, Ty, TyKind, TypeAndMut,
+    UintTy,
 };
 use rustc_span::def_id::DefId;
 use rustc_span::Span;
 use rustc_span::DUMMY_SP;
 use rustc_target::abi::call::{CastTarget, FnAbi, PassMode, Reg, RegKind};
-use rustc_target::abi::{
-    Abi, Align, FieldsShape, LayoutOf, Primitive, Scalar, Size, VariantIdx, Variants,
-};
+use rustc_target::abi::{Abi, Align, FieldsShape, Primitive, Scalar, Size, VariantIdx, Variants};
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::fmt;
@@ -150,13 +149,17 @@ impl<'tcx> ConvSpirvType<'tcx> for PointeeTy<'tcx> {
     fn spirv_type(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
         match *self {
             PointeeTy::Ty(ty) => ty.spirv_type(span, cx),
-            PointeeTy::Fn(ty) => FnAbi::of_fn_ptr(cx, ty, &[]).spirv_type(span, cx),
+            PointeeTy::Fn(ty) => cx
+                .fn_abi_of_fn_ptr(ty, ty::List::empty())
+                .spirv_type(span, cx),
         }
     }
     fn spirv_type_immediate(&self, span: Span, cx: &CodegenCx<'tcx>) -> Word {
         match *self {
             PointeeTy::Ty(ty) => ty.spirv_type_immediate(span, cx),
-            PointeeTy::Fn(ty) => FnAbi::of_fn_ptr(cx, ty, &[]).spirv_type_immediate(span, cx),
+            PointeeTy::Fn(ty) => cx
+                .fn_abi_of_fn_ptr(ty, ty::List::empty())
+                .spirv_type_immediate(span, cx),
         }
     }
 }

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -16,10 +16,9 @@ use rustc_codegen_ssa::MemFlags;
 use rustc_middle::bug;
 use rustc_middle::ty::Ty;
 use rustc_span::Span;
-use rustc_target::abi::{Abi, Align, Scalar, Size};
+use rustc_target::abi::{Abi, Align, Scalar, Size, WrappingRange};
 use std::convert::TryInto;
 use std::iter::{self, empty};
-use std::ops::Range;
 
 macro_rules! simple_op {
     (
@@ -794,7 +793,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
     // silly clippy, we can't rename this!
     #[allow(clippy::wrong_self_convention)]
-    fn to_immediate_scalar(&mut self, val: Self::Value, scalar: &Scalar) -> Self::Value {
+    fn to_immediate_scalar(&mut self, val: Self::Value, scalar: Scalar) -> Self::Value {
         if scalar.is_bool() {
             let bool = SpirvType::Bool.def(self.span(), self);
             return self.trunc(val, bool);
@@ -982,7 +981,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         self
     }
 
-    fn range_metadata(&mut self, _load: Self::Value, _range: Range<u128>) {
+    fn range_metadata(&mut self, _load: Self::Value, _range: WrappingRange) {
         // ignore
     }
 

--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -8,11 +8,11 @@ use rustc_codegen_ssa::mir::operand::OperandRef;
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::traits::{BuilderMethods, IntrinsicCallMethods};
 use rustc_middle::bug;
+use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{FnDef, Instance, ParamEnv, Ty, TyKind};
 use rustc_span::source_map::Span;
 use rustc_span::sym;
 use rustc_target::abi::call::{FnAbi, PassMode};
-use rustc_target::abi::LayoutOf;
 
 fn int_type_width_signed(ty: Ty<'_>, cx: &CodegenCx<'_>) -> Option<(u64, bool)> {
     match ty.kind() {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -6,12 +6,13 @@ use rspirv::spirv::Word;
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::traits::{BaseTypeMethods, ConstMethods, MiscMethods, StaticMethods};
 use rustc_middle::bug;
-use rustc_middle::mir::interpret::{alloc_range, Allocation, GlobalAlloc, ScalarMaybeUninit};
-use rustc_middle::ty::layout::TyAndLayout;
-use rustc_mir::interpret::Scalar;
+use rustc_middle::mir::interpret::{
+    alloc_range, Allocation, GlobalAlloc, Scalar, ScalarMaybeUninit,
+};
+use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_span::symbol::Symbol;
 use rustc_span::{Span, DUMMY_SP};
-use rustc_target::abi::{self, AddressSpace, HasDataLayout, Integer, LayoutOf, Primitive, Size};
+use rustc_target::abi::{self, AddressSpace, HasDataLayout, Integer, Primitive, Size};
 
 impl<'tcx> CodegenCx<'tcx> {
     pub fn constant_u8(&self, span: Span, val: u8) -> SpirvValue {
@@ -207,7 +208,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
     fn scalar_to_backend(
         &self,
         scalar: Scalar,
-        layout: &abi::Scalar,
+        layout: abi::Scalar,
         ty: Self::Type,
     ) -> Self::Value {
         match scalar {
@@ -426,7 +427,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 // tldr, the pointer here is only needed for the offset
                 let value = match alloc.read_scalar(self, alloc_range(*offset, size)).unwrap() {
                     ScalarMaybeUninit::Scalar(scalar) => {
-                        self.scalar_to_backend(scalar, &self.primitive_to_scalar(primitive), ty)
+                        self.scalar_to_backend(scalar, self.primitive_to_scalar(primitive), ty)
                     }
                     ScalarMaybeUninit::Uninit => self.undef(ty),
                 };

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -11,12 +11,12 @@ use rspirv::spirv::{
 use rustc_codegen_ssa::traits::{BaseTypeMethods, BuilderMethods};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
-use rustc_middle::ty::layout::TyAndLayout;
+use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::{Instance, Ty, TyKind};
 use rustc_span::Span;
 use rustc_target::abi::{
     call::{ArgAbi, ArgAttribute, ArgAttributes, FnAbi, PassMode},
-    LayoutOf, Size,
+    Size,
 };
 
 impl<'tcx> CodegenCx<'tcx> {

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -118,7 +118,6 @@ extern crate rustc_hir;
 extern crate rustc_index;
 extern crate rustc_interface;
 extern crate rustc_middle;
-extern crate rustc_mir;
 extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
@@ -171,9 +170,9 @@ use rustc_errors::{ErrorReported, FatalError, Handler};
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::middle::cstore::EncodedMetadata;
 use rustc_middle::mir::mono::{Linkage, MonoItem, Visibility};
+use rustc_middle::mir::pretty::write_mir_pretty;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, query, DefIdTree, Instance, InstanceDef, TyCtxt};
-use rustc_mir::util::write_mir_pretty;
 use rustc_session::config::{self, OptLevel, OutputFilenames, OutputType};
 use rustc_session::Session;
 use rustc_span::symbol::{sym, Symbol};
@@ -500,6 +499,7 @@ impl ExtraBackendMethods for SpirvCodegenBackend {
         &self,
         _: TyCtxt<'tcx>,
         _: &mut Self::Module,
+        _: &str,
         _: AllocatorKind,
         _: bool,
     ) {

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -11,7 +11,7 @@
     ),
     register_attr(spirv)
 )]
-#![feature(const_generics)]
+#![feature(adt_const_params)]
 // BEGIN - Embark standard lints v0.4
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
@@ -88,7 +88,7 @@
     // We deblierately provide an unimplemented version of our API on CPU
     // platforms so that code completion still works.
     clippy::unimplemented,
-    // The part of `const-generics` we're using (C-like enums) is not incomplete.
+    // The part of `adt_const_params` we're using (C-like enums) is not incomplete.
     incomplete_features,
 )]
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-08-27"
+channel = "nightly-2021-09-29"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/tests/ui/arch/control_barrier.rs
+++ b/tests/ui/arch/control_barrier.rs
@@ -1,6 +1,6 @@
 // build-pass
 
-#![feature(const_generics)]
+#![feature(adt_const_params)]
 #![allow(incomplete_features)]
 
 use spirv_std::memory::{Scope, Semantics};

--- a/tests/ui/arch/memory_barrier.rs
+++ b/tests/ui/arch/memory_barrier.rs
@@ -1,6 +1,6 @@
 // build-pass
 
-#![feature(const_generics)]
+#![feature(adt_const_params)]
 #![allow(incomplete_features)]
 
 use spirv_std::memory::{Scope, Semantics};

--- a/tests/ui/dis/generic-fn-op-name.rs
+++ b/tests/ui/dis/generic-fn-op-name.rs
@@ -6,7 +6,7 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
-#![feature(const_generics)]
+#![feature(adt_const_params)]
 #![allow(incomplete_features)]
 
 use spirv_std::image::Dimensionality;

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,7 +1,7 @@
 error: Cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2138:14
+    --> $CORE_SRC/intrinsics.rs:2137:14
      |
-2138 |     unsafe { copy(src, dst, count) }
+2137 |     unsafe { copy(src, dst, count) }
      |              ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -5,9 +5,9 @@
 %8 = OpVariable  %5  Function
 OpLine %9 319 5
 OpStore %8 %10
-OpLine %11 703 8
+OpLine %11 699 8
 OpCopyMemory %8 %4
-OpLine %11 704 8
+OpLine %11 700 8
 %12 = OpLoad  %13  %8
 OpLine %14 7 13
 OpStore %6 %12

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -5,9 +5,9 @@
 %8 = OpVariable  %5  Function
 OpLine %9 319 5
 OpStore %8 %10
-OpLine %11 703 8
+OpLine %11 699 8
 OpCopyMemory %8 %4
-OpLine %11 704 8
+OpLine %11 700 8
 %12 = OpLoad  %13  %8
 OpLine %14 7 13
 OpStore %6 %12

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -7,7 +7,7 @@ OpLine %9 7 35
 %10 = OpLoad  %11  %4
 OpLine %9 7 13
 OpStore %8 %10
-OpLine %12 894 8
+OpLine %12 890 8
 OpCopyMemory %6 %8
 OpLine %9 8 1
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -7,7 +7,7 @@ OpLine %9 7 37
 %10 = OpLoad  %11  %4
 OpLine %12 1013 17
 OpStore %8 %10
-OpLine %13 894 8
+OpLine %13 890 8
 OpCopyMemory %6 %8
 OpLine %9 8 1
 OpReturn

--- a/tests/ui/dis/unroll_loops.stderr
+++ b/tests/ui/dis/unroll_loops.stderr
@@ -15,7 +15,7 @@ OpBranchConditional %17 %22 %21
 %22 = OpLabel
 OpLine %7 9 10
 %23 = OpSLessThan  %18  %10 %24
-OpLine %7 9 4
+OpLine %7 9 10
 OpSelectionMerge %25 None
 OpBranchConditional %23 %26 %27
 %26 = OpLabel

--- a/tests/ui/spirv-attr/invalid-target.rs
+++ b/tests/ui/spirv-attr/invalid-target.rs
@@ -17,10 +17,10 @@
 // * builtin: `position`
 
 // NOTE(eddyb) accounting for the number of errors this test actually produces:
-// * 461 "attribute is only valid on" errors (see `invalid-target.stderr`)
-// * 40 `#[spirv(...)]` (excluding `macro_rules!`, which doesn't get the above error)
-// * at most 12 attributes per `#[spirv(...)]`, so an upper bound of `40*12 = 480`
-// * the difference between 480 and 461 is 19, i.e. valid attributes, made up of:
+// * 473 errors, all "attribute is only valid on" (see `invalid-target.stderr`)
+// * 41 uses of `#[spirv(...)]` in this test
+// * at most 12 attributes per `#[spirv(...)]`, so an upper bound of `41*12 = 492`
+// * the difference between 492 and 473 is 19, i.e. valid attributes, made up of:
 //   * 4 on `_Struct`
 //   * 8 on functions, i.e. 2 on each of:
 //     * `_inherent_method`

--- a/tests/ui/spirv-attr/invalid-target.stderr
+++ b/tests/ui/spirv-attr/invalid-target.stderr
@@ -1,218 +1,74 @@
-error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:9
-    |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |         ^^^^^^^
+error: attribute is only valid on a struct, not on a macro def
+  --> $DIR/invalid-target.rs:34:5
+   |
+34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+   |     ^^^^^^^
 
-error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:18
-    |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                  ^^^^^
+error: attribute is only valid on a struct, not on a macro def
+  --> $DIR/invalid-target.rs:34:14
+   |
+34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+   |              ^^^^^
 
-error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:25
-    |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                         ^^^^^^^^^^^^^
+error: attribute is only valid on a struct, not on a macro def
+  --> $DIR/invalid-target.rs:34:21
+   |
+34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+   |                     ^^^^^^^^^^^^^
 
-error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:40
-    |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                                        ^^^^^^^^^^^^^^^^^^
+error: attribute is only valid on a struct, not on a macro def
+  --> $DIR/invalid-target.rs:34:36
+   |
+34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+   |                                    ^^^^^^^^^^^^^^^^^^
 
-error: attribute is only valid on a function, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:339:9
-    |
-339 |         vertex, // fn-only
-    |         ^^^^^^
+error: attribute is only valid on a function, not on a macro def
+  --> $DIR/invalid-target.rs:35:5
+   |
+35 |     vertex, // fn-only
+   |     ^^^^^^
 
-error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:9
-    |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |         ^^^^^^^
+error: attribute is only valid on a function parameter, not on a macro def
+  --> $DIR/invalid-target.rs:36:5
+   |
+36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |     ^^^^^^^
 
-error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:18
-    |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                  ^^^^^^^^
+error: attribute is only valid on a function parameter, not on a macro def
+  --> $DIR/invalid-target.rs:36:14
+   |
+36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |              ^^^^^^^^
 
-error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:28
-    |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                            ^^^^^^^^^^^^^^^^^^
+error: attribute is only valid on a function parameter, not on a macro def
+  --> $DIR/invalid-target.rs:36:24
+   |
+36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                        ^^^^^^^^^^^^^^^^^^
 
-error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:48
-    |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                ^^^^^^^^^^^
+error: attribute is only valid on a function parameter, not on a macro def
+  --> $DIR/invalid-target.rs:36:44
+   |
+36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                            ^^^^^^^^^^^
 
-error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:61
-    |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                             ^^^^
+error: attribute is only valid on a function parameter, not on a macro def
+  --> $DIR/invalid-target.rs:36:57
+   |
+36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                         ^^^^
 
-error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:67
-    |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                                   ^^^^^^^^^
+error: attribute is only valid on a function parameter, not on a macro def
+  --> $DIR/invalid-target.rs:36:63
+   |
+36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+   |                                                               ^^^^^^^^^
 
-error: attribute is only valid on a function or closure, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:341:9
-    |
-341 |         unroll_loops, // fn/closure-only
-    |         ^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:9
-    |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |         ^^^^^^^
-
-error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:18
-    |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                  ^^^^^
-
-error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:25
-    |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                         ^^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:40
-    |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                                        ^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function, not on a type parameter
-   --> $DIR/invalid-target.rs:345:9
-    |
-345 |         vertex, // fn-only
-    |         ^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:9
-    |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |         ^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:18
-    |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                  ^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:28
-    |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                            ^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:48
-    |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                ^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:61
-    |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                             ^^^^
-
-error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:67
-    |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                                   ^^^^^^^^^
-
-error: attribute is only valid on a function or closure, not on a type parameter
-   --> $DIR/invalid-target.rs:347:9
-    |
-347 |         unroll_loops, // fn/closure-only
-    |         ^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:9
-    |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |         ^^^^^^^
-
-error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:18
-    |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                  ^^^^^
-
-error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:25
-    |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                         ^^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:40
-    |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
-    |                                        ^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function, not on a const parameter
-   --> $DIR/invalid-target.rs:351:9
-    |
-351 |         vertex, // fn-only
-    |         ^^^^^^
-
-error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:9
-    |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |         ^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:18
-    |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                  ^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:28
-    |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                            ^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:48
-    |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                ^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:61
-    |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                             ^^^^
-
-error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:67
-    |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                                   ^^^^^^^^^
-
-error: attribute is only valid on a function or closure, not on a const parameter
-   --> $DIR/invalid-target.rs:353:9
-    |
-353 |         unroll_loops, // fn/closure-only
-    |         ^^^^^^^^^^^^
+error: attribute is only valid on a function or closure, not on a macro def
+  --> $DIR/invalid-target.rs:37:5
+   |
+37 |     unroll_loops, // fn/closure-only
+   |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
   --> $DIR/invalid-target.rs:44:5
@@ -1936,6 +1792,222 @@ error: attribute is only valid on a function or closure, not on a match arm
 330 |             unroll_loops, // fn/closure-only
     |             ^^^^^^^^^^^^
 
+error: attribute is only valid on a struct, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:338:9
+    |
+338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |         ^^^^^^^
+
+error: attribute is only valid on a struct, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:338:18
+    |
+338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                  ^^^^^
+
+error: attribute is only valid on a struct, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:338:25
+    |
+338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                         ^^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:338:40
+    |
+338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                                        ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:339:9
+    |
+339 |         vertex, // fn-only
+    |         ^^^^^^
+
+error: attribute is only valid on a function parameter, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:340:9
+    |
+340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |         ^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:340:18
+    |
+340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                  ^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:340:28
+    |
+340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                            ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:340:48
+    |
+340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                ^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:340:61
+    |
+340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:340:67
+    |
+340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
+
+error: attribute is only valid on a function or closure, not on a lifetime parameter
+   --> $DIR/invalid-target.rs:341:9
+    |
+341 |         unroll_loops, // fn/closure-only
+    |         ^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a type parameter
+   --> $DIR/invalid-target.rs:344:9
+    |
+344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |         ^^^^^^^
+
+error: attribute is only valid on a struct, not on a type parameter
+   --> $DIR/invalid-target.rs:344:18
+    |
+344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                  ^^^^^
+
+error: attribute is only valid on a struct, not on a type parameter
+   --> $DIR/invalid-target.rs:344:25
+    |
+344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                         ^^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a type parameter
+   --> $DIR/invalid-target.rs:344:40
+    |
+344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                                        ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function, not on a type parameter
+   --> $DIR/invalid-target.rs:345:9
+    |
+345 |         vertex, // fn-only
+    |         ^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type parameter
+   --> $DIR/invalid-target.rs:346:9
+    |
+346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |         ^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type parameter
+   --> $DIR/invalid-target.rs:346:18
+    |
+346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                  ^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type parameter
+   --> $DIR/invalid-target.rs:346:28
+    |
+346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                            ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type parameter
+   --> $DIR/invalid-target.rs:346:48
+    |
+346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                ^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type parameter
+   --> $DIR/invalid-target.rs:346:61
+    |
+346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a type parameter
+   --> $DIR/invalid-target.rs:346:67
+    |
+346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
+
+error: attribute is only valid on a function or closure, not on a type parameter
+   --> $DIR/invalid-target.rs:347:9
+    |
+347 |         unroll_loops, // fn/closure-only
+    |         ^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a const parameter
+   --> $DIR/invalid-target.rs:350:9
+    |
+350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |         ^^^^^^^
+
+error: attribute is only valid on a struct, not on a const parameter
+   --> $DIR/invalid-target.rs:350:18
+    |
+350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                  ^^^^^
+
+error: attribute is only valid on a struct, not on a const parameter
+   --> $DIR/invalid-target.rs:350:25
+    |
+350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                         ^^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a const parameter
+   --> $DIR/invalid-target.rs:350:40
+    |
+350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+    |                                        ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function, not on a const parameter
+   --> $DIR/invalid-target.rs:351:9
+    |
+351 |         vertex, // fn-only
+    |         ^^^^^^
+
+error: attribute is only valid on a function parameter, not on a const parameter
+   --> $DIR/invalid-target.rs:352:9
+    |
+352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |         ^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a const parameter
+   --> $DIR/invalid-target.rs:352:18
+    |
+352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                  ^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a const parameter
+   --> $DIR/invalid-target.rs:352:28
+    |
+352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                            ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a const parameter
+   --> $DIR/invalid-target.rs:352:48
+    |
+352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                ^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a const parameter
+   --> $DIR/invalid-target.rs:352:61
+    |
+352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                             ^^^^
+
+error: attribute is only valid on a function parameter, not on a const parameter
+   --> $DIR/invalid-target.rs:352:67
+    |
+352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                                   ^^^^^^^^^
+
+error: attribute is only valid on a function or closure, not on a const parameter
+   --> $DIR/invalid-target.rs:353:9
+    |
+353 |         unroll_loops, // fn/closure-only
+    |         ^^^^^^^^^^^^
+
 error: attribute is only valid on a struct, not on a associated type
    --> $DIR/invalid-target.rs:228:9
     |
@@ -2764,16 +2836,5 @@ error: attribute is only valid on a function or closure, not on a foreign functi
 94 |         unroll_loops, // fn/closure-only
    |         ^^^^^^^^^^^^
 
-error: #[spirv(..)] cannot be applied to a macro
-  --> $DIR/invalid-target.rs:33:1
-   |
-33 | / #[spirv(
-34 | |     sampler, block, sampled_image, generic_image_type, // struct-only
-35 | |     vertex, // fn-only
-36 | |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-37 | |     unroll_loops, // fn/closure-only
-38 | | )]
-   | |__^
-
-error: aborting due to 462 previous errors
+error: aborting due to 473 previous errors
 


### PR DESCRIPTION
This gets us to a nightly that includes several PRs I want to take advantage of (to end with our call ABI struggles, once and for all), but I don't want to bundle that with the rustup.

Small note about the `spirv-attr/invalid-target` test changes, they were a result of:
* https://github.com/rust-lang/rust/pull/88019

We now get to handle macros just like every other item, so all errors are uniform and accounted for.