### PR TITLE
Add `RayQuery::confirm_intersection`

### DIFF
--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -288,14 +288,28 @@ impl RayQuery {
     }
 
     /// Terminates further execution of a ray query; further calls to
-    /// [`Self::proceed`] will return `false`.The value returned by any prior
+    /// [`Self::proceed`] will return `false`. The value returned by any prior
     /// execution of [`Self::proceed`] with the same ray query object must have
-    /// been true. Refer to the client API specification for more details.
+    /// been true.
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryTerminateKHR")]
     #[inline]
     pub unsafe fn terminate(&self) {
         asm!("OpRayQueryTerminateKHR {}", in(reg) self)
+    }
+
+    /// Confirms a triangle intersection to be included in the determination
+    /// of the closest hit for a ray query.
+    ///
+    /// [`Self::proceed()`] must have been called on this object, and it must
+    /// have returned true. The current intersection candidate must have a
+    /// [`Self::get_candidate_intersection_type()`] of
+    /// [`CandidateIntersection::Triangle`].
+    #[spirv_std_macros::gpu_only]
+    #[doc(alias = "OpRayQueryConfirmIntersectionKHR")]
+    #[inline]
+    pub unsafe fn confirm_intersection(&self) {
+        asm!("OpRayQueryConfirmIntersectionKHR {}", in(reg) self)
     }
 
     /// Returns the type of the current candidate intersection.

--- a/tests/ui/arch/ray_query_confirm_intersection_khr.rs
+++ b/tests/ui/arch/ray_query_confirm_intersection_khr.rs
@@ -10,5 +10,6 @@ pub fn main(#[spirv(descriptor_set = 0, binding = 0)] accel: &AccelerationStruct
         spirv_std::ray_query!(let mut handle);
         handle.initialize(accel, RayFlags::NONE, 0, Vec3::ZERO, 0.0, Vec3::ZERO, 0.0);
         assert!(handle.proceed());
+        handle.confirm_intersection();
     }
 }

--- a/tests/ui/arch/ray_query_terminate_khr.rs
+++ b/tests/ui/arch/ray_query_terminate_khr.rs
@@ -9,6 +9,7 @@ pub fn main(#[spirv(descriptor_set = 0, binding = 0)] accel: &AccelerationStruct
     unsafe {
         spirv_std::ray_query!(let mut handle);
         handle.initialize(accel, RayFlags::NONE, 0, Vec3::ZERO, 0.0, Vec3::ZERO, 0.0);
+        assert!(handle.proceed());
         handle.terminate();
     }
 }


### PR DESCRIPTION
I spent like 20 minutes looking for this one before realising that it wasn't implemented :sweat_smile:

You need this if the ray query flags do not contain `RayFlags::OPAQUE`, as otherwise a `while ray.proceed() {}` will just skip through all the candidate intersections without confirming any of them. Essentially, you need it for alpha clipping and stuff like that. See here for an example: https://github.com/expenses/transmission-renderer/blob/c5dbd648e513def2719f3971fd5d9c8ce992ba63/shader/src/lib.rs#L736-L766

