### PR TITLE
Fix tests

### DIFF
--- a/tests/ui/dis/entry-pass-mode-cast-array.stderr
+++ b/tests/ui/dis/entry-pass-mode-cast-array.stderr
@@ -1,21 +1,13 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-%5 = OpVariable  %6  Function
-%7 = OpVariable  %6  Function
-OpLine %8 13 12
-%9 = OpLoad  %10  %11
-OpLine %8 13 0
-OpStore %5 %9
-OpLine %8 14 4
-%12 = OpInBoundsAccessChain  %13  %5 %14
-%15 = OpInBoundsAccessChain  %13  %5 %14
-%16 = OpLoad  %17  %15
-%18 = OpFAdd  %17  %16 %19
-OpStore %12 %18
-OpLine %8 15 17
-OpCopyMemory %7 %5
-OpLine %8 15 4
-OpCopyMemory %20 %7
-OpLine %8 16 1
+OpLine %5 13 12
+%6 = OpLoad  %7  %8
+OpLine %5 14 4
+%9 = OpCompositeExtract  %10  %6 0
+%11 = OpFAdd  %10  %9 %12
+%13 = OpCompositeInsert  %7  %11 %6 0
+OpLine %5 15 4
+OpStore %14 %13
+OpLine %5 16 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/issue-731.stderr
+++ b/tests/ui/dis/issue-731.stderr
@@ -1,21 +1,13 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-%5 = OpVariable  %6  Function
-%7 = OpVariable  %6  Function
-OpLine %8 11 12
-%9 = OpLoad  %10  %11
-OpLine %8 11 0
-OpStore %5 %9
-OpLine %8 12 4
-%12 = OpInBoundsAccessChain  %13  %5 %14
-%15 = OpInBoundsAccessChain  %13  %5 %14
-%16 = OpLoad  %17  %15
-%18 = OpFAdd  %17  %16 %19
-OpStore %12 %18
-OpLine %8 13 17
-OpCopyMemory %7 %5
-OpLine %8 13 4
-OpCopyMemory %20 %7
-OpLine %8 14 1
+OpLine %5 11 12
+%6 = OpLoad  %7  %8
+OpLine %5 12 4
+%9 = OpCompositeExtract  %10  %6 0
+%11 = OpFAdd  %10  %9 %12
+%13 = OpCompositeInsert  %7  %11 %6 0
+OpLine %5 13 4
+OpStore %14 %13
+OpLine %5 14 1
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
We don't retest PRs after a different PR has been merged to main, so tests that pass in a PR might not actually pass in main, due to other subsequent PRs mucking it up. That happened here - https://github.com/EmbarkStudios/rust-gpu/pull/766 added some disassemble tests, but then https://github.com/EmbarkStudios/rust-gpu/pull/772 was tested on a base commit older than 766, and it changed the output of 766's tests, and so only once both were in main did tests start failing. So, quick fix 'em up here, seems like an expected/normal change.