### PR TITLE
Add a preserve_bindings opt to the builder and codegen opts

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -251,6 +251,9 @@ pub struct CodegenArgs {
     pub uniform_buffer_standard_layout: bool,
     pub scalar_block_layout: bool,
     pub skip_block_layout: bool,
+
+    // spirv-opt flags
+    pub preserve_bindings: bool,
 }
 
 impl CodegenArgs {
@@ -289,6 +292,8 @@ impl CodegenArgs {
         opts.optflagopt("", "scalar-block-layout", "Enable VK_EXT_scalar_block_layout when checking standard uniform, storage buffer, and push constant layouts. Scalar layout rules are more permissive than relaxed block layout so in effect this will override the --relax-block-layout option.", "");
         opts.optflagopt("", "skip-block-layout", "Skip checking standard uniform/storage buffer layout. Overrides any --relax-block-layout or --scalar-block-layout option.", "");
 
+        opts.optflagopt("", "preserve-bindings", "Preserve unused descriptor bindings. Useful for reflection.", "");
+
         let matches = opts.parse(args)?;
         let module_output_type =
             matches.opt_get_default("module-output", ModuleOutputType::Single)?;
@@ -305,6 +310,8 @@ impl CodegenArgs {
         let uniform_buffer_standard_layout = matches.opt_present("uniform-buffer-standard-layout");
         let scalar_block_layout = matches.opt_present("scalar-block-layout");
         let skip_block_layout = matches.opt_present("skip-block-layout");
+
+        let preserve_bindings = matches.opt_present("preserve-bindings");
 
         let relax_block_layout = if relax_block_layout { Some(true) } else { None };
 
@@ -334,6 +341,8 @@ impl CodegenArgs {
             uniform_buffer_standard_layout,
             scalar_block_layout,
             skip_block_layout,
+
+            preserve_bindings,
         })
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -292,7 +292,12 @@ impl CodegenArgs {
         opts.optflagopt("", "scalar-block-layout", "Enable VK_EXT_scalar_block_layout when checking standard uniform, storage buffer, and push constant layouts. Scalar layout rules are more permissive than relaxed block layout so in effect this will override the --relax-block-layout option.", "");
         opts.optflagopt("", "skip-block-layout", "Skip checking standard uniform/storage buffer layout. Overrides any --relax-block-layout or --scalar-block-layout option.", "");
 
-        opts.optflagopt("", "preserve-bindings", "Preserve unused descriptor bindings. Useful for reflection.", "");
+        opts.optflagopt(
+            "",
+            "preserve-bindings",
+            "Preserve unused descriptor bindings. Useful for reflection.",
+            "",
+        );
 
         let matches = opts.parse(args)?;
         let module_output_type =

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -209,7 +209,7 @@ fn post_link_single_module(
     let opt_options = spirv_tools::opt::Options {
         validator_options: Some(val_options.clone()),
         max_id_bound: None,
-        preserve_bindings: true,
+        preserve_bindings: cg_args.preserve_bindings,
         preserve_spec_constants: false,
     };
 

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -209,7 +209,7 @@ fn post_link_single_module(
     let opt_options = spirv_tools::opt::Options {
         validator_options: Some(val_options.clone()),
         max_id_bound: None,
-        preserve_bindings: false,
+        preserve_bindings: true,
         preserve_spec_constants: false,
     };
 

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -166,6 +166,9 @@ pub struct SpirvBuilder {
     pub uniform_buffer_standard_layout: bool,
     pub scalar_block_layout: bool,
     pub skip_block_layout: bool,
+
+    // spirv-opt flags
+    pub preserve_bindings: bool,
 }
 
 impl SpirvBuilder {
@@ -187,6 +190,8 @@ impl SpirvBuilder {
             uniform_buffer_standard_layout: false,
             scalar_block_layout: false,
             skip_block_layout: false,
+
+            preserve_bindings: false,
         }
     }
 
@@ -275,6 +280,12 @@ impl SpirvBuilder {
     /// --scalar-block-layout option.
     pub fn skip_block_layout(mut self, v: bool) -> Self {
         self.skip_block_layout = v;
+        self
+    }
+
+    /// Preserve unused descriptor bindings. Useful for reflection.
+    pub fn preserve_bindings(mut self, v: bool) -> Self {
+        self.preserve_bindings = v;
         self
     }
 
@@ -423,6 +434,9 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
     }
     if builder.skip_block_layout {
         llvm_args.push("--skip-block-layout");
+    }
+    if builder.preserve_bindings {
+        llvm_args.push("--preserve-bindings");
     }
     let llvm_args = join_checking_for_separators(llvm_args, " ");
     if !llvm_args.is_empty() {


### PR DESCRIPTION
~~This resolves https://github.com/EmbarkStudios/rust-gpu/issues/827 and makes reflection a lot easier. I think having it set to true unconditionally is the right move but two alternatives are:~~

~~* Setting it to `cg_args.spirv_metadata != SpirvMetadata::None`. This is pretty unclear behaviour but it does keep things the same in the default case.~~
* Adding a new `CodegenArgs::opt_preserve_bindings` argument. Adds more complexity and is easily missed. Doesn't really 'just work'.