### PR TITLE
Add an `IndexUnchecked` trait that uses `asm!`

### DIFF
--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -246,7 +246,7 @@ pub fn signed_max<T: SignedInteger>(a: T, b: T) -> T {
     unsafe { call_glsl_op_with_ints::<_, 42>(a, b) }
 }
 
-/// Index into an array or RuntiemArray without bounds checking.
+/// Index into an array or `RuntimeArray` without bounds checking.
 pub trait IndexUnchecked<T> {
     /// Returns a reference to the element at `index`. The equivalent of `get_unchecked`.
     unsafe fn index_unchecked(&self, index: usize) -> &T;

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -249,8 +249,14 @@ pub fn signed_max<T: SignedInteger>(a: T, b: T) -> T {
 /// Index into an array or `RuntimeArray` without bounds checking.
 pub trait IndexUnchecked<T> {
     /// Returns a reference to the element at `index`. The equivalent of `get_unchecked`.
+    ///
+    /// # Safety
+    /// Behavior is undefined if the `index` value is greater than or equal to the length of the array.
     unsafe fn index_unchecked(&self, index: usize) -> &T;
     /// Returns a mutable reference to the element at `index`. The equivalent of `get_unchecked_mut`.
+    ///
+    /// # Safety
+    /// Behavior is undefined if the `index` value is greater than or equal to the length of the array.
     unsafe fn index_unchecked_mut(&mut self, index: usize) -> &mut T;
 }
 

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -255,6 +255,7 @@ pub trait IndexUnchecked<T> {
 }
 
 impl<T> IndexUnchecked<T> for [T] {
+    #[spirv_std_macros::gpu_only]
     unsafe fn index_unchecked(&self, index: usize) -> &T {
         asm!(
             "%slice_ptr = OpLoad _ {slice_ptr_ptr}",
@@ -267,6 +268,7 @@ impl<T> IndexUnchecked<T> for [T] {
         )
     }
 
+    #[spirv_std_macros::gpu_only]
     unsafe fn index_unchecked_mut(&mut self, index: usize) -> &mut T {
         asm!(
             "%slice_ptr = OpLoad _ {slice_ptr_ptr}",
@@ -281,6 +283,7 @@ impl<T> IndexUnchecked<T> for [T] {
 }
 
 impl<T, const N: usize> IndexUnchecked<T> for [T; N] {
+    #[spirv_std_macros::gpu_only]
     unsafe fn index_unchecked(&self, index: usize) -> &T {
         asm!(
             "%val_ptr = OpAccessChain _ {array_ptr} {index}",
@@ -291,6 +294,7 @@ impl<T, const N: usize> IndexUnchecked<T> for [T; N] {
         )
     }
 
+    #[spirv_std_macros::gpu_only]
     unsafe fn index_unchecked_mut(&mut self, index: usize) -> &mut T {
         asm!(
             "%val_ptr = OpAccessChain _ {array_ptr} {index}",

--- a/tests/ui/arch/index_unchecked.rs
+++ b/tests/ui/arch/index_unchecked.rs
@@ -1,0 +1,14 @@
+// build-pass
+
+use spirv_std::arch::IndexUnchecked;
+
+#[spirv(fragment)]
+pub fn main(
+    #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] runtime_array: &mut [u32],
+    #[spirv(descriptor_set = 1, binding = 1, storage_buffer)] array: &mut [u32; 5],
+) {
+    unsafe {
+        *runtime_array.index_unchecked_mut(0) = *array.index_unchecked(0);
+        *array.index_unchecked_mut(1) = *runtime_array.index_unchecked(1);
+    }
+}


### PR DESCRIPTION
After https://github.com/EmbarkStudios/rust-gpu/pull/803 it became possible to write `asm!` functions that index into arrays and `RuntimeArray`s without bounds checking. This PR exposes these functions as a trait. I decided on `index_unchecked*` instead of `get_unchecked*` to avoid the name aliasing. It could still be pretty confusing though.