### PR TITLE
Gather all interface `OpVariable`s into `OpEntryPoint`s.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: compiletest
         if: ${{ matrix.target != 'aarch64-linux-android' }}
-        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1,spv1.3
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1,vulkan1.2,spv1.3
 
       # Examples
       - name: cargo check examples

--- a/crates/rustc_codegen_spirv/src/linker/entry_interface.rs
+++ b/crates/rustc_codegen_spirv/src/linker/entry_interface.rs
@@ -1,0 +1,104 @@
+//! Passes that pertain to `OpEntryPoint`'s "interface variables".
+
+use crate::linker::ipo::CallGraph;
+use indexmap::{IndexMap, IndexSet};
+use rspirv::dr::{Module, Operand};
+use rspirv::spirv::{Op, StorageClass, Word};
+use std::mem;
+
+type Id = Word;
+
+/// Update `OpEntryPoint`s to contain all of the `OpVariable`s they reference,
+/// whether directly or through some function in their call graph.
+///
+/// This is needed for (arguably-not-interface) `Private` in SPIR-V >= 1.4,
+/// but also any interface variables declared "out of band" (e.g. via `asm!`).
+pub fn gather_all_interface_vars_from_uses(module: &mut Module) {
+    // Start by mapping out which global (i.e. `OpVariable` or constants) IDs
+    // can be used to access any interface-relevant `OpVariable`s
+    // (where "interface-relevant" depends on the version, see comments below).
+    let mut used_vars_per_global_id: IndexMap<Id, IndexSet<Id>> = IndexMap::new();
+    let version = module.header.as_ref().unwrap().version();
+    for inst in &module.types_global_values {
+        let mut used_vars = IndexSet::new();
+
+        // Base case: the global itself is an interface-relevant `OpVariable`.
+        let interface_relevant_var = inst.class.opcode == Op::Variable && {
+            if version > (1, 3) {
+                // SPIR-V >= v1.4 includes all OpVariables in the interface.
+                true
+            } else {
+                let storage_class = inst.operands[0].unwrap_storage_class();
+                // SPIR-V <= v1.3 only includes Input and Output in the interface.
+                storage_class == StorageClass::Input || storage_class == StorageClass::Output
+            }
+        };
+        if interface_relevant_var {
+            used_vars.insert(inst.result_id.unwrap());
+        }
+
+        // Nested constant refs (e.g. `&&&0`) can create chains of `OpVariable`s
+        // where only the outer-most `OpVariable` may be accessed directly,
+        // but the interface variables need to include all the nesting levels.
+        used_vars.extend(
+            inst.operands
+                .iter()
+                .filter_map(|operand| operand.id_ref_any())
+                .filter_map(|id| used_vars_per_global_id.get(&id))
+                .flatten(),
+        );
+
+        if !used_vars.is_empty() {
+            used_vars_per_global_id.insert(inst.result_id.unwrap(), used_vars);
+        }
+    }
+
+    // Initial uses come from functions directly referencing global instructions.
+    let mut used_vars_per_fn_idx: Vec<IndexSet<Id>> = module
+        .functions
+        .iter()
+        .map(|func| {
+            func.all_inst_iter()
+                .flat_map(|inst| &inst.operands)
+                .filter_map(|operand| operand.id_ref_any())
+                .filter_map(|id| used_vars_per_global_id.get(&id))
+                .flatten()
+                .copied()
+                .collect()
+        })
+        .collect();
+
+    // Uses can then be propagated through the call graph, from callee to caller.
+    let call_graph = CallGraph::collect(module);
+    for caller_idx in call_graph.post_order() {
+        let mut used_vars = mem::take(&mut used_vars_per_fn_idx[caller_idx]);
+        for &callee_idx in &call_graph.callees[caller_idx] {
+            used_vars.extend(&used_vars_per_fn_idx[callee_idx]);
+        }
+        used_vars_per_fn_idx[caller_idx] = used_vars;
+    }
+
+    // All transitive uses are available, add them to `OpEntryPoint`s.
+    for (i, entry) in module.entry_points.iter_mut().enumerate() {
+        assert_eq!(entry.class.opcode, Op::EntryPoint);
+        let &entry_func_idx = call_graph.entry_points.get_index(i).unwrap();
+        assert_eq!(
+            module.functions[entry_func_idx].def_id().unwrap(),
+            entry.operands[1].unwrap_id_ref()
+        );
+
+        // NOTE(eddyb) it might be better to remove any unused vars, or warn
+        // the user about their presence, but for now this keeps them around.
+        let mut interface_vars: IndexSet<Id> = entry.operands[3..]
+            .iter()
+            .map(|operand| operand.unwrap_id_ref())
+            .collect();
+
+        interface_vars.extend(&used_vars_per_fn_idx[entry_func_idx]);
+
+        entry.operands.truncate(3);
+        entry
+            .operands
+            .extend(interface_vars.iter().map(|&id| Operand::IdRef(id)));
+    }
+}

--- a/crates/rustc_codegen_spirv/src/linker/ipo.rs
+++ b/crates/rustc_codegen_spirv/src/linker/ipo.rs
@@ -14,7 +14,7 @@ pub struct CallGraph {
     pub entry_points: IndexSet<FuncIdx>,
 
     /// `callees[i].contains(j)` implies `functions[i]` calls `functions[j]`.
-    callees: Vec<IndexSet<FuncIdx>>,
+    pub callees: Vec<IndexSet<FuncIdx>>,
 }
 
 impl CallGraph {

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -4,6 +4,7 @@ mod test;
 mod dce;
 mod destructure_composites;
 mod duplicates;
+mod entry_interface;
 mod import_export_link;
 mod inline;
 mod ipo;
@@ -268,6 +269,11 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
             peephole_opts::vector_ops(output.header.as_mut().unwrap(), &types, func);
             peephole_opts::bool_fusion(output.header.as_mut().unwrap(), &types, func);
         }
+    }
+
+    {
+        let _timer = sess.timer("link_gather_all_interface_vars_from_uses");
+        entry_interface::gather_all_interface_vars_from_uses(&mut output);
     }
 
     if opts.spirv_metadata == SpirvMetadata::NameVariables {

--- a/tests/ui/arch/ray_query_initialize_khr.rs
+++ b/tests/ui/arch/ray_query_initialize_khr.rs
@@ -1,5 +1,5 @@
 // build-pass
-// compile-flags: -Ctarget-feature=+RayQueryKHR,+ext:SPV_KHR_ray_query
+// compile-flags: -Ctarget-feature=+RayTracingKHR,+RayQueryKHR,+ext:SPV_KHR_ray_tracing,+ext:SPV_KHR_ray_query
 
 use glam::Vec3;
 use spirv_std::ray_tracing::{AccelerationStructure, RayFlags, RayQuery};

--- a/tests/ui/dis/asm_op_decorate.rs
+++ b/tests/ui/dis/asm_op_decorate.rs
@@ -5,6 +5,11 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// FIXME(eddyb) this should use revisions to track both the `vulkan1.2` output
+// and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
+// are not supported in `compiletest-rs`.
+// ignore-vulkan1.2
+
 use spirv_std as _;
 
 fn add_decorate() {

--- a/tests/ui/image/sample_depth_reference/sample_lod.rs
+++ b/tests/ui/image/sample_depth_reference/sample_lod.rs
@@ -8,12 +8,12 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled),
     #[spirv(descriptor_set = 1, binding = 1)] image_array: &Image!(2D, type=f32, arrayed, sampled),
     #[spirv(descriptor_set = 2, binding = 2)] sampler: &Sampler,
-    #[spirv(descriptor_set = 3, binding = 3)] cubemap: &Image!(3D, type=f32),
+    #[spirv(descriptor_set = 3, binding = 3)] cubemap: &Image!(3D, type=f32, sampled),
     output: &mut f32,
 ) {
     let v2 = glam::Vec2::new(0.0, 1.0);
     let v3 = glam::Vec3A::new(0.0, 0.0, 1.0);
     *output = image.sample_depth_reference_by_lod(*sampler, v2, 1.0, 0.0);
     *output += image_array.sample_depth_reference_by_lod(*sampler, v3, 1.0, 0.0);
-    *output += image_array.sample_depth_reference_by_lod(*sampler, v3, 1.0, 0.0);
+    *output += cubemap.sample_depth_reference_by_lod(*sampler, v3, 1.0, 0.0);
 }


### PR DESCRIPTION
~~*Opened as draft because the test changes required basing this on #792.*~~

Fixes #748, but the goal became more to get `--target-env vulkan1.2` testing going, and the last commit even turns it on in CI (assuming we want that).