### PR TITLE
Update spirv-tools to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ffcd721c949125c13b1213a292477a2d82621512b094564bd918c3a1c7f7ff"
+checksum = "ca7f0f689581589b0a31000317fa31257cb24d040227708718ebd9fedf5cdd2b"
 dependencies = [
  "memchr",
  "spirv-tools-sys",
@@ -2264,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b967db819666ccf7a0373876321bfe852922edcc7f3e30e3a7668b02e1961119"
+checksum = "2980b0b4b2a9b5edfeb1dc8a35e84aac07b9c6dcd2339cce004d9355fb62a59d"
 dependencies = [
  "cc",
 ]

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -44,7 +44,7 @@ sanitize-filename = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"
-spirv-tools = { version = "0.7", default-features = false }
+spirv-tools = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 pipe = "0.4"


### PR DESCRIPTION
This updates to the v2022.1 tag for spirv-tools, there were some changes in optimization passes, but I think since rust-gpu only uses the command line tools the change shouldn't have an impact directly.