### PR TITLE
Remove SPIRV_SHADER_PASSTHROUGH for wgpu example on Mac

### DIFF
--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -22,7 +22,7 @@ pub fn start(options: &Options) {
 
 pub async fn start_internal(
     _options: &Options,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'static>,
+    shader_binary: wgpu::ShaderModuleDescriptor<'static>,
 ) {
     let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
     let adapter = instance
@@ -38,8 +38,7 @@ pub async fn start_internal(
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: None,
-                features: wgpu::Features::TIMESTAMP_QUERY
-                    | wgpu::Features::SPIRV_SHADER_PASSTHROUGH,
+                features: wgpu::Features::TIMESTAMP_QUERY,
                 limits: wgpu::Limits::default(),
             },
             None,
@@ -52,7 +51,7 @@ pub async fn start_internal(
     let timestamp_period = queue.get_timestamp_period();
 
     // Load the shaders from disk
-    let module = unsafe { device.create_shader_module_spirv(&shader_binary) };
+    let module = device.create_shader_module(&shader_binary);
 
     let top = 2u32.pow(20);
     let src_range = 1..top;

--- a/examples/runners/wgpu/src/graphics.rs
+++ b/examples/runners/wgpu/src/graphics.rs
@@ -33,9 +33,9 @@ fn mouse_button_index(button: MouseButton) -> usize {
 }
 
 async fn run(
-    event_loop: EventLoop<wgpu::ShaderModuleDescriptorSpirV<'static>>,
+    event_loop: EventLoop<wgpu::ShaderModuleDescriptor<'static>>,
     window: Window,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'static>,
+    shader_binary: wgpu::ShaderModuleDescriptor<'static>,
 ) {
     let instance = wgpu::Instance::new(wgpu::Backends::VULKAN | wgpu::Backends::METAL);
 
@@ -57,7 +57,7 @@ async fn run(
         .await
         .expect("Failed to find an appropriate adapter");
 
-    let features = wgpu::Features::PUSH_CONSTANTS | wgpu::Features::SPIRV_SHADER_PASSTHROUGH;
+    let features = wgpu::Features::PUSH_CONSTANTS;
     let limits = wgpu::Limits {
         max_push_constant_size: 256,
         ..Default::default()
@@ -82,7 +82,7 @@ async fn run(
         label: None,
         bind_group_layouts: &[],
         push_constant_ranges: &[wgpu::PushConstantRange {
-            stages: wgpu::ShaderStages::all(),
+            stages: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
             range: 0..std::mem::size_of::<ShaderConstants>() as u32,
         }],
     });
@@ -214,7 +214,7 @@ async fn run(
 
                         rpass.set_pipeline(render_pipeline);
                         rpass.set_push_constants(
-                            wgpu::ShaderStages::all(),
+                            wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                             0,
                             bytemuck::bytes_of(&push_constants),
                         );
@@ -284,9 +284,9 @@ fn create_pipeline(
     device: &wgpu::Device,
     pipeline_layout: &wgpu::PipelineLayout,
     surface_format: wgpu::TextureFormat,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'_>,
+    shader_binary: wgpu::ShaderModuleDescriptor<'_>,
 ) -> wgpu::RenderPipeline {
-    let module = unsafe { device.create_shader_module_spirv(&shader_binary) };
+    let module = device.create_shader_module(&shader_binary);
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,
         layout: Some(pipeline_layout),

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -86,8 +86,8 @@ pub enum RustGPUShader {
 
 fn maybe_watch(
     shader: RustGPUShader,
-    on_watch: Option<Box<dyn FnMut(wgpu::ShaderModuleDescriptorSpirV<'static>) + Send + 'static>>,
-) -> wgpu::ShaderModuleDescriptorSpirV<'static> {
+    on_watch: Option<Box<dyn FnMut(wgpu::ShaderModuleDescriptor<'static>) + Send + 'static>>,
+) -> wgpu::ShaderModuleDescriptor<'static> {
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
         use spirv_builder::{CompileResult, MetadataPrintout, SpirvBuilder};
@@ -123,13 +123,13 @@ fn maybe_watch(
         };
         fn handle_compile_result(
             compile_result: CompileResult,
-        ) -> wgpu::ShaderModuleDescriptorSpirV<'static> {
+        ) -> wgpu::ShaderModuleDescriptor<'static> {
             let module_path = compile_result.module.unwrap_single();
             let data = std::fs::read(module_path).unwrap();
             let spirv = Cow::Owned(wgpu::util::make_spirv_raw(&data).into_owned());
-            wgpu::ShaderModuleDescriptorSpirV {
+            wgpu::ShaderModuleDescriptor {
                 label: None,
-                source: spirv,
+                source: wgpu::ShaderSource::SpirV(spirv),
             }
         }
         handle_compile_result(initial_result)

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -137,10 +137,10 @@ fn maybe_watch(
     #[cfg(any(target_os = "android", target_arch = "wasm32"))]
     {
         match shader {
-            RustGPUShader::Simplest => wgpu::include_spirv_raw!(env!("simplest_shader.spv")),
-            RustGPUShader::Sky => wgpu::include_spirv_raw!(env!("sky_shader.spv")),
-            RustGPUShader::Compute => wgpu::include_spirv_raw!(env!("compute_shader.spv")),
-            RustGPUShader::Mouse => wgpu::include_spirv_raw!(env!("mouse_shader.spv")),
+            RustGPUShader::Simplest => wgpu::include_spirv!(env!("simplest_shader.spv")),
+            RustGPUShader::Sky => wgpu::include_spirv!(env!("sky_shader.spv")),
+            RustGPUShader::Compute => wgpu::include_spirv!(env!("compute_shader.spv")),
+            RustGPUShader::Mouse => wgpu::include_spirv!(env!("mouse_shader.spv")),
         }
     }
 }


### PR DESCRIPTION
I removed the use of SPIRV_SHADER_PASSTHROUGH feature because it is not supported on mac.

PRO:
  -  Run WGPU example on Mac without Vulkan SDK(2GB-ish)
  -  No use of `unsafe`

CON:
  - Removing SPIRV_SHADER_PASSTHROUGH might make loading SPIR-V slightly slower on Vulkan supported OS, but I have not confirmed this
  
TEST:
  - `cargo run` in /examples/runners/wgpu and got sky to show up after deleting Vulkan SDK directory

NOTE: 
  - [wgpu::Features::TIMESTAMP_QUERY](https://wgpu.rs/doc/wgpu/struct.Features.html#associatedconstant.TIMESTAMP_QUERY) is required for compute shader, so Vulkan SDK installation is still necessary if mac users want to try compute shader.
  - Due to compute shader still requiring Vulkan SDK, `"vulkan-portability"` feature is not removed.
  

  
Related MR: 
https://github.com/EmbarkStudios/rust-gpu/pull/852