### PR TITLE
Support `glam` 0.18 in `spirv-std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
 dependencies = [
  "num-traits",
 ]

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = "1.2.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
 spirv-types = { path = "./shared", version = "0.4.0-alpha.12" }
 spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.12" }
-glam = { version = "0.17.0", default-features = false, features = ["libm"], optional = true }
+glam = { version = ">=0.17, <=0.18", default-features = false, features = ["libm"], optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
Testing to support a range of glam versions to make upgrades easier as our dependency on glam is pretty basic, just need the main types to exist to extend them.

This is similar to how we do in a related crate we use: https://github.com/h3r2tic/dolly/pull/3

If we in the future will have specific requirements on different glam versions, we can use the winit-approach of having a feature toggle per major glam version we want to support (such as `glam017`, `glam018`). But that is extra work and don't think we'll need it