### PR TITLE
Add tests for every builtin

### DIFF
--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -57,22 +57,22 @@ const BUILTINS: &[(&str, BuiltIn)] = {
         ("frag_depth", FragDepth),
         ("helper_invocation", HelperInvocation),
         ("num_workgroups", NumWorkgroups),
-        ("workgroup_size", WorkgroupSize),
+        // ("workgroup_size", WorkgroupSize), -- constant
         ("workgroup_id", WorkgroupId),
         ("local_invocation_id", LocalInvocationId),
         ("global_invocation_id", GlobalInvocationId),
         ("local_invocation_index", LocalInvocationIndex),
-        ("work_dim", WorkDim),
-        ("global_size", GlobalSize),
-        ("enqueued_workgroup_size", EnqueuedWorkgroupSize),
-        ("global_offset", GlobalOffset),
-        ("global_linear_id", GlobalLinearId),
+        // ("work_dim", WorkDim), -- Kernel-only
+        // ("global_size", GlobalSize), -- Kernel-only
+        // ("enqueued_workgroup_size", EnqueuedWorkgroupSize), -- Kernel-only
+        // ("global_offset", GlobalOffset), -- Kernel-only
+        // ("global_linear_id", GlobalLinearId), -- Kernel-only
         ("subgroup_size", SubgroupSize),
-        ("subgroup_max_size", SubgroupMaxSize),
+        // ("subgroup_max_size", SubgroupMaxSize), -- Kernel-only
         ("num_subgroups", NumSubgroups),
-        ("num_enqueued_subgroups", NumEnqueuedSubgroups),
+        // ("num_enqueued_subgroups", NumEnqueuedSubgroups), -- Kernel-only
         ("subgroup_id", SubgroupId),
-        ("subgroup_local_invocation_id", SubgroupLocalInvocationId),
+        // ("subgroup_local_invocation_id", SubgroupLocalInvocationId), -- Kernel-only
         ("vertex_index", VertexIndex),
         ("instance_index", InstanceIndex),
         ("subgroup_eq_mask", SubgroupEqMask),
@@ -107,7 +107,7 @@ const BUILTINS: &[(&str, BuiltIn)] = {
         ("primitive_indices_nv", PrimitiveIndicesNV),
         ("clip_distance_per_view_nv", ClipDistancePerViewNV),
         ("cull_distance_per_view_nv", CullDistancePerViewNV),
-        ("layer_per_viewNV", LayerPerViewNV),
+        ("layer_per_view_nv", LayerPerViewNV),
         ("mesh_view_count_nv", MeshViewCountNV),
         ("mesh_view_indices_nv", MeshViewIndicesNV),
         ("bary_coord_nv", BaryCoordNV),

--- a/crates/rustc_codegen_spirv/src/target.rs
+++ b/crates/rustc_codegen_spirv/src/target.rs
@@ -56,7 +56,7 @@ impl SpirvTarget {
             TargetEnv::OpenGL_4_1 => (1, 0),
             TargetEnv::OpenGL_4_2 => (1, 0),
             TargetEnv::OpenGL_4_3 => (1, 0),
-            TargetEnv::OpenGL_4_5 => (1, 3),
+            TargetEnv::OpenGL_4_5 => (1, 0),
 
             TargetEnv::OpenCL_1_2 => (1, 0),
             TargetEnv::OpenCL_2_0 => (1, 0),

--- a/tests/ui/spirv-attr/all-builtins.rs.ignored
+++ b/tests/ui/spirv-attr/all-builtins.rs.ignored
@@ -1,0 +1,128 @@
+// This test currently fails because the only-vulkan1.1 compiletests flag is ignored. So, running
+// compiletests on e.g. --target-env opengl4.5 will attempt to execute this test and fail.
+// build-pass
+// only-vulkan1.1
+// compile-flags: -Ctarget-feature=+DeviceGroup,+DrawParameters,+FragmentBarycentricNV,+FragmentDensityEXT,+FragmentFullyCoveredEXT,+Geometry,+GroupNonUniform,+GroupNonUniformBallot,+MeshShadingNV,+MultiView,+MultiViewport,+RayTracingKHR,+SampleRateShading,+ShaderSMBuiltinsNV,+ShaderStereoViewNV,+StencilExportEXT,+Tessellation,+ext:SPV_AMD_shader_explicit_vertex_parameter,+ext:SPV_EXT_fragment_fully_covered,+ext:SPV_EXT_fragment_invocation_density,+ext:SPV_EXT_shader_stencil_export,+ext:SPV_KHR_ray_tracing,+ext:SPV_NV_fragment_shader_barycentric,+ext:SPV_NV_mesh_shader,+ext:SPV_NV_shader_sm_builtins,+ext:SPV_NV_stereo_view_rendering
+
+use spirv_std::glam::*;
+
+#[derive(Clone, Copy)]
+#[spirv(matrix)]
+pub struct Matrix4x3 {
+    pub x: glam::Vec3,
+    pub y: glam::Vec3,
+    pub z: glam::Vec3,
+    pub w: glam::Vec3,
+}
+
+#[spirv(tessellation_control)]
+pub fn tessellation_control(
+    #[spirv(invocation_id)] invocation_id: u32,
+    #[spirv(patch_vertices)] patch_vertices: u32,
+    #[spirv(tess_level_inner)] tess_level_inner: &mut [f32; 2],
+    #[spirv(tess_level_outer)] tess_level_outer: &mut [f32; 4],
+) {
+}
+
+#[spirv(tessellation_evaluation)]
+pub fn tessellation_evaluation(#[spirv(tess_coord)] tess_coord: Vec3) {}
+
+#[spirv(compute(threads(1)))]
+pub fn compute(
+    #[spirv(global_invocation_id)] global_invocation_id: UVec3,
+    #[spirv(local_invocation_id)] local_invocation_id: UVec3,
+    #[spirv(num_subgroups)] num_subgroups: u32,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    #[spirv(subgroup_id)] subgroup_id: u32,
+    #[spirv(workgroup_id)] workgroup_id: UVec3,
+) {
+}
+
+#[spirv(vertex)]
+pub fn vertex(
+    #[spirv(SMIDNV)] smidnv: u32,
+    #[spirv(bary_coord_no_persp_amd)] bary_coord_no_persp_amd: u32,
+    #[spirv(bary_coord_no_persp_centroid_amd)] bary_coord_no_persp_centroid_amd: u32,
+    #[spirv(bary_coord_no_persp_nv)] bary_coord_no_persp_nv: u32,
+    #[spirv(bary_coord_no_persp_sample_amd)] bary_coord_no_persp_sample_amd: u32,
+    #[spirv(bary_coord_nv)] bary_coord_nv: u32,
+    #[spirv(bary_coord_pull_model_amd)] bary_coord_pull_model_amd: u32,
+    #[spirv(bary_coord_smooth_amd)] bary_coord_smooth_amd: u32,
+    #[spirv(bary_coord_smooth_centroid_amd)] bary_coord_smooth_centroid_amd: u32,
+    #[spirv(bary_coord_smooth_sample_amd)] bary_coord_smooth_sample_amd: u32,
+    #[spirv(base_instance)] base_instance: u32,
+    #[spirv(base_vertex)] base_vertex: u32,
+    #[spirv(clip_distance_per_view_nv)] clip_distance_per_view_nv: u32,
+    #[spirv(cull_distance_per_view_nv)] cull_distance_per_view_nv: u32,
+    #[spirv(device_index)] device_index: u32,
+    #[spirv(draw_index)] draw_index: u32,
+    #[spirv(frag_depth)] frag_depth: &mut f32,
+    #[spirv(frag_stencil_ref_ext)] frag_stencil_ref_ext: &mut u32,
+    #[spirv(instance_index)] instance_index: u32,
+    #[spirv(layer_per_view_nv)] layer_per_view_nv: u32,
+    #[spirv(local_invocation_index)] local_invocation_index: UVec3,
+    #[spirv(mesh_view_count_nv)] mesh_view_count_nv: u32,
+    #[spirv(mesh_view_indices_nv)] mesh_view_indices_nv: u32,
+    #[spirv(point_size)] point_size: &mut u32,
+    #[spirv(position)] position: &mut u32,
+    #[spirv(position_per_view_nv)] position_per_view_nv: u32,
+    #[spirv(primitive_count_nv)] primitive_count_nv: u32,
+    #[spirv(primitive_indices_nv)] primitive_indices_nv: u32,
+    #[spirv(secondary_position_nv)] secondary_position_nv: u32,
+    #[spirv(secondary_viewport_mask_nv)] secondary_viewport_mask_nv: u32,
+    #[spirv(sm_count_nv)] sm_count_nv: u32,
+    #[spirv(subgroup_eq_mask)] subgroup_eq_mask: UVec4,
+    #[spirv(subgroup_ge_mask)] subgroup_ge_mask: UVec4,
+    #[spirv(subgroup_gt_mask)] subgroup_gt_mask: UVec4,
+    #[spirv(subgroup_le_mask)] subgroup_le_mask: UVec4,
+    #[spirv(subgroup_lt_mask)] subgroup_lt_mask: UVec4,
+    #[spirv(subgroup_size)] subgroup_size: u32,
+    #[spirv(task_count_nv)] task_count_nv: u32,
+    #[spirv(vertex_index)] vertex_index: u32,
+    #[spirv(view_index)] view_index: u32,
+    #[spirv(viewport_mask_nv)] viewport_mask_nv: u32,
+    #[spirv(viewport_mask_per_view_nv)] viewport_mask_per_view_nv: u32,
+    #[spirv(warp_id_nv)] warp_id_nv: u32,
+    #[spirv(warps_per_sm_nv)] warps_per_sm_nv: u32,
+    // #[spirv(front_facing)] front_facing: bool, -- ICE
+    // #[spirv(fully_covered_ext)] fully_covered_ext: bool, -- ICE
+    // #[spirv(helper_invocation)] helper_invocation: bool, -- ICE
+    // #[spirv(vertex_id)] vertex_id: u32, -- not allowed with vulkan
+) {
+}
+
+#[spirv(fragment)]
+pub fn fragment(
+    #[spirv(clip_distance)] clip_distance: [f32; 1],
+    #[spirv(cull_distance)] cull_distance: [f32; 1],
+    #[spirv(frag_coord)] frag_coord: Vec4,
+    #[spirv(frag_invocation_count_ext)] frag_invocation_count_ext: u32,
+    #[spirv(frag_size_ext)] frag_size_ext: UVec2,
+    #[spirv(layer)] layer: u32,
+    #[spirv(point_coord)] point_coord: Vec2,
+    #[spirv(primitive_id)] primitive_id: u32,
+    #[spirv(sample_id)] sample_id: u32,
+    #[spirv(sample_mask)] sample_mask: [u32; 1],
+    #[spirv(sample_position)] sample_position: Vec2,
+    #[spirv(viewport_index)] viewport_index: u32,
+) {
+}
+#[spirv(closest_hit)]
+pub fn closest_hit(
+    #[spirv(hit_kind)] hit_kind: u32,
+    #[spirv(incoming_ray_flags)] incoming_ray_flags: u32,
+    #[spirv(instance_custom_index)] instance_custom_index: u32,
+    #[spirv(instance_id)] instance_id: u32,
+    #[spirv(launch_id)] launch_id: UVec3,
+    #[spirv(launch_size)] launch_size: UVec3,
+    #[spirv(object_ray_direction)] object_ray_direction: Vec3,
+    #[spirv(object_ray_origin)] object_ray_origin: Vec3,
+    #[spirv(object_to_world)] object_to_world: Matrix4x3,
+    #[spirv(ray_geometry_index)] ray_geometry_index: u32,
+    #[spirv(ray_tmax)] ray_tmax: f32,
+    #[spirv(ray_tmin)] ray_tmin: f32,
+    #[spirv(world_ray_direction)] world_ray_direction: Vec3,
+    #[spirv(world_ray_origin)] world_ray_origin: Vec3,
+    #[spirv(world_to_object)] world_to_object: Matrix4x3,
+) {
+}


### PR DESCRIPTION
In discord, it was pointed out that `#[spirv(workgroup_size)]` is broken - the decoration applies to a _constant_, not a _variable_, and it _specifies_ the workgroup size, it's not _provided with_ the workgroup size. (A subsequent discussion also showed that WorkgroupSize in SPIR-V is just plain broken with multi-entry-point shaders - but the LocalSize(Id) execution mode is a replacement for its behavior)

So, I decided to add a test for every builtin, to make sure nothing else is broken! turns out `bool` builtins are broken, I'll file a follow-up issue, and we had a fair amount of Kernel-only builtins which shouldn't be included.

Also, fixed a typo with `layer_per_view_nv`, and fixed `opengl4.5` targeting SPIR-V 1.3 - spirv-val complains when trying to build with env opengl4.5, it's required to be 1.0.

Unfortunately, the test can't actually be added to CI, because compiletests is broken. Either @eddyb or I will hopefully be filing a fix soon. (both `// ignore-vulkan1.1` and `// only-vulkan1.1` are broken)