### PR TITLE
Enable Vulkan for WGPU runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,15 +57,6 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ash"
-version = "0.33.3+1.2.191"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
-dependencies = [
- "libloading",
-]
-
-[[package]]
-name = "ash"
 version = "0.35.0+1.2.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7638ce84f8c84d6fd6faa63aa267574d345181ba591c0eeb5550d4c30cd600"
@@ -80,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b51f10940e9e2022ff1cecbc73ba848d0edda13084f2063980546e945b0e7b"
 dependencies = [
  "anyhow",
- "ash 0.35.0+1.2.203",
+ "ash",
  "plist",
  "serde",
 ]
@@ -91,7 +82,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f510c6da81963f828aaaf863983bc51f223fba4e8c3f054d98c941c7e19ee7"
 dependencies = [
- "ash 0.35.0+1.2.203",
+ "ash",
  "raw-window-handle 0.3.4",
  "raw-window-metal",
 ]
@@ -736,7 +727,7 @@ dependencies = [
 name = "example-runner-ash"
 version = "0.4.0-alpha.12"
 dependencies = [
- "ash 0.35.0+1.2.203",
+ "ash",
  "ash-molten",
  "ash-window",
  "cfg-if 1.0.0",
@@ -1154,6 +1145,7 @@ checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1273,8 +1265,7 @@ dependencies = [
 [[package]]
 name = "metal"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+source = "git+https://github.com/gfx-rs/metal-rs?rev=a357159#a35715916fec38bbc08a510ecf7d115edc500c72"
 dependencies = [
  "bitflags",
  "block",
@@ -1373,8 +1364,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7216bec6be822a562dda435236539c7fb5aa5e5ceecc8c565e81139ed1d4b0"
+source = "git+https://github.com/gfx-rs/naga?rev=a45b9a6#a45b9a6cc691a671aa24a32114b51c5acae02420"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2749,8 +2739,7 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
+source = "git+https://github.com/gfx-rs/wgpu#0ac9ce002656565ccd05b889f5856f4e2c38fa73"
 dependencies = [
  "arrayvec",
  "js-sys",
@@ -2770,8 +2759,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659a371d93a66fd0c15f0a5a730d0877416c82e0c539fd46741673a49f02afad"
+source = "git+https://github.com/gfx-rs/wgpu#0ac9ce002656565ccd05b889f5856f4e2c38fa73"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -2793,11 +2781,10 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abbd51f4f3d61db9c02dd776f643437823b6fa85e8642b4bb6d278b74335fc1"
+source = "git+https://github.com/gfx-rs/wgpu#0ac9ce002656565ccd05b889f5856f4e2c38fa73"
 dependencies = [
  "arrayvec",
- "ash 0.33.3+1.2.191",
+ "ash",
  "bit-set",
  "bitflags",
  "block",
@@ -2831,8 +2818,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
+source = "git+https://github.com/gfx-rs/wgpu#0ac9ce002656565ccd05b889f5856f4e2c38fa73"
 dependencies = [
  "bitflags",
 ]

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -19,7 +19,8 @@ use-compiled-tools = ["spirv-builder/use-compiled-tools"]
 cfg-if = "1.0.0"
 shared = { path = "../../shaders/shared" }
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
-wgpu = { version = "0.12", features = ["spirv"] }
+# Vulkan SDK or MoltenVK needs to be installed for `vulkan-portability` to work on macOS
+wgpu = { git = "https://github.com/gfx-rs/wgpu", features = ["spirv", "vulkan-portability"] }
 winit = { version = "0.26" }
 structopt = "0.3"
 strum = { version = "0.23.0", default_features = false, features = ["std", "derive"] }


### PR DESCRIPTION
Metal doesn't support SPIR-V shader passthrough, so on macOS using WGPU runner you get following error with any example:

```
Features SPIRV_SHADER_PASSTHROUGH are required but not enabled on the device
```

Vulkan supports shader passthrough, but requires compatibility layer of MoltenVK to work, which needs to be installed on the host machine. Currently this feature is only available on master.