### PR TITLE
Split out a new `-types` crate so `spirv-builder` stops loading LLVM via dylibs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,7 @@ dependencies = [
  "pretty_assertions",
  "rspirv",
  "rustc-demangle",
+ "rustc_codegen_spirv-types",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -2013,6 +2014,14 @@ dependencies = [
  "spirv-tools",
  "syn",
  "tempfile",
+]
+
+[[package]]
+name = "rustc_codegen_spirv-types"
+version = "0.4.0-alpha.12"
+dependencies = [
+ "rspirv",
+ "serde",
 ]
 
 [[package]]
@@ -2223,6 +2232,7 @@ dependencies = [
  "notify",
  "raw-string",
  "rustc_codegen_spirv",
+ "rustc_codegen_spirv-types",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "examples/multibuilder",
 
     "crates/rustc_codegen_spirv",
+    "crates/rustc_codegen_spirv-types",
     "crates/spirv-builder",
     "crates/spirv-std",
     "crates/spirv-std/shared",

--- a/crates/rustc_codegen_spirv-types/Cargo.toml
+++ b/crates/rustc_codegen_spirv-types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rustc_codegen_spirv-types"
+description = "SPIR-V backend types shared between rustc_codegen_spirv and spirv-builder"
+version = "0.4.0-alpha.12"
+authors = ["Embark <opensource@embark-studios.com>"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/EmbarkStudios/rust-gpu"
+
+[dependencies]
+rspirv = "0.11"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/rustc_codegen_spirv-types/src/compile_result.rs
+++ b/crates/rustc_codegen_spirv-types/src/compile_result.rs
@@ -1,5 +1,5 @@
-use rustc_data_structures::fx::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 #[serde(untagged)]
 pub enum ModuleResult {
     SingleModule(PathBuf),
-    MultiModule(FxHashMap<String, PathBuf>),
+    MultiModule(BTreeMap<String, PathBuf>),
 }
 
 impl ModuleResult {
@@ -20,7 +20,7 @@ impl ModuleResult {
         }
     }
 
-    pub fn unwrap_multi(&self) -> &FxHashMap<String, PathBuf> {
+    pub fn unwrap_multi(&self) -> &BTreeMap<String, PathBuf> {
         match self {
             ModuleResult::MultiModule(result) => result,
             ModuleResult::SingleModule(_) => {
@@ -46,28 +46,24 @@ impl CompileResult {
 }
 
 #[derive(Default)]
-struct Trie {
+struct Trie<'a> {
     present: bool,
-    children: FxHashMap<String, Box<Trie>>,
+    children: BTreeMap<&'a str, Trie<'a>>,
 }
 
-impl Trie {
-    fn create_from<'a>(entry_points: impl IntoIterator<Item = &'a str>) -> Self {
+impl<'a> Trie<'a> {
+    fn create_from(entry_points: impl IntoIterator<Item = &'a str>) -> Self {
         let mut result = Trie::default();
         for entry in entry_points {
-            result.insert(entry.split("::").map(|x| x.to_owned()));
+            result.insert(entry.split("::"));
         }
         result
     }
 
-    fn insert(&mut self, mut sequence: impl Iterator<Item = String>) {
+    fn insert(&mut self, mut sequence: impl Iterator<Item = &'a str>) {
         match sequence.next() {
             None => self.present = true,
-            Some(next) => self
-                .children
-                .entry(next)
-                .or_insert_with(Default::default)
-                .insert(sequence),
+            Some(next) => self.children.entry(next).or_default().insert(sequence),
         }
     }
 

--- a/crates/rustc_codegen_spirv-types/src/lib.rs
+++ b/crates/rustc_codegen_spirv-types/src/lib.rs
@@ -1,0 +1,6 @@
+//! Types used by both `rustc_codegen_spirv` and `spirv-builder`.
+
+pub use rspirv::spirv::Capability;
+
+mod compile_result;
+pub use compile_result::*;

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"
 spirv-tools = { version = "0.8", default-features = false }
+rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.12" }
 
 [dev-dependencies]
 pipe = "0.4"

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -137,7 +137,6 @@ mod attr;
 mod builder;
 mod builder_spirv;
 mod codegen_cx;
-mod compile_result;
 mod decorations;
 mod link;
 mod linker;
@@ -149,8 +148,6 @@ mod target_feature;
 
 use builder::Builder;
 use codegen_cx::CodegenCx;
-pub use compile_result::*;
-pub use rspirv;
 use rspirv::binary::Assemble;
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_codegen_ssa::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -17,6 +17,7 @@ memchr = "2.4"
 raw-string = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types" }
 # See comment in lib.rs invoke_rustc for why this is here
 rustc_codegen_spirv = { path = "../rustc_codegen_spirv", default-features = false }
 

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -86,8 +86,8 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-pub use rustc_codegen_spirv::rspirv::spirv::Capability;
-pub use rustc_codegen_spirv::{CompileResult, ModuleResult};
+pub use rustc_codegen_spirv_types::Capability;
+pub use rustc_codegen_spirv_types::{CompileResult, ModuleResult};
 
 #[derive(Debug)]
 #[non_exhaustive]

--- a/crates/spirv-builder/src/watch.rs
+++ b/crates/spirv-builder/src/watch.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, sync::mpsc::sync_channel};
 
 use notify::{Event, RecursiveMode, Watcher};
-use rustc_codegen_spirv::CompileResult;
+use rustc_codegen_spirv_types::CompileResult;
 
 use crate::{leaf_deps, SpirvBuilder, SpirvBuilderError};
 

--- a/examples/runners/wgpu/src/graphics.rs
+++ b/examples/runners/wgpu/src/graphics.rs
@@ -59,7 +59,7 @@ async fn run(
 
     let features = wgpu::Features::PUSH_CONSTANTS | wgpu::Features::SPIRV_SHADER_PASSTHROUGH;
     let limits = wgpu::Limits {
-        max_push_constant_size: 256,
+        max_push_constant_size: 128,
         ..Default::default()
     };
 


### PR DESCRIPTION
Before this PR, `spirv-builder` depended on `rustc_codegen_spirv` not just in `Cargo.toml`, but also used some of its exports, which meant `rustc` was linking anything using `spirv-builder` (such as our example runners, that support hot reloading) against `librustc_codegen_spirv.so`.

The problem with that is that kind of dylib dependency is `rustc_codegen_spirv` depends on `rustc_driver` which depends on `rustc_codegen_llvm` which links (statically or dynamically) against LLVM, so LLVM's global ctors run.

And then the Vulkan driver *also* gets loaded, and if it uses LLVM, it will *also* run LLVM global ctors.
Depending on dynamic linking/loading semantics, the LLVMs may get partially deduplicated and conflicts occur:
```
: CommandLine Error: Option 'use-dbg-addr' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```

This problem is the same as the one mentioned in [the recent blog post on Mesa's NIR](https://www.jlekstrand.net/jason/blog/2022/01/in-defense-of-nir/):
> Third is that some games actually link against LLVM and, historically, LLVM hasn’t done well with two different versions of it loaded at the same time. Some of this is LLVM and some of it is the way C++ shared library loading is handled on Linux.

<hr>

This PR moves the couple definitions `spirv-builder` needs, out of `rustc_codegen_spirv`, and into a new `rustc_codegen_spirv-types` crate. That allows to avoid linking against any dylibs that would bring LLVM in.

That makes `example-runner-wgpu` work again on Mesa's AMD Radeon Vulkan (RADV) driver, on Mesa 21.3.7 (though I am not entirely sure if the original breaking change was in Mesa, distro packaging, or `spirv-builder`).

Also, for the GPU I was testing with (reported by RADV as "FIJI"), I've had to also drive-by halving of `max_push_constant_size`, to match the `maxPushConstantsSize = 128` reported by the driver.