### PR TITLE
Add error for insts not allowed outside fragment

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -157,6 +157,11 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
         import_export_link::run(sess, &mut output)?;
     }
 
+    {
+        let _timer = sess.timer("link_fragment_inst_check");
+        simple_passes::check_fragment_insts(sess, &output)?;
+    }
+
     // HACK(eddyb) this has to run before the `remove_zombies` pass, so that any
     // zombies that are passed as call arguments, but eventually unused, won't
     // be (incorrectly) considered used.

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -81,7 +81,17 @@ fn apply_rewrite_rules(rewrite_rules: &FxHashMap<Word, Word>, blocks: &mut [Bloc
 }
 
 fn get_names(module: &Module) -> FxHashMap<Word, &str> {
-    module
+    let entry_names = module
+        .entry_points
+        .iter()
+        .filter(|i| i.class.opcode == Op::EntryPoint)
+        .map(|i| {
+            (
+                i.operands[1].unwrap_id_ref(),
+                i.operands[2].unwrap_literal_string(),
+            )
+        });
+    let debug_names = module
         .debug_names
         .iter()
         .filter(|i| i.class.opcode == Op::Name)
@@ -90,8 +100,9 @@ fn get_names(module: &Module) -> FxHashMap<Word, &str> {
                 i.operands[0].unwrap_id_ref(),
                 i.operands[1].unwrap_literal_string(),
             )
-        })
-        .collect()
+        });
+    // items later on take priority
+    entry_names.chain(debug_names).collect()
 }
 
 fn get_name<'a>(names: &FxHashMap<Word, &'a str>, id: Word) -> Cow<'a, str> {

--- a/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
+++ b/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
@@ -241,7 +241,7 @@ pub fn check_fragment_insts(sess: &Session, module: &Module) -> Result<()> {
                 visited[index] = false;
 
                 let names = names.get_or_insert_with(|| get_names(module));
-                let stack = stack.iter().map(|&s| get_name(names, s).into_owned());
+                let stack = stack.iter().rev().map(|&s| get_name(names, s).into_owned());
                 let note = once("Stack:".to_string())
                     .chain(stack)
                     .collect::<Vec<_>>()

--- a/tests/ui/image/implicit_not_in_fragment.rs
+++ b/tests/ui/image/implicit_not_in_fragment.rs
@@ -1,0 +1,23 @@
+// build-fail
+
+use spirv_std::{arch, Image, Sampler};
+
+fn deeper_stack(image2d: &Image!(2D, type=f32, sampled), sampler: &Sampler) -> glam::Vec4 {
+    let v2 = glam::Vec2::new(0.0, 1.0);
+    image2d.sample(*sampler, v2)
+}
+fn deep_stack(image2d: &Image!(2D, type=f32, sampled), sampler: &Sampler) -> glam::Vec4 {
+    deeper_stack(image2d, sampler)
+}
+
+#[spirv(vertex)]
+pub fn main(
+    #[spirv(descriptor_set = 0, binding = 0)] image2d: &Image!(2D, type=f32, sampled),
+    #[spirv(descriptor_set = 0, binding = 1)] sampler: &Sampler,
+    output: &mut glam::Vec4,
+) {
+    let v2 = glam::Vec2::new(0.0, 1.0);
+    let r0 = deep_stack(image2d, sampler);
+    let r1: glam::Vec4 = image2d.sample(*sampler, v2);
+    *output = r0 + r1;
+}

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -1,0 +1,18 @@
+error: ImageSampleImplicitLod cannot be used outside a fragment shader
+  |
+  = note: Stack:
+          Unnamed function ID %79
+          implicit_not_in_fragment::main
+          implicit_not_in_fragment::deep_stack
+          implicit_not_in_fragment::deeper_stack
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::vec4::Vec4, glam::vec2::Vec2>
+
+error: ImageSampleImplicitLod cannot be used outside a fragment shader
+  |
+  = note: Stack:
+          Unnamed function ID %79
+          implicit_not_in_fragment::main
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::vec4::Vec4, glam::vec2::Vec2>
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -5,14 +5,14 @@ error: ImageSampleImplicitLod cannot be used outside a fragment shader
           implicit_not_in_fragment::deeper_stack
           implicit_not_in_fragment::deep_stack
           implicit_not_in_fragment::main
-          Unnamed function ID %79
+          main
 
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
           <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::vec4::Vec4, glam::vec2::Vec2>
           implicit_not_in_fragment::main
-          Unnamed function ID %79
+          main
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -1,18 +1,18 @@
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          Unnamed function ID %79
-          implicit_not_in_fragment::main
-          implicit_not_in_fragment::deep_stack
-          implicit_not_in_fragment::deeper_stack
           <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::vec4::Vec4, glam::vec2::Vec2>
+          implicit_not_in_fragment::deeper_stack
+          implicit_not_in_fragment::deep_stack
+          implicit_not_in_fragment::main
+          Unnamed function ID %79
 
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          Unnamed function ID %79
-          implicit_not_in_fragment::main
           <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::vec4::Vec4, glam::vec2::Vec2>
+          implicit_not_in_fragment::main
+          Unnamed function ID %79
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lang/consts/nested-ref-in-composite.stderr
+++ b/tests/ui/lang/consts/nested-ref-in-composite.stderr
@@ -6,7 +6,7 @@ error: constant arrays/structs cannot contain pointers to other constants
    |
    = note: Stack:
            nested_ref_in_composite::main_pair
-           Unnamed function ID %24
+           main_pair
 
 error: constant arrays/structs cannot contain pointers to other constants
   --> $DIR/nested-ref-in-composite.rs:27:19
@@ -16,7 +16,7 @@ error: constant arrays/structs cannot contain pointers to other constants
    |
    = note: Stack:
            nested_ref_in_composite::main_array3
-           Unnamed function ID %33
+           main_array3
 
 error: error:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -2,7 +2,7 @@ error: pointer has non-null integer address
   |
   = note: Stack:
           allocate_const_scalar::main
-          Unnamed function ID %4
+          main
 
 error: error:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
   |


### PR DESCRIPTION
This sort of "visit some functions in DFS" should probably be extracted to a reusable/common place, but I'm lazyyy.

Fixes #762