### PR TITLE
Add support for zero sized types as struct fields

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -412,6 +412,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             if field_ty_kind
                                 .sizeof(self)
                                 .map_or(true, |size| offset_in_field < size)
+                                // If the field is a zero sized type, check the type to
+                                // get the correct entry
+                                || offset_in_field == Size::ZERO && leaf_ty == field_ty
                             {
                                 Some((i, field_ty, field_ty_kind, offset_in_field))
                             } else {

--- a/tests/ui/lang/core/ref/zst_member_ref_arg.rs
+++ b/tests/ui/lang/core/ref/zst_member_ref_arg.rs
@@ -1,0 +1,18 @@
+// build-pass
+
+use spirv_std as _;
+struct A;
+struct B;
+
+struct S {
+    x: A,
+    y: B,
+}
+
+fn f(x: &B) {}
+
+#[spirv(fragment)]
+pub fn main() {
+    let s = S { x: A, y: B };
+    f(&s.y);
+}


### PR DESCRIPTION
Fixes `Cannot cast between pointers`_error caused by zero sized types
[Discussion in the #rust-gpu channel](https://discord.com/channels/750717012564770887/750717499737243679/967770208418799686)