### PR TITLE
Switch `rustc_codegen_spirv` to static lib

### DIFF
--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -9,9 +9,6 @@ repository = "https://github.com/EmbarkStudios/rust-gpu"
 #categories = []
 #readme = "README.md"
 
-[lib]
-crate-type = ["dylib"]
-
 [features]
 # By default, the use-compiled-tools is enabled, as doesn't require additional
 # setup steps for the user. This does however mean that you will need to disable


### PR DESCRIPTION
Was set as a `dylib` but not really sure why. Having it as a static library enables dependencies, like `spriv-builder`, to start building directly after the frontend section of the build of the crate is done. Rather than having to wait for the codegen as well.

Saw clean ´spirv-builder` build times go from 46.3 -> 45.8 seconds with this. Have seen bigger benefits when combined with other optimizations as well (example: https://github.com/EmbarkStudios/rust-gpu/issues/858#issuecomment-1094259795)

Part of #858
