### PR TITLE
Upgrade SPIRV-Tools prebuild to 2022-04-14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
             target: aarch64-linux-android
     runs-on: ${{ matrix.os }}
     env:
-      spirv_tools_version: "20210805"
+      spirv_tools_version: "20220414" # get platform-specific download link from https://github.com/KhronosGroup/SPIRV-Tools/blob/master/docs/downloads.md
       RUSTUP_UNPACK_RAM: "26214400"
       RUSTUP_IO_THREADS: "1"
     steps:
@@ -33,8 +33,8 @@ jobs:
         name: Linux - Install native dependencies
         run: |
           sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
-          mkdir "${HOME}/spirv-tools"
-          curl -fL https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/linux-clang-release/continuous/1530/20210805-040049/install.tgz | tar -xz -C "${HOME}/spirv-tools"
+          mkdir "${HOME}/spirv-tools"          
+          curl -fL https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/linux-clang-release/continuous/1744/20220414-060821/install.tgz | tar -xz -C "${HOME}/spirv-tools"
           echo "${HOME}/spirv-tools/install/bin" >> $GITHUB_PATH
       - if: ${{ runner.os == 'macOS' }}
         name: Mac - Install spirv-tools
@@ -47,7 +47,7 @@ jobs:
         run: |
           tmparch=$(mktemp)
           mkdir "${HOME}/spirv-tools"
-          curl -fL -o "$tmparch" https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/windows-msvc-2017-release/continuous/1517/20210805-040116/install.zip
+          curl -fL -o "$tmparch" https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/windows-msvc-2017-release/continuous/1732/20220414-060824/install.zip
           unzip "$tmparch" -d "${HOME}/spirv-tools"
       - if: ${{ runner.os == 'Windows' }}
         # Runs separately to add spir-v tools to Powershell's Path.

--- a/tests/ui/image/sample_depth_reference/sample_gradient.rs
+++ b/tests/ui/image/sample_depth_reference/sample_gradient.rs
@@ -8,16 +8,34 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled),
     #[spirv(descriptor_set = 1, binding = 1)] image_array: &Image!(2D, type=f32, arrayed, sampled),
     #[spirv(descriptor_set = 2, binding = 2)] sampler: &Sampler,
-    #[spirv(descriptor_set = 3, binding = 3)] cubemap: &Image!(3D, type=f32, sampled),
     output: &mut f32,
 ) {
     let v2 = glam::Vec2::new(0.0, 1.0);
     let v2_dx = glam::Vec2::new(0.0, 1.0);
     let v2_dy = glam::Vec2::new(0.0, 1.0);
     let v3 = glam::Vec3A::new(0.0, 0.0, 1.0);
-    let v3_dx = glam::Vec3A::new(0.0, 1.0, 0.5);
-    let v3_dy = glam::Vec3A::new(0.0, 1.0, 0.5);
     *output = image.sample_depth_reference_by_gradient(*sampler, v2, 1.0, v2_dx, v2_dy);
     *output += image_array.sample_depth_reference_by_gradient(*sampler, v3, 1.0, v2_dx, v2_dy);
+}
+
+// NOTE(eddyb) this is separate because it runs afoul of this rule:
+// > VUID-StandaloneSpirv-OpImage-04777
+// > `OpImage*Dref*` instructions **must** not consume an image whose `Dim` is 3D
+// FIXME(eddyb) look into whether non-Vulkan `OpImage*Dref*` usage can ever be 3D
+#[cfg(not(any(
+    target_env = "vulkan1.0",
+    target_env = "vulkan1.1",
+    target_env = "vulkan1.1spv1.4",
+    target_env = "vulkan1.2"
+)))]
+#[spirv(fragment)]
+pub fn main_cubemap(
+    #[spirv(descriptor_set = 2, binding = 2)] sampler: &Sampler,
+    #[spirv(descriptor_set = 3, binding = 3)] cubemap: &Image!(3D, type=f32, sampled),
+    output: &mut f32,
+) {
+    let v3 = glam::Vec3A::new(0.0, 0.0, 1.0);
+    let v3_dx = glam::Vec3A::new(0.0, 1.0, 0.5);
+    let v3_dy = glam::Vec3A::new(0.0, 1.0, 0.5);
     *output += cubemap.sample_depth_reference_by_gradient(*sampler, v3, 1.0, v3_dx, v3_dy);
 }

--- a/tests/ui/image/sample_depth_reference/sample_lod.rs
+++ b/tests/ui/image/sample_depth_reference/sample_lod.rs
@@ -8,12 +8,30 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled),
     #[spirv(descriptor_set = 1, binding = 1)] image_array: &Image!(2D, type=f32, arrayed, sampled),
     #[spirv(descriptor_set = 2, binding = 2)] sampler: &Sampler,
-    #[spirv(descriptor_set = 3, binding = 3)] cubemap: &Image!(3D, type=f32, sampled),
     output: &mut f32,
 ) {
     let v2 = glam::Vec2::new(0.0, 1.0);
     let v3 = glam::Vec3A::new(0.0, 0.0, 1.0);
     *output = image.sample_depth_reference_by_lod(*sampler, v2, 1.0, 0.0);
     *output += image_array.sample_depth_reference_by_lod(*sampler, v3, 1.0, 0.0);
+}
+
+// NOTE(eddyb) this is separate because it runs afoul of this rule:
+// > VUID-StandaloneSpirv-OpImage-04777
+// > `OpImage*Dref*` instructions **must** not consume an image whose `Dim` is 3D
+// FIXME(eddyb) look into whether non-Vulkan `OpImage*Dref*` usage can ever be 3D
+#[cfg(not(any(
+    target_env = "vulkan1.0",
+    target_env = "vulkan1.1",
+    target_env = "vulkan1.1spv1.4",
+    target_env = "vulkan1.2"
+)))]
+#[spirv(fragment)]
+pub fn main_cubemap(
+    #[spirv(descriptor_set = 2, binding = 2)] sampler: &Sampler,
+    #[spirv(descriptor_set = 3, binding = 3)] cubemap: &Image!(3D, type=f32, sampled),
+    output: &mut f32,
+) {
+    let v3 = glam::Vec3A::new(0.0, 0.0, 1.0);
     *output += cubemap.sample_depth_reference_by_lod(*sampler, v3, 1.0, 0.0);
 }


### PR DESCRIPTION
For Linux and Windows, Mac CI uses latest installed from `brew`

Also added comment about how/where to get the download link for next upgrade.

Resolves: #866
