### PR TITLE
Added version tags to some crates referencing rustc_codegen_spirv

### DIFF
--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -17,8 +17,8 @@ memchr = "2.4"
 raw-string = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types" }
+rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.12" }
 # See comment in lib.rs invoke_rustc for why this is here
-rustc_codegen_spirv = { path = "../rustc_codegen_spirv", default-features = false }
+rustc_codegen_spirv = { path = "../rustc_codegen_spirv", version = "0.4.0-alpha.12", default-features = false }
 
 notify = { version = "5.0.0-pre.11", optional = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,5 +14,5 @@ use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
 
 [dependencies]
 compiletest = { version = "0.7.0", package = "compiletest_rs" }
-rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", default-features = false }
+rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", version = "0.4.0-alpha.12", default-features = false }
 structopt = "0.3.21"


### PR DESCRIPTION
Some lingering dependencies to `rustc_codegen_spirv` that don't use the version number. `cargo-release` complains about this.