### PR TITLE
Fix CODEOWNERS issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/crates/ @eddyb
+* @eddyb
 
-/examples/ @termhn @VZout
+/examples/ @fu5ha @VZout


### PR DESCRIPTION
Fixes two issues with the configuration:
- @fu5ha wasn't getting review request due to user name rename.
- Our [Embark Open Source Tool project checker](https://github.com/EmbarkStudios/opensource/tree/main/src) that validates our projects have maintainers assigned categorized this as not fully maintained as didn't have a root owner `*`, @eddyb I made this you right now instead of just for `/crates/`. But we can tweak that going forward also. But this will keep our Slack bot happy