### PR TITLE
examples: fix pipeline layout in compute runner

### DIFF
--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -2,7 +2,7 @@ use wgpu::util::DeviceExt;
 
 use super::Options;
 use futures::future::join;
-use std::{convert::TryInto, future::Future, num::NonZeroU64, time::Duration};
+use std::{convert::TryInto, future::Future, time::Duration};
 
 fn block_on<T>(future: impl Future<Output = T>) -> T {
     cfg_if::cfg_if! {
@@ -64,15 +64,13 @@ pub async fn start_internal(
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: None,
         entries: &[
-            // XXX - some graphics cards do not support empty bind layout groups, so
-            // create a dummy entry.
             wgpu::BindGroupLayoutEntry {
                 binding: 0,
                 count: None,
                 visibility: wgpu::ShaderStages::COMPUTE,
                 ty: wgpu::BindingType::Buffer {
                     has_dynamic_offset: false,
-                    min_binding_size: Some(NonZeroU64::new(1).unwrap()),
+                    min_binding_size: None,
                     ty: wgpu::BufferBindingType::Storage { read_only: false },
                 },
             },

--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -63,18 +63,16 @@ pub async fn start_internal(
 
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: None,
-        entries: &[
-            wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                count: None,
-                visibility: wgpu::ShaderStages::COMPUTE,
-                ty: wgpu::BindingType::Buffer {
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                    ty: wgpu::BufferBindingType::Storage { read_only: false },
-                },
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            count: None,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                has_dynamic_offset: false,
+                min_binding_size: None,
+                ty: wgpu::BufferBindingType::Storage { read_only: false },
             },
-        ],
+        }],
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {


### PR DESCRIPTION
(Remove the outdated comment which refered to the prior empty compute shader and doesn't apply anymore as the current example takes one buffer descriptor.)

The motivation behind `min_binding_size` is not totally clear to me but seems to involve the buffer size bound to the descriptor. Two options appear valid here:
- `None`: defers the wgpu check to runtime and it will internally validate that the bound buffer matches the shader interface.
- `Some(n * sizeof::<u32>())`: It needs to be able to hold at least one element ([u32] buffer) -> `Some(NonZeroU64::new(4).unwrap())` at least

Both approaches work fine locally but the `None` case seems less of a hassle