### PR TITLE
Support 'threads' with 'mesh_nv' and 'task_nv'

### DIFF
--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -651,7 +651,7 @@ fn parse_entry_attrs(
                 .execution_modes
                 .push((origin_mode, ExecutionModeExtra::new([])));
         }
-        GLCompute => {
+        GLCompute | MeshNV | TaskNV => {
             if let Some(local_size) = local_size {
                 entry
                     .execution_modes
@@ -660,7 +660,7 @@ fn parse_entry_attrs(
                 return Err((
                     arg.span(),
                     String::from(
-                        "The `threads` argument must be specified when using `#[spirv(compute)]`",
+                        "The `threads` argument must be specified when using `#[spirv(compute)]`, '#[spirv(mesh_nv)]' or '#[spirv(task_nv)]'",
                     ),
                 ));
             }

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -660,7 +660,7 @@ fn parse_entry_attrs(
                 return Err((
                     arg.span(),
                     String::from(
-                        "The `threads` argument must be specified when using `#[spirv(compute)]`, '#[spirv(mesh_nv)]' or '#[spirv(task_nv)]'",
+                        "The `threads` argument must be specified when using `#[spirv(compute)]`, `#[spirv(mesh_nv)]` or `#[spirv(task_nv)]`",
                     ),
                 ));
             }


### PR DESCRIPTION
```threads(...)``` is currently only supported for ```compute``` shaders and is ignored in ```mesh_nv``` & ```task_nv``` shaders. I added support for it to work correctly, my simple mesh shader runs now.

Also discussed here #869 