### PR TITLE
Update to nightly-2022-07-04

### DIFF
--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -464,7 +464,7 @@ impl<'tcx> Visitor<'tcx> for CheckSpirvAttrVisitor<'tcx> {
 
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         let target = match expr.kind {
-            hir::ExprKind::Closure(..) => Target::Closure,
+            hir::ExprKind::Closure { .. } => Target::Closure,
             _ => Target::Expression,
         };
 

--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -358,6 +358,15 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
         todo!()
     }
 
+    fn type_checked_load(
+        &mut self,
+        _llvtable: Self::Value,
+        _vtable_byte_offset: u64,
+        _typeid: Self::Value,
+    ) -> Self::Value {
+        todo!()
+    }
+
     fn va_start(&mut self, _val: Self::Value) -> Self::Value {
         todo!()
     }

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -207,7 +207,7 @@ impl CodegenBackend for SpirvCodegenBackend {
                 .parse::<target::SpirvTarget>()
                 .map(|target| target.rustc_target())
                 .ok(),
-            TargetTriple::TargetPath(_) => None,
+            TargetTriple::TargetJson { .. } => None,
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -12,8 +12,7 @@ use rustc_target::abi::{Align, Size};
 use std::cell::RefCell;
 use std::fmt;
 use std::iter;
-use std::lazy::SyncLazy;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 /// Spir-v types are represented as simple Words, which are the `result_id` of instructions like
 /// `OpTypeInteger`. Sometimes, however, we want to inspect one of these Words and ask questions
@@ -403,7 +402,7 @@ pub struct SpirvTypePrinter<'cx, 'tcx> {
 /// track of a stack of what types are currently being printed, to not infinitely loop.
 /// Unfortunately, unlike `fmt::Display`, we can't easily pass down the "stack" of
 /// currently-being-printed types, so we use a global static.
-static DEBUG_STACK: SyncLazy<Mutex<Vec<Word>>> = SyncLazy::new(|| Mutex::new(Vec::new()));
+static DEBUG_STACK: LazyLock<Mutex<Vec<Word>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
 impl fmt::Debug for SpirvTypePrinter<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -188,6 +188,7 @@ pub unsafe fn read_clock_uvec2_khr<V: Vector<u32, 2>, const SCOPE: u32>() -> V {
 }
 
 #[spirv_std_macros::gpu_only]
+#[allow(dead_code)]
 unsafe fn call_glsl_op_with_ints<T: Integer, const OP: u32>(a: T, b: T) -> T {
     let mut result = T::default();
     asm!(

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -3,13 +3,13 @@
 //! This module is intended as a low level abstraction over SPIR-V instructions.
 //! These functions will typically map to a single instruction, and will perform
 //! no additional safety checks beyond type-checking.
+#[cfg(target_arch = "spirv")]
+use crate::integer::Integer;
 use crate::{
     integer::{SignedInteger, UnsignedInteger},
     scalar::Scalar,
     vector::Vector,
 };
-#[cfg(target_arch = "spirv")]
-use crate::integer::Integer;
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
 

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -4,7 +4,7 @@
 //! These functions will typically map to a single instruction, and will perform
 //! no additional safety checks beyond type-checking.
 use crate::{
-    integer::{Integer, SignedInteger, UnsignedInteger},
+    integer::{SignedInteger, UnsignedInteger},
     scalar::Scalar,
     vector::Vector,
 };

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -187,8 +187,7 @@ pub unsafe fn read_clock_uvec2_khr<V: Vector<u32, 2>, const SCOPE: u32>() -> V {
     result
 }
 
-#[spirv_std_macros::gpu_only]
-#[allow(dead_code)]
+#[cfg(target_arch = "spirv")]
 unsafe fn call_glsl_op_with_ints<T: Integer, const OP: u32>(a: T, b: T) -> T {
     let mut result = T::default();
     asm!(

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -9,6 +9,8 @@ use crate::{
     vector::Vector,
 };
 #[cfg(target_arch = "spirv")]
+use crate::integer::Integer;
+#[cfg(target_arch = "spirv")]
 use core::arch::asm;
 
 mod atomics;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2022-06-27"
+channel = "nightly-2022-07-04"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2022-06-13"
+channel = "nightly-2022-06-20"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2022-06-20"
+channel = "nightly-2022-06-27"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,7 +1,7 @@
 error: Cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2214:9
+    --> $CORE_SRC/intrinsics.rs:2527:9
      |
-2214 |         copy(src, dst, count)
+2527 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1151 8
+OpLine %8 1107 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1151 8
+OpLine %8 1107 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1342 8
+OpLine %11 1298 8
 OpStore %6 %9
 OpLine %8 8 1
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1342 8
+OpLine %11 1298 8
 OpStore %6 %9
 OpLine %8 8 1
 OpReturn

--- a/tests/ui/spirv-attr/invalid-matrix-type-empty.stderr
+++ b/tests/ui/spirv-attr/invalid-matrix-type-empty.stderr
@@ -2,7 +2,7 @@ error: #[spirv(matrix)] type must have at least two fields
  --> $DIR/invalid-matrix-type-empty.rs:7:1
   |
 7 | pub struct _EmptyStruct {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/spirv-attr/invalid-matrix-type.stderr
+++ b/tests/ui/spirv-attr/invalid-matrix-type.stderr
@@ -1,31 +1,22 @@
 error: #[spirv(matrix)] type must have at least two fields
  --> $DIR/invalid-matrix-type.rs:7:1
   |
-7 | / pub struct _FewerFields {
-8 | |     _v: glam::Vec3,
-9 | | }
-  | |_^
+7 | pub struct _FewerFields {
+  | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: #[spirv(matrix)] type fields must all be vectors
   --> $DIR/invalid-matrix-type.rs:12:1
    |
-12 | / pub struct _NotVectorField {
-13 | |     _x: f32,
-14 | |     _y: f32,
-15 | |     _z: f32,
-16 | | }
-   | |_^
+12 | pub struct _NotVectorField {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: field type is f32
 
 error: #[spirv(matrix)] type fields must all be the same type
   --> $DIR/invalid-matrix-type.rs:19:1
    |
-19 | / pub struct _DifferentType {
-20 | |     _x: glam::Vec3,
-21 | |     _y: glam::Vec2,
-22 | | }
-   | |_^
+19 | pub struct _DifferentType {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
The update to `07-04` gave a dead code warning on `fn call_glsl_op_with_ints()` in `crates\spirv-std\src\arch.rs:191`. I seem to be able to silence the warning, but I'm a bit confused by I'm getting it in the first place, since it's obviously being used by the public functions below it.