### PR TITLE
Error when int doesn't have spirv(flat)

### DIFF
--- a/tests/ui/byte_addressable_buffer/arr.rs
+++ b/tests/ui/byte_addressable_buffer/arr.rs
@@ -5,7 +5,7 @@ use spirv_std::{glam::Vec4, ByteAddressableBuffer};
 #[spirv(fragment)]
 pub fn load(
     #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &mut [u32],
-    out: &mut [i32; 4],
+    #[spirv(flat)] out: &mut [i32; 4],
 ) {
     unsafe {
         let buf = ByteAddressableBuffer::new(buf);
@@ -16,7 +16,7 @@ pub fn load(
 #[spirv(fragment)]
 pub fn store(
     #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &mut [u32],
-    val: [i32; 4],
+    #[spirv(flat)] val: [i32; 4],
 ) {
     unsafe {
         let mut buf = ByteAddressableBuffer::new(buf);

--- a/tests/ui/byte_addressable_buffer/big_struct.rs
+++ b/tests/ui/byte_addressable_buffer/big_struct.rs
@@ -14,7 +14,7 @@ pub struct BigStruct {
 #[spirv(fragment)]
 pub fn load(
     #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &mut [u32],
-    out: &mut BigStruct,
+    #[spirv(flat)] out: &mut BigStruct,
 ) {
     unsafe {
         let buf = ByteAddressableBuffer::new(buf);
@@ -25,7 +25,7 @@ pub fn load(
 #[spirv(fragment)]
 pub fn store(
     #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &mut [u32],
-    val: BigStruct,
+    #[spirv(flat)] val: BigStruct,
 ) {
     unsafe {
         let mut buf = ByteAddressableBuffer::new(buf);

--- a/tests/ui/byte_addressable_buffer/u32.rs
+++ b/tests/ui/byte_addressable_buffer/u32.rs
@@ -5,7 +5,7 @@ use spirv_std::ByteAddressableBuffer;
 #[spirv(fragment)]
 pub fn load(
     #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &mut [u32],
-    out: &mut u32,
+    #[spirv(flat)] out: &mut u32,
 ) {
     unsafe {
         let buf = ByteAddressableBuffer::new(buf);
@@ -14,7 +14,10 @@ pub fn load(
 }
 
 #[spirv(fragment)]
-pub fn store(#[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &mut [u32], val: u32) {
+pub fn store(
+    #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &mut [u32],
+    #[spirv(flat)] val: u32,
+) {
     unsafe {
         let mut buf = ByteAddressableBuffer::new(buf);
         buf.store(5, val);

--- a/tests/ui/dis/pass-mode-cast-struct.rs
+++ b/tests/ui/dis/pass-mode-cast-struct.rs
@@ -24,7 +24,7 @@ impl Foo {
 }
 
 #[spirv(fragment)]
-pub fn main(in_packed: u64, out_sum: &mut u32) {
+pub fn main(#[spirv(flat)] in_packed: u64, #[spirv(flat)] out_sum: &mut u32) {
     let foo = Foo::unpack(in_packed);
     *out_sum = foo.a + (foo.b + foo.c) as u32;
 }

--- a/tests/ui/image/query/query_levels.rs
+++ b/tests/ui/image/query/query_levels.rs
@@ -6,7 +6,7 @@ use spirv_std::{arch, Image};
 #[spirv(fragment)]
 pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled),
-    output: &mut u32,
+    #[spirv(flat)] output: &mut u32,
 ) {
     *output = image.query_levels();
 }

--- a/tests/ui/image/query/query_samples.rs
+++ b/tests/ui/image/query/query_samples.rs
@@ -6,7 +6,7 @@ use spirv_std::{arch, Image};
 #[spirv(fragment)]
 pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled, multisampled),
-    output: &mut u32,
+    #[spirv(flat)] output: &mut u32,
 ) {
     *output = image.query_samples();
 }

--- a/tests/ui/image/query/query_size.rs
+++ b/tests/ui/image/query/query_size.rs
@@ -6,7 +6,7 @@ use spirv_std::{arch, Image};
 #[spirv(fragment)]
 pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled=false),
-    output: &mut glam::UVec2,
+    #[spirv(flat)] output: &mut glam::UVec2,
 ) {
     *output = image.query_size();
 }

--- a/tests/ui/image/query/query_size_lod.rs
+++ b/tests/ui/image/query/query_size_lod.rs
@@ -6,7 +6,7 @@ use spirv_std::{arch, Image};
 #[spirv(fragment)]
 pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled),
-    output: &mut glam::UVec2,
+    #[spirv(flat)] output: &mut glam::UVec2,
 ) {
     *output = image.query_size_lod(0);
 }

--- a/tests/ui/lang/asm/infer-access-chain-array.rs
+++ b/tests/ui/lang/asm/infer-access-chain-array.rs
@@ -8,7 +8,7 @@ use spirv_std as _;
 use glam::Vec4;
 
 #[spirv(fragment)]
-pub fn main(#[spirv(push_constant)] array_in: &[Vec4; 16], i: u32, out: &mut Vec4) {
+pub fn main(#[spirv(push_constant)] array_in: &[Vec4; 16], #[spirv(flat)] i: u32, out: &mut Vec4) {
     unsafe {
         asm!(
             "%val_ptr = OpAccessChain _ {array_ptr} {index}",

--- a/tests/ui/lang/asm/infer-access-chain-slice.rs
+++ b/tests/ui/lang/asm/infer-access-chain-slice.rs
@@ -10,7 +10,7 @@ use glam::Vec4;
 #[spirv(fragment)]
 pub fn main(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] slice_in: &[Vec4],
-    i: u32,
+    #[spirv(flat)] i: u32,
     out: &mut Vec4,
 ) {
     unsafe {

--- a/tests/ui/lang/consts/issue-329.rs
+++ b/tests/ui/lang/consts/issue-329.rs
@@ -10,6 +10,6 @@ const OFFSETS: [f32; 18] = [
 
 #[allow(unused_attributes)]
 #[spirv(fragment)]
-pub fn main(x: &mut u32) {
+pub fn main(#[spirv(flat)] x: &mut u32) {
     *x = OFFSETS.len() as u32;
 }

--- a/tests/ui/lang/consts/nested-ref-in-composite.rs
+++ b/tests/ui/lang/consts/nested-ref-in-composite.rs
@@ -18,11 +18,11 @@ fn array3_deep_load(r: &'static [&'static u32; 3]) -> [u32; 3] {
 }
 
 #[spirv(fragment)]
-pub fn main_pair(pair_out: &mut (u32, f32)) {
+pub fn main_pair(#[spirv(flat)] pair_out: &mut (u32, f32)) {
     *pair_out = pair_deep_load(&(&123, &3.14));
 }
 
 #[spirv(fragment)]
-pub fn main_array3(array3_out: &mut [u32; 3]) {
+pub fn main_array3(#[spirv(flat)] array3_out: &mut [u32; 3]) {
     *array3_out = array3_deep_load(&[&0, &1, &2]);
 }

--- a/tests/ui/lang/consts/nested-ref.rs
+++ b/tests/ui/lang/consts/nested-ref.rs
@@ -22,9 +22,9 @@ fn deep_transpose(r: &'static &'static Mat2) -> Mat2 {
 
 #[spirv(fragment)]
 pub fn main(
-    scalar_out: &mut u32,
+    #[spirv(flat)] scalar_out: &mut u32,
     #[spirv(push_constant)] vec_in: &Vec2,
-    bool_out: &mut u32,
+    #[spirv(flat)] bool_out: &mut u32,
     vec_out: &mut Vec2,
 ) {
     *scalar_out = deep_load(&&123);

--- a/tests/ui/lang/consts/shallow-ref.rs
+++ b/tests/ui/lang/consts/shallow-ref.rs
@@ -15,7 +15,12 @@ fn scalar_load(r: &'static u32) -> u32 {
 const ROT90: Mat2 = const_mat2![[0.0, 1.0], [-1.0, 0.0]];
 
 #[spirv(fragment)]
-pub fn main(scalar_out: &mut u32, vec_in: Vec2, bool_out: &mut u32, vec_out: &mut Vec2) {
+pub fn main(
+    #[spirv(flat)] scalar_out: &mut u32,
+    vec_in: Vec2,
+    #[spirv(flat)] bool_out: &mut u32,
+    vec_out: &mut Vec2,
+) {
     *scalar_out = scalar_load(&123);
     *bool_out = (vec_in == Vec2::ZERO) as u32;
     *vec_out = ROT90.transpose() * vec_in;

--- a/tests/ui/lang/control_flow/closure_multi.rs
+++ b/tests/ui/lang/control_flow/closure_multi.rs
@@ -9,7 +9,7 @@ fn closure_user<F: FnMut(&u32, u32)>(ptr: &u32, xmax: u32, mut callback: F) {
 }
 
 #[spirv(fragment)]
-pub fn main(ptr: &mut u32) {
+pub fn main(#[spirv(flat)] ptr: &mut u32) {
     closure_user(ptr, 10, |ptr, i| {
         if *ptr == i {
             spirv_std::arch::kill();

--- a/tests/ui/lang/control_flow/defer.rs
+++ b/tests/ui/lang/control_flow/defer.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 32 {
         let current_position = 0;
         if i < current_position {

--- a/tests/ui/lang/control_flow/for_range.rs
+++ b/tests/ui/lang/control_flow/for_range.rs
@@ -3,6 +3,6 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     for _ in 0..i {}
 }

--- a/tests/ui/lang/control_flow/for_with_custom_range_iter.rs
+++ b/tests/ui/lang/control_flow/for_with_custom_range_iter.rs
@@ -25,6 +25,6 @@ impl<T: Num + Ord + Copy> Iterator for RangeIter<T> {
 }
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     for _ in RangeIter(0..i) {}
 }

--- a/tests/ui/lang/control_flow/if.rs
+++ b/tests/ui/lang/control_flow/if.rs
@@ -3,6 +3,6 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i > 0 {}
 }

--- a/tests/ui/lang/control_flow/if_else.rs
+++ b/tests/ui/lang/control_flow/if_else.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i > 0 {
     } else {
     }

--- a/tests/ui/lang/control_flow/if_else_if_else.rs
+++ b/tests/ui/lang/control_flow/if_else_if_else.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i > 0 {
     } else if i < 0 {
     } else {

--- a/tests/ui/lang/control_flow/if_if.rs
+++ b/tests/ui/lang/control_flow/if_if.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i > 0 {
         if i < 10 {}
     }

--- a/tests/ui/lang/control_flow/if_return_else.rs
+++ b/tests/ui/lang/control_flow/if_return_else.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i < 10 {
         return;
     } else {

--- a/tests/ui/lang/control_flow/if_return_else_return.rs
+++ b/tests/ui/lang/control_flow/if_return_else_return.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i < 10 {
         return;
     } else {

--- a/tests/ui/lang/control_flow/if_while.rs
+++ b/tests/ui/lang/control_flow/if_while.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i == 0 {
         while i < 10 {}
     }

--- a/tests/ui/lang/control_flow/ifx2.rs
+++ b/tests/ui/lang/control_flow/ifx2.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     if i > 0 {}
     if i > 1 {}
 }

--- a/tests/ui/lang/control_flow/while.rs
+++ b/tests/ui/lang/control_flow/while.rs
@@ -3,6 +3,6 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {}
 }

--- a/tests/ui/lang/control_flow/while_break.rs
+++ b/tests/ui/lang/control_flow/while_break.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         break;
     }

--- a/tests/ui/lang/control_flow/while_continue.rs
+++ b/tests/ui/lang/control_flow/while_continue.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         continue;
     }

--- a/tests/ui/lang/control_flow/while_if_break.rs
+++ b/tests/ui/lang/control_flow/while_if_break.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         if i == 0 {
             break;

--- a/tests/ui/lang/control_flow/while_if_break_else_break.rs
+++ b/tests/ui/lang/control_flow/while_if_break_else_break.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         if i == 0 {
             break;

--- a/tests/ui/lang/control_flow/while_if_break_if_break.rs
+++ b/tests/ui/lang/control_flow/while_if_break_if_break.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         if i == 0 {
             break;

--- a/tests/ui/lang/control_flow/while_if_continue.rs
+++ b/tests/ui/lang/control_flow/while_if_continue.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         if i == 0 {
             continue;

--- a/tests/ui/lang/control_flow/while_if_continue_else_continue.rs
+++ b/tests/ui/lang/control_flow/while_if_continue_else_continue.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         if i == 0 {
             continue;

--- a/tests/ui/lang/control_flow/while_return.rs
+++ b/tests/ui/lang/control_flow/while_return.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 10 {
         return;
     }

--- a/tests/ui/lang/control_flow/while_while.rs
+++ b/tests/ui/lang/control_flow/while_while.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 20 {
         while i < 10 {}
     }

--- a/tests/ui/lang/control_flow/while_while_break.rs
+++ b/tests/ui/lang/control_flow/while_while_break.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 20 {
         while i < 10 {
             break;

--- a/tests/ui/lang/control_flow/while_while_continue.rs
+++ b/tests/ui/lang/control_flow/while_while_continue.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 20 {
         while i < 10 {
             continue;

--- a/tests/ui/lang/control_flow/while_while_if_break.rs
+++ b/tests/ui/lang/control_flow/while_while_if_break.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 20 {
         while i < 10 {
             if i > 10 {

--- a/tests/ui/lang/control_flow/while_while_if_continue.rs
+++ b/tests/ui/lang/control_flow/while_while_if_continue.rs
@@ -3,7 +3,7 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(i: i32) {
+pub fn main(#[spirv(flat)] i: i32) {
     while i < 20 {
         while i < 10 {
             if i > 5 {

--- a/tests/ui/lang/core/ops/range-contains.rs
+++ b/tests/ui/lang/core/ops/range-contains.rs
@@ -11,6 +11,6 @@ fn has_two_decimal_digits(x: u32) -> bool {
 }
 
 #[spirv(fragment)]
-pub fn main(i: u32, o: &mut u32) {
+pub fn main(#[spirv(flat)] i: u32, #[spirv(flat)] o: &mut u32) {
     *o = has_two_decimal_digits(i) as u32;
 }

--- a/tests/ui/lang/core/unwrap_or.rs
+++ b/tests/ui/lang/core/unwrap_or.rs
@@ -7,6 +7,6 @@
 use spirv_std as _;
 
 #[spirv(fragment)]
-pub fn main(out: &mut u32) {
+pub fn main(#[spirv(flat)] out: &mut u32) {
     *out = None.unwrap_or(15);
 }

--- a/tests/ui/lang/f32/packing.rs
+++ b/tests/ui/lang/f32/packing.rs
@@ -5,61 +5,61 @@ use spirv_std::float::*;
 use spirv_std::glam::{Vec2, Vec4};
 
 #[spirv(fragment)]
-pub fn test_vec2_to_f16x2(i: Vec2, o: &mut u32) {
+pub fn test_vec2_to_f16x2(i: Vec2, #[spirv(flat)] o: &mut u32) {
     *o = vec2_to_f16x2(i);
 }
 
 #[spirv(fragment)]
-pub fn test_f16x2_to_vec2(i: u32, o: &mut Vec2) {
+pub fn test_f16x2_to_vec2(#[spirv(flat)] i: u32, o: &mut Vec2) {
     *o = f16x2_to_vec2(i);
 }
 
 #[spirv(fragment)]
-pub fn test_f32_to_f16(i: f32, o: &mut u32) {
+pub fn test_f32_to_f16(i: f32, #[spirv(flat)] o: &mut u32) {
     *o = f32_to_f16(i);
 }
 
 #[spirv(fragment)]
-pub fn test_f16_to_f32(i: u32, o: &mut f32) {
+pub fn test_f16_to_f32(#[spirv(flat)] i: u32, o: &mut f32) {
     *o = f16_to_f32(i);
 }
 
 #[spirv(fragment)]
-pub fn test_vec4_to_u8x4_snorm(i: Vec4, o: &mut u32) {
+pub fn test_vec4_to_u8x4_snorm(i: Vec4, #[spirv(flat)] o: &mut u32) {
     *o = vec4_to_u8x4_snorm(i);
 }
 
 #[spirv(fragment)]
-pub fn test_vec4_to_u8x4_unorm(i: Vec4, o: &mut u32) {
+pub fn test_vec4_to_u8x4_unorm(i: Vec4, #[spirv(flat)] o: &mut u32) {
     *o = vec4_to_u8x4_unorm(i);
 }
 
 #[spirv(fragment)]
-pub fn test_vec2_to_u16x2_snorm(i: Vec2, o: &mut u32) {
+pub fn test_vec2_to_u16x2_snorm(i: Vec2, #[spirv(flat)] o: &mut u32) {
     *o = vec2_to_u16x2_snorm(i);
 }
 
 #[spirv(fragment)]
-pub fn test_vec2_to_u16x2_unorm(i: Vec2, o: &mut u32) {
+pub fn test_vec2_to_u16x2_unorm(i: Vec2, #[spirv(flat)] o: &mut u32) {
     *o = vec2_to_u16x2_unorm(i);
 }
 
 #[spirv(fragment)]
-pub fn test_u8x4_to_vec4_snorm(i: u32, o: &mut Vec4) {
+pub fn test_u8x4_to_vec4_snorm(#[spirv(flat)] i: u32, o: &mut Vec4) {
     *o = u8x4_to_vec4_snorm(i);
 }
 
 #[spirv(fragment)]
-pub fn test_u8x4_to_vec4_unorm(i: u32, o: &mut Vec4) {
+pub fn test_u8x4_to_vec4_unorm(#[spirv(flat)] i: u32, o: &mut Vec4) {
     *o = u8x4_to_vec4_unorm(i);
 }
 
 #[spirv(fragment)]
-pub fn test_u16x2_to_vec2_snorm(i: u32, o: &mut Vec2) {
+pub fn test_u16x2_to_vec2_snorm(#[spirv(flat)] i: u32, o: &mut Vec2) {
     *o = u16x2_to_vec2_snorm(i);
 }
 
 #[spirv(fragment)]
-pub fn test_u16x2_to_vec2_unorm(i: u32, o: &mut Vec2) {
+pub fn test_u16x2_to_vec2_unorm(#[spirv(flat)] i: u32, o: &mut Vec2) {
     *o = u16x2_to_vec2_unorm(i);
 }

--- a/tests/ui/lang/panic/track_caller.rs
+++ b/tests/ui/lang/panic/track_caller.rs
@@ -12,6 +12,6 @@ fn track_caller_maybe_panic(x: u32) {
 }
 
 #[spirv(fragment)]
-pub fn main(x: u32) {
+pub fn main(#[spirv(flat)] x: u32) {
     track_caller_maybe_panic(x);
 }

--- a/tests/ui/spirv-attr/int-without-flat.rs
+++ b/tests/ui/spirv-attr/int-without-flat.rs
@@ -1,0 +1,6 @@
+// build-fail
+
+use spirv_std as _;
+
+#[spirv(fragment)]
+pub fn fragment(int: u32, double: f64) {}

--- a/tests/ui/spirv-attr/int-without-flat.stderr
+++ b/tests/ui/spirv-attr/int-without-flat.stderr
@@ -1,0 +1,14 @@
+error: parameter must be decorated with #[spirv(flat)]
+ --> $DIR/int-without-flat.rs:6:22
+  |
+6 | pub fn fragment(int: u32, double: f64) {}
+  |                      ^^^
+
+error: parameter must be decorated with #[spirv(flat)]
+ --> $DIR/int-without-flat.rs:6:35
+  |
+6 | pub fn fragment(int: u32, double: f64) {}
+  |                                   ^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #797

Should really instead be fixed by https://github.com/KhronosGroup/SPIRV-Tools/issues/3066, but that's been open for a while and probably won't be fixed any time soon.