### PR TITLE
compiletests: unlock `// {only,ignore}-*` usage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,9 +347,8 @@ dependencies = [
 
 [[package]]
 name = "compiletest_rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64698e5e2435db061a85e6320af12c30c5fd88eb84b35d2c1e03ce4f143255ca"
+version = "0.7.1"
+source = "git+https://github.com/Manishearth/compiletest-rs.git?rev=4ab843a1dc6ed9a82657d86d22397c6c5bb95b01#4ab843a1dc6ed9a82657d86d22397c6c5bb95b01"
 dependencies = [
  "diff",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ codegen-units = 256
 [patch.crates-io]
 spirv-std = { path = "./crates/spirv-std" }
 spirv-std-macros = { path = "./crates/spirv-std/macros" }
+# HACK(eddyb) needed to include this PR (until it's part of a release):
+# * Manishearth/compiletest-rs#249 (for `// only-*` support)
+compiletest_rs = { git = "https://github.com/Manishearth/compiletest-rs.git", rev = "4ab843a1dc6ed9a82657d86d22397c6c5bb95b01" }

--- a/tests/ui/spirv-attr/all-builtins.rs
+++ b/tests/ui/spirv-attr/all-builtins.rs
@@ -1,5 +1,3 @@
-// This test currently fails because the only-vulkan1.1 compiletests flag is ignored. So, running
-// compiletests on e.g. --target-env opengl4.5 will attempt to execute this test and fail.
 // build-pass
 // only-vulkan1.1
 // compile-flags: -Ctarget-feature=+DeviceGroup,+DrawParameters,+FragmentBarycentricNV,+FragmentDensityEXT,+FragmentFullyCoveredEXT,+Geometry,+GroupNonUniform,+GroupNonUniformBallot,+MeshShadingNV,+MultiView,+MultiViewport,+RayTracingKHR,+SampleRateShading,+ShaderSMBuiltinsNV,+ShaderStereoViewNV,+StencilExportEXT,+Tessellation,+ext:SPV_AMD_shader_explicit_vertex_parameter,+ext:SPV_EXT_fragment_fully_covered,+ext:SPV_EXT_fragment_invocation_density,+ext:SPV_EXT_shader_stencil_export,+ext:SPV_KHR_ray_tracing,+ext:SPV_NV_fragment_shader_barycentric,+ext:SPV_NV_mesh_shader,+ext:SPV_NV_shader_sm_builtins,+ext:SPV_NV_stereo_view_rendering


### PR DESCRIPTION
~~*Opening as draft because https://github.com/Manishearth/compiletest-rs/pull/249 isn't merged yet.*~~

This enables the test from #789 to correctly run only on `vulkan1.1` targets, and be ignored on other targets (tested both with the default and `--target-env opengl4.5`).

We should also be able to use `// ignore-*` now, without `compiletest-rs` panicking.