### PR TITLE
Improve the calculation of location sizes for arrays and structs (revives #513)

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -535,7 +535,14 @@ impl<'tcx> CodegenCx<'tcx> {
                 Decoration::Location,
                 std::iter::once(Operand::LiteralInt32(*location)),
             );
-            *location += 1;
+            // Arrays take up multiple locations
+            *location += if let SpirvType::Array { count, .. } = self.lookup_type(value_spirv_type) {
+                self.builder
+                    .lookup_const_u64(count)
+                    .expect("Array type has invalid count value") as u32
+            } else {
+                1
+            }
         }
 
         // Emit the `OpVariable` with its *Result* ID set to `var`.

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -557,7 +557,7 @@ impl<'tcx> CodegenCx<'tcx> {
 
     fn location_size_of_type(&self, ty: Word) -> u32 {
         match self.lookup_type(ty) {
-            // Arrays take up multiple locations.git 
+            // Arrays take up multiple locations.
             SpirvType::Array { count, .. } => {
                 self.builder
                     .lookup_const_u64(count)
@@ -577,7 +577,7 @@ impl<'tcx> CodegenCx<'tcx> {
             SpirvType::Vector { count: 2, .. } => 1,
             // 3 or 4 component vectors take up 2 locations if they have a 64-bit scalar type.
             SpirvType::Vector { element, .. } => match self.lookup_type(element) {
-                SpirvType::Float(64) | Spirv::Integer(64, _) => 2,
+                SpirvType::Float(64) | SpirvType::Integer(64, _) => 2,
                 _ => 1,
             },
             _ => 1,

--- a/tests/ui/dis/array_location_calculation.rs
+++ b/tests/ui/dis/array_location_calculation.rs
@@ -1,0 +1,7 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-fn=add_two_ints::add_two_ints
+
+use spirv_std as _;
+
+#[spirv(fragment)]
+pub fn array_locations(one: [f32; 7], two: [f32; 3], three: f32) {}

--- a/tests/ui/dis/array_location_calculation.rs
+++ b/tests/ui/dis/array_location_calculation.rs
@@ -1,7 +1,7 @@
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals
 
-use spirv_std as _;
+use spirv_std::{self as _, glam::{Mat3, DVec3, IVec4}};
 
 #[spirv(fragment)]
-pub fn main(one: [f32; 7], two: [f32; 3], three: f32) {}
+pub fn main(one: [f32; 7], two: [f32; 3], three: Mat3, four: DVec3, five: IVec4, six: f32, seven: u32) {}

--- a/tests/ui/dis/array_location_calculation.rs
+++ b/tests/ui/dis/array_location_calculation.rs
@@ -1,7 +1,7 @@
 // build-pass
-// compile-flags: -C llvm-args=--disassemble-fn=add_two_ints::add_two_ints
+// compile-flags: -C llvm-args=--disassemble-globals
 
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn array_locations(one: [f32; 7], two: [f32; 3], three: f32) {}
+pub fn main(one: [f32; 7], two: [f32; 3], three: f32) {}

--- a/tests/ui/dis/array_location_calculation.stderr
+++ b/tests/ui/dis/array_location_calculation.stderr
@@ -1,0 +1,78 @@
+thread 'rustc' panicked at 'no function with the name `add_two_ints::add_two_ints` found in:
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown
+; Bound: 28
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_shader_clock"
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint Fragment %1 "array_locations" %2 %3 %4
+OpExecutionMode %1 OriginUpperLeft
+%5 = OpString "C:/Users/Ashley/Desktop/rust-gpu/tests/ui/dis/array_location_calculation.rs"
+OpName %6 "array_location_calculation::array_locations"
+OpName %2 "one"
+OpName %3 "two"
+OpName %4 "three"
+OpDecorate %7 ArrayStride 4
+OpDecorate %8 ArrayStride 4
+OpDecorate %2 Location 0
+OpDecorate %3 Location 7
+OpDecorate %4 Location 10
+%9 = OpTypeVoid
+%10 = OpTypeFloat 32
+%11 = OpTypeInt 32 0
+%12 = OpConstant  %11  7
+%7 = OpTypeArray %10 %12
+%13 = OpConstant  %11  3
+%8 = OpTypeArray %10 %13
+%14 = OpTypeFunction %9 %7 %8 %10
+%15 = OpTypeFunction %9
+%16 = OpTypePointer Input %7
+%2 = OpVariable  %16  Input
+%17 = OpTypePointer Input %8
+%3 = OpVariable  %17  Input
+%18 = OpTypePointer Input %10
+%4 = OpVariable  %18  Input
+%6 = OpFunction  %9  None %14
+%19 = OpFunctionParameter  %7
+%20 = OpFunctionParameter  %8
+%21 = OpFunctionParameter  %10
+%22 = OpLabel
+OpLine %5 7 67
+OpReturn
+OpFunctionEnd
+%1 = OpFunction  %9  None %15
+%23 = OpLabel
+OpLine %5 7 23
+%24 = OpLoad  %7  %2
+OpLine %5 7 38
+%25 = OpLoad  %8  %3
+OpLine %5 7 53
+%26 = OpLoad  %10  %4
+OpLine %5 7 0
+%27 = OpFunctionCall  %9  %6 %24 %25 %26
+OpReturn
+OpFunctionEnd
+', crates/rustc_codegen_spirv/src/codegen_cx/mod.rs:378:21
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: internal compiler error: unexpected panic
+
+note: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/EmbarkStudios/rust-gpu/issues/new
+
+note: rustc 1.58.0-nightly (29b124802 2021-10-25) running on x86_64-pc-windows-msvc
+
+note: compiler flags: -Z codegen-backend=C:/Users/Ashley/Desktop/rust-gpu/target/release/deps/rustc_codegen_spirv.dll -Z symbol-mangling-version=v0 -Z unstable-options -Z crate-attr=no_std -Z crate-attr=feature(register_attr,asm) -Z crate-attr=register_attr(spirv) -C prefer-dynamic -C overflow-checks=off -C debug-assertions=off -C debuginfo=2 -C embed-bitcode=no -C target-feature=+Int8,+Int16,+Int64,+Float64,+ShaderClockKHR,+ext:SPV_KHR_shader_clock -C llvm-args=--disassemble-fn=add_two_ints::add_two_ints --crate-type dylib
+
+query stack during panic:
+end of query stack
+note: `rust-gpu` version 0.4.0-alpha.12
+

--- a/tests/ui/dis/array_location_calculation.stderr
+++ b/tests/ui/dis/array_location_calculation.stderr
@@ -1,37 +1,84 @@
+[crates/rustc_codegen_spirv/src/codegen_cx/entry.rs:583] other = Integer(
+    32,
+    true,
+)
+[crates/rustc_codegen_spirv/src/codegen_cx/entry.rs:589] other = Integer(
+    32,
+    false,
+)
 OpCapability Float64
 OpCapability Int16
 OpCapability Int64
 OpCapability Int8
 OpCapability ShaderClockKHR
 OpCapability Shader
-OpCapability VulkanMemoryModel
 OpExtension "SPV_KHR_shader_clock"
-OpExtension "SPV_KHR_vulkan_memory_model"
-OpMemoryModel Logical Vulkan
-OpEntryPoint Fragment %1 "main" %2 %3 %4
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2 %3 %4 %5 %6 %7 %8
 OpExecutionMode %1 OriginUpperLeft
-%5 = OpString "$OPSTRING_FILENAME/array_location_calculation.rs"
-OpName %6 "array_location_calculation::main"
+%9 = OpString "$OPSTRING_FILENAME/array_location_calculation.rs"
+OpMemberName %10 0 "x_axis"
+OpMemberName %10 1 "y_axis"
+OpMemberName %10 2 "z_axis"
+OpName %10 "spirv_std::glam::core::storage::Columns3<spirv_std::glam::XYZ<f32>>"
+OpMemberName %11 0 "0"
+OpName %11 "spirv_std::glam::Mat3"
+OpName %12 "array_location_calculation::main"
 OpName %2 "one"
 OpName %3 "two"
 OpName %4 "three"
-OpDecorate %7 ArrayStride 4
-OpDecorate %8 ArrayStride 4
+OpName %5 "four"
+OpName %6 "five"
+OpName %7 "six"
+OpName %8 "seven"
+OpMemberName %10 0 "x_axis"
+OpMemberName %10 1 "y_axis"
+OpMemberName %10 2 "z_axis"
+OpMemberName %11 0 "0"
+OpMemberName %11 0 "0"
+OpMemberName %10 0 "x_axis"
+OpMemberName %10 1 "y_axis"
+OpMemberName %10 2 "z_axis"
+OpDecorate %13 ArrayStride 4
+OpDecorate %14 ArrayStride 4
+OpMemberDecorate %10 0 Offset 0
+OpMemberDecorate %10 1 Offset 16
+OpMemberDecorate %10 2 Offset 32
+OpMemberDecorate %11 0 Offset 0
 OpDecorate %2 Location 0
 OpDecorate %3 Location 7
 OpDecorate %4 Location 10
-%9 = OpTypeVoid
-%10 = OpTypeFloat 32
-%11 = OpTypeInt 32 0
-%12 = OpConstant  %11  7
-%7 = OpTypeArray %10 %12
-%13 = OpConstant  %11  3
-%8 = OpTypeArray %10 %13
-%14 = OpTypeFunction %9 %7 %8 %10
-%15 = OpTypeFunction %9
-%16 = OpTypePointer Input %7
-%2 = OpVariable  %16  Input
-%17 = OpTypePointer Input %8
-%3 = OpVariable  %17  Input
-%18 = OpTypePointer Input %10
-%4 = OpVariable  %18  Input
+OpDecorate %5 Location 13
+OpDecorate %6 Location 15
+OpDecorate %7 Location 16
+OpDecorate %8 Location 17
+%15 = OpTypeVoid
+%16 = OpTypeFloat 32
+%17 = OpTypeInt 32 0
+%18 = OpConstant  %17  7
+%13 = OpTypeArray %16 %18
+%19 = OpConstant  %17  3
+%14 = OpTypeArray %16 %19
+%20 = OpTypeVector %16 3
+%10 = OpTypeStruct %20 %20 %20
+%11 = OpTypeStruct %10
+%21 = OpTypeFloat 64
+%22 = OpTypeVector %21 3
+%23 = OpTypeInt 32 1
+%24 = OpTypeVector %23 4
+%25 = OpTypeFunction %15 %13 %14 %11 %22 %24 %16 %17
+%26 = OpTypeFunction %15
+%27 = OpTypePointer Input %13
+%2 = OpVariable  %27  Input
+%28 = OpTypePointer Input %14
+%3 = OpVariable  %28  Input
+%29 = OpTypePointer Input %11
+%4 = OpVariable  %29  Input
+%30 = OpTypePointer Input %22
+%5 = OpVariable  %30  Input
+%31 = OpTypePointer Input %24
+%6 = OpVariable  %31  Input
+%32 = OpTypePointer Input %16
+%7 = OpVariable  %32  Input
+%33 = OpTypePointer Input %17
+%8 = OpVariable  %33  Input

--- a/tests/ui/dis/array_location_calculation.stderr
+++ b/tests/ui/dis/array_location_calculation.stderr
@@ -1,8 +1,3 @@
-thread 'rustc' panicked at 'no function with the name `add_two_ints::add_two_ints` found in:
-; SPIR-V
-; Version: 1.3
-; Generator: Unknown
-; Bound: 28
 OpCapability Float64
 OpCapability Int16
 OpCapability Int64
@@ -13,10 +8,10 @@ OpCapability VulkanMemoryModel
 OpExtension "SPV_KHR_shader_clock"
 OpExtension "SPV_KHR_vulkan_memory_model"
 OpMemoryModel Logical Vulkan
-OpEntryPoint Fragment %1 "array_locations" %2 %3 %4
+OpEntryPoint Fragment %1 "main" %2 %3 %4
 OpExecutionMode %1 OriginUpperLeft
-%5 = OpString "C:/Users/Ashley/Desktop/rust-gpu/tests/ui/dis/array_location_calculation.rs"
-OpName %6 "array_location_calculation::array_locations"
+%5 = OpString "$OPSTRING_FILENAME/array_location_calculation.rs"
+OpName %6 "array_location_calculation::main"
 OpName %2 "one"
 OpName %3 "two"
 OpName %4 "three"
@@ -40,39 +35,3 @@ OpDecorate %4 Location 10
 %3 = OpVariable  %17  Input
 %18 = OpTypePointer Input %10
 %4 = OpVariable  %18  Input
-%6 = OpFunction  %9  None %14
-%19 = OpFunctionParameter  %7
-%20 = OpFunctionParameter  %8
-%21 = OpFunctionParameter  %10
-%22 = OpLabel
-OpLine %5 7 67
-OpReturn
-OpFunctionEnd
-%1 = OpFunction  %9  None %15
-%23 = OpLabel
-OpLine %5 7 23
-%24 = OpLoad  %7  %2
-OpLine %5 7 38
-%25 = OpLoad  %8  %3
-OpLine %5 7 53
-%26 = OpLoad  %10  %4
-OpLine %5 7 0
-%27 = OpFunctionCall  %9  %6 %24 %25 %26
-OpReturn
-OpFunctionEnd
-', crates/rustc_codegen_spirv/src/codegen_cx/mod.rs:378:21
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-error: internal compiler error: unexpected panic
-
-note: the compiler unexpectedly panicked. this is a bug.
-
-note: we would appreciate a bug report: https://github.com/EmbarkStudios/rust-gpu/issues/new
-
-note: rustc 1.58.0-nightly (29b124802 2021-10-25) running on x86_64-pc-windows-msvc
-
-note: compiler flags: -Z codegen-backend=C:/Users/Ashley/Desktop/rust-gpu/target/release/deps/rustc_codegen_spirv.dll -Z symbol-mangling-version=v0 -Z unstable-options -Z crate-attr=no_std -Z crate-attr=feature(register_attr,asm) -Z crate-attr=register_attr(spirv) -C prefer-dynamic -C overflow-checks=off -C debug-assertions=off -C debuginfo=2 -C embed-bitcode=no -C target-feature=+Int8,+Int16,+Int64,+Float64,+ShaderClockKHR,+ext:SPV_KHR_shader_clock -C llvm-args=--disassemble-fn=add_two_ints::add_two_ints --crate-type dylib
-
-query stack during panic:
-end of query stack
-note: `rust-gpu` version 0.4.0-alpha.12
-

--- a/tests/ui/dis/array_location_calculation.stderr
+++ b/tests/ui/dis/array_location_calculation.stderr
@@ -1,19 +1,13 @@
-[crates/rustc_codegen_spirv/src/codegen_cx/entry.rs:583] other = Integer(
-    32,
-    true,
-)
-[crates/rustc_codegen_spirv/src/codegen_cx/entry.rs:589] other = Integer(
-    32,
-    false,
-)
 OpCapability Float64
 OpCapability Int16
 OpCapability Int64
 OpCapability Int8
 OpCapability ShaderClockKHR
 OpCapability Shader
+OpCapability VulkanMemoryModel
 OpExtension "SPV_KHR_shader_clock"
-OpMemoryModel Logical Simple
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
 OpEntryPoint Fragment %1 "main" %2 %3 %4 %5 %6 %7 %8
 OpExecutionMode %1 OriginUpperLeft
 %9 = OpString "$OPSTRING_FILENAME/array_location_calculation.rs"


### PR DESCRIPTION
See https://github.com/EmbarkStudios/rust-gpu/pull/513.

This PR builds on top of that to support structs and 3 or 4 component 64-bit scalar type vectors (see https://github.com/EmbarkStudios/rust-gpu/pull/513#pullrequestreview-628664056).