### PR TITLE
default.nix: handle nixpkgs alias removal (x11 -> xlibsWrapper, xlibs -> xorg).

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,11 +10,11 @@ in with pkgs; stdenv.mkDerivation rec {
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   buildInputs = [
-    pkgconfig rustup x11 libxkbcommon
+    pkgconfig rustup xlibsWrapper libxkbcommon
   ];
 
   # Runtime dependencies.
-  LD_LIBRARY_PATH = with xlibs; lib.makeLibraryPath [
+  LD_LIBRARY_PATH = with xorg; lib.makeLibraryPath [
     libX11 libXcursor libXi libXrandr vulkan-loader
   ];
 }


### PR DESCRIPTION
Turns out two names I used were already aliases, by the time I wrote this `default.nix` (oops), and https://github.com/NixOS/nixpkgs/pull/161146 removed them. I've replaced them with the "new" names (almost 3 years old by now).