### PR TITLE
Use the safe shader initialisation path of wgpu

### DIFF
--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -22,7 +22,7 @@ pub fn start(options: &Options) {
 
 pub async fn start_internal(
     _options: &Options,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'static>,
+    shader_binary: wgpu::ShaderModuleDescriptor<'static>,
 ) {
     let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
     let adapter = instance
@@ -38,8 +38,7 @@ pub async fn start_internal(
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: None,
-                features: wgpu::Features::TIMESTAMP_QUERY
-                    | wgpu::Features::SPIRV_SHADER_PASSTHROUGH,
+                features: wgpu::Features::TIMESTAMP_QUERY,
                 limits: wgpu::Limits::default(),
             },
             None,
@@ -52,7 +51,7 @@ pub async fn start_internal(
     let timestamp_period = queue.get_timestamp_period();
 
     // Load the shaders from disk
-    let module = unsafe { device.create_shader_module_spirv(&shader_binary) };
+    let module = device.create_shader_module(&shader_binary);
 
     let top = 2u32.pow(20);
     let src_range = 1..top;
@@ -66,20 +65,16 @@ pub async fn start_internal(
 
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: None,
-        entries: &[
-            // XXX - some graphics cards do not support empty bind layout groups, so
-            // create a dummy entry.
-            wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                count: None,
-                visibility: wgpu::ShaderStages::COMPUTE,
-                ty: wgpu::BindingType::Buffer {
-                    has_dynamic_offset: false,
-                    min_binding_size: Some(NonZeroU64::new(1).unwrap()),
-                    ty: wgpu::BufferBindingType::Storage { read_only: false },
-                },
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            count: None,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                has_dynamic_offset: false,
+                min_binding_size: Some(NonZeroU64::new(4).unwrap()),
+                ty: wgpu::BufferBindingType::Storage { read_only: false },
             },
-        ],
+        }],
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {

--- a/examples/runners/wgpu/src/graphics.rs
+++ b/examples/runners/wgpu/src/graphics.rs
@@ -33,9 +33,9 @@ fn mouse_button_index(button: MouseButton) -> usize {
 }
 
 async fn run(
-    event_loop: EventLoop<wgpu::ShaderModuleDescriptorSpirV<'static>>,
+    event_loop: EventLoop<wgpu::ShaderModuleDescriptor<'static>>,
     window: Window,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'static>,
+    shader_binary: wgpu::ShaderModuleDescriptor<'static>,
 ) {
     let instance = wgpu::Instance::new(wgpu::Backends::VULKAN | wgpu::Backends::METAL);
 
@@ -57,7 +57,7 @@ async fn run(
         .await
         .expect("Failed to find an appropriate adapter");
 
-    let features = wgpu::Features::PUSH_CONSTANTS | wgpu::Features::SPIRV_SHADER_PASSTHROUGH;
+    let features = wgpu::Features::PUSH_CONSTANTS;
     let limits = wgpu::Limits {
         max_push_constant_size: 256,
         ..Default::default()
@@ -284,9 +284,9 @@ fn create_pipeline(
     device: &wgpu::Device,
     pipeline_layout: &wgpu::PipelineLayout,
     surface_format: wgpu::TextureFormat,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'_>,
+    shader_binary: wgpu::ShaderModuleDescriptor<'_>,
 ) -> wgpu::RenderPipeline {
-    let module = unsafe { device.create_shader_module_spirv(&shader_binary) };
+    let module = device.create_shader_module(&shader_binary);
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,
         layout: Some(pipeline_layout),

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -86,8 +86,8 @@ pub enum RustGPUShader {
 
 fn maybe_watch(
     shader: RustGPUShader,
-    on_watch: Option<Box<dyn FnMut(wgpu::ShaderModuleDescriptorSpirV<'static>) + Send + 'static>>,
-) -> wgpu::ShaderModuleDescriptorSpirV<'static> {
+    on_watch: Option<Box<dyn FnMut(wgpu::ShaderModuleDescriptor<'static>) + Send + 'static>>,
+) -> wgpu::ShaderModuleDescriptor<'static> {
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
         use spirv_builder::{CompileResult, MetadataPrintout, SpirvBuilder};
@@ -123,11 +123,13 @@ fn maybe_watch(
         };
         fn handle_compile_result(
             compile_result: CompileResult,
-        ) -> wgpu::ShaderModuleDescriptorSpirV<'static> {
+        ) -> wgpu::ShaderModuleDescriptor<'static> {
             let module_path = compile_result.module.unwrap_single();
             let data = std::fs::read(module_path).unwrap();
-            let spirv = Cow::Owned(wgpu::util::make_spirv_raw(&data).into_owned());
-            wgpu::ShaderModuleDescriptorSpirV {
+            let spirv = wgpu::ShaderSource::SpirV(Cow::Owned(
+                wgpu::util::make_spirv_raw(&data).into_owned(),
+            ));
+            wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: spirv,
             }

--- a/examples/shaders/mouse-shader/src/lib.rs
+++ b/examples/shaders/mouse-shader/src/lib.rs
@@ -224,7 +224,8 @@ pub fn main_fs(
     };
 
     // FIXME: Naga does not like for loops
-    let mut paint_for_button = |i| {
+    let mut i = 0;
+    while i < 3 {
         painter.fill(
             mouse_button(i),
             RED.lerp(
@@ -237,11 +238,9 @@ pub fn main_fs(
                     constants.time - constants.mouse_button_press_time[i],
                 ),
             ),
-        )
-    };
-    paint_for_button(0);
-    paint_for_button(1);
-    paint_for_button(2);
+        );
+        i += 1;
+    }
 
     painter.fill_with_contrast_border(
         mouse_circle

--- a/examples/shaders/mouse-shader/src/lib.rs
+++ b/examples/shaders/mouse-shader/src/lib.rs
@@ -223,7 +223,8 @@ pub fn main_fs(
         .intersect(mouse_circle)
     };
 
-    for i in 0..3 {
+    // FIXME: Naga does not like for loops
+    let mut paint_for_button = |i| {
         painter.fill(
             mouse_button(i),
             RED.lerp(
@@ -236,8 +237,11 @@ pub fn main_fs(
                     constants.time - constants.mouse_button_press_time[i],
                 ),
             ),
-        );
-    }
+        )
+    };
+    paint_for_button(0);
+    paint_for_button(1);
+    paint_for_button(2);
 
     painter.fill_with_contrast_border(
         mouse_circle


### PR DESCRIPTION
`wgpu` can handle our example shaders safely now, except for the mouse shader, which needed a small change (e04d2d9a0996c5f97491c0b393645c4f05f5452d) to work around naga (?) not handling for loops properly.

This needs further investigation.