### PR TITLE
Update `crossbeam-utils` v0.8.5 -> v0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,12 +518,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]


### PR DESCRIPTION
Just updates the lockfile. `cargo deny` was locally failing for me with the previous version that had https://rustsec.org/advisories/RUSTSEC-2022-0041 filed on it.

Odd that `cargo deny` CI step was not failing on it
