### PR TITLE
Update to 0.4.0-alpha.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "compiletests"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "compiletest_rs",
  "rustc_codegen_spirv",
@@ -352,14 +352,14 @@ dependencies = [
 
 [[package]]
 name = "compiletests-deps-helper"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "spirv-std",
 ]
 
 [[package]]
 name = "compute-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "rayon",
  "spirv-std",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-ash"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "ash",
  "ash-molten",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-cpu"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "minifb",
  "rayon",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-wgpu"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if 1.0.0",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "example-runner-wgpu-builder"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "spirv-builder",
 ]
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "mouse-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "shared",
  "spirv-std",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "multibuilder"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "spirv-builder",
 ]
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "reduce"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "spirv-std",
 ]
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "bytemuck",
  "spirv-std",
@@ -2160,7 +2160,7 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simplest-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "shared",
  "spirv-std",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "sky-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 dependencies = [
  "shared",
  "spirv-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 dependencies = [
  "ar",
  "bimap",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "rustc_codegen_spirv-types"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 dependencies = [
  "rspirv",
  "serde",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-builder"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 dependencies = [
  "memchr",
  "notify",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 dependencies = [
  "bitflags",
  "glam",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-types"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 
 [[package]]
 name = "spirv-tools"

--- a/crates/rustc_codegen_spirv-types/Cargo.toml
+++ b/crates/rustc_codegen_spirv-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc_codegen_spirv-types"
 description = "SPIR-V backend types shared between rustc_codegen_spirv and spirv-builder"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"
 spirv-tools = { version = "0.8", default-features = false }
-rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.13" }
+rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.14" }
 
 [dev-dependencies]
 pipe = "0.4"

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-builder"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -19,8 +19,8 @@ memchr = "2.4"
 raw-string = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.13" }
+rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.14" }
 # See comment in lib.rs invoke_rustc for why this is here
-rustc_codegen_spirv = { path = "../rustc_codegen_spirv", version = "0.4.0-alpha.13", default-features = false }
+rustc_codegen_spirv = { path = "../rustc_codegen_spirv", version = "0.4.0-alpha.14", default-features = false }
 
 notify = { version = "5.0.0-pre.11", optional = true }

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "Standard functions and types for SPIR-V"
 [dependencies]
 bitflags = "1.2.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
-spirv-std-types = { path = "./shared", version = "0.4.0-alpha.13" }
+spirv-std-types = { path = "./shared", version = "0.4.0-alpha.14" }
 spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.13" }
 glam = { version = ">=0.17, <=0.21", default-features = false, features = ["libm"], optional = true }
 

--- a/crates/spirv-std/macros/Cargo.toml
+++ b/crates/spirv-std/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ description = "Macros for spirv-std"
 proc-macro = true
 
 [dependencies]
-spirv-std-types = { path = "../shared", version = "0.4.0-alpha.13" }
+spirv-std-types = { path = "../shared", version = "0.4.0-alpha.14" }
 proc-macro2 = "1.0.24"
 quote = "1.0.8"
 syn = { version = "1.0.58", features=["full"] }

--- a/crates/spirv-std/shared/Cargo.toml
+++ b/crates/spirv-std/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spirv-std-types"
 description = "SPIR-V types shared between spirv-std and spirv-std-macros"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -36,11 +36,11 @@ skip = [
 # by default infinite
 skip-tree = [
     # we don't really care if our example brings in some duplicate dependencies, for now
-    { name = "example-runner-ash", version = "0.4.0-alpha.13", depth = 20 },
-    { name = "example-runner-cpu", version = "0.4.0-alpha.13", depth = 20 },
-    { name = "example-runner-wgpu", version = "0.4.0-alpha.13", depth = 20 },
-    { name = "compiletests", version = "0.4.0-alpha.13", depth = 20 },
-    { name = "compiletests-deps-helper", version = "0.4.0-alpha.13", depth = 20 },
+    { name = "example-runner-ash", version = "0.0.0", depth = 20 },
+    { name = "example-runner-cpu", version = "0.0.0", depth = 20 },
+    { name = "example-runner-wgpu", version = "0.0.0", depth = 20 },
+    { name = "compiletests", version = "0.0.0", depth = 20 },
+    { name = "compiletests-deps-helper", version = "0.0.0", depth = 20 },
 ]
 
 

--- a/examples/multibuilder/Cargo.toml
+++ b/examples/multibuilder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multibuilder"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-ash"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/cpu/Cargo.toml
+++ b/examples/runners/cpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-cpu"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-wgpu"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/runners/wgpu/builder/Cargo.toml
+++ b/examples/runners/wgpu/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-runner-wgpu-builder"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/compute-shader/Cargo.toml
+++ b/examples/shaders/compute-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/mouse-shader/Cargo.toml
+++ b/examples/shaders/mouse-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mouse-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/reduce/Cargo.toml
+++ b/examples/shaders/reduce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduce"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/shared/Cargo.toml
+++ b/examples/shaders/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/simplest-shader/Cargo.toml
+++ b/examples/shaders/simplest-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplest-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/shaders/sky-shader/Cargo.toml
+++ b/examples/shaders/sky-shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky-shader"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletests"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,5 +14,5 @@ use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
 
 [dependencies]
 compiletest = { version = "0.7.0", package = "compiletest_rs" }
-rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", version = "0.4.0-alpha.13", default-features = false }
+rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", version = "0.4.0-alpha.14", default-features = false }
 structopt = "0.3.21"

--- a/tests/deps-helper/Cargo.toml
+++ b/tests/deps-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletests-deps-helper"
-version = "0.4.0-alpha.13"
+version = "0.0.0"
 description = "Shared dependencies of all the compiletest tests"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"


### PR DESCRIPTION
Now that`spirv-std` has been renamed to `spirv-std-types`, we can bump the version to 0.4.0-alpha.14