### PR TITLE
Hint `"rust-analyzer.rustcSource": "discover"` next to `rustc_private = true`.

### DIFF
--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -51,6 +51,8 @@ pipe = "0.4"
 pretty_assertions = "1.0"
 tempfile = "3.2"
 
+# Note that in order to use RA and have access to `rustc_*` crates, you also
+# need to set `"rust-analyzer.rustcSource": "discover"` in e.g. VSCode.
 [package.metadata.rust-analyzer]
 # This crate uses #[feature(rustc_private)]
 rustc_private = true


### PR DESCRIPTION
This information comes [from the clippy docs](https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md#rust-analyzer) (the "nightly RA" part doesn't seem to be relevant), but it otherwise doesn't seem very discoverable (to the point that I didn't even think anything like it existed yet).

We should probably also document this aspect of using RA like clippy does, but I wasn't sure where to put it.