### PR TITLE
Added toolchain check to rustc_codegen_spirv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,17 +321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "compiletest_rs"
 version = "0.7.1"
 source = "git+https://github.com/Manishearth/compiletest-rs.git?rev=4ab843a1dc6ed9a82657d86d22397c6c5bb95b01#4ab843a1dc6ed9a82657d86d22397c6c5bb95b01"
@@ -2009,7 +1998,6 @@ version = "0.4.0-alpha.14"
 dependencies = [
  "ar",
  "bimap",
- "colored",
  "hashbrown",
  "indexmap",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "compiletest_rs"
 version = "0.7.1"
 source = "git+https://github.com/Manishearth/compiletest-rs.git?rev=4ab843a1dc6ed9a82657d86d22397c6c5bb95b01#4ab843a1dc6ed9a82657d86d22397c6c5bb95b01"
@@ -1998,6 +2009,7 @@ version = "0.4.0-alpha.14"
 dependencies = [
  "ar",
  "bimap",
+ "colored",
  "hashbrown",
  "indexmap",
  "libc",
@@ -2014,6 +2026,7 @@ dependencies = [
  "spirv-tools",
  "syn",
  "tempfile",
+ "version_check",
 ]
 
 [[package]]
@@ -2506,9 +2519,9 @@ checksum = "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,6 @@ dependencies = [
  "spirv-tools",
  "syn",
  "tempfile",
- "version_check",
 ]
 
 [[package]]

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -59,9 +59,6 @@ pipe = "0.4"
 pretty_assertions = "1.0"
 tempfile = "3.2"
 
-[build-dependencies]
-colored = "2"
-
 # Note that in order to use RA and have access to `rustc_*` crates, you also
 # need to set `"rust-analyzer.rustcSource": "discover"` in e.g. VSCode.
 [package.metadata.rust-analyzer]

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -26,6 +26,12 @@ use-installed-tools = ["spirv-tools/use-installed-tools"]
 # If enabled will compile and link the C++ code for the spirv tools, the compiled
 # version is preferred if both this and `use-installed-tools` are enabled
 use-compiled-tools = ["spirv-tools/use-compiled-tools"]
+# If enabled, this will not check whether the current rustc version is set to the
+# appropriate channel. rustc_cogeden_spirv requires a specific nightly version,
+# and will likely produce compile errors when built against a different toolchain.
+# Enable this feature to be able to experiment with other versions.
+skip-toolchain-check = []
+
 
 [dependencies]
 # HACK(eddyb) these only exist to unify features across dependency trees,
@@ -52,6 +58,10 @@ rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "
 pipe = "0.4"
 pretty_assertions = "1.0"
 tempfile = "3.2"
+
+[build-dependencies]
+version_check = "0.9.4"
+colored = "2"
 
 # Note that in order to use RA and have access to `rustc_*` crates, you also
 # need to set `"rust-analyzer.rustcSource": "discover"` in e.g. VSCode.

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -60,7 +60,6 @@ pretty_assertions = "1.0"
 tempfile = "3.2"
 
 [build-dependencies]
-version_check = "0.9.4"
 colored = "2"
 
 # Note that in order to use RA and have access to `rustc_*` crates, you also

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -1,0 +1,59 @@
+//! This custom build script merely checks whether we're compiling with the appropriate Rust toolchain
+
+#[allow(unused_imports)]
+use colored::*;
+use std::process::Command;
+
+/// The required toolchain version for this package. Update accordingly.
+#[cfg(not(feature = "skip-toolchain-check"))]
+const REQUIRED_TOOLCHAIN: &str = "nightly-2022-08-29";
+
+/// The required toolchain commit hash for this package. Update accordingly.
+#[cfg(not(feature = "skip-toolchain-check"))]
+const REQUIRED_COMMIT_HASH: &str = "ce36e88256f09078519f8bc6b21e4dc88f88f523";
+
+#[cfg(not(feature = "skip-toolchain-check"))]
+fn get_rustc_commit_hash() -> Option<String> {
+    let rustc = std::env::var("RUSTC").unwrap_or(String::from("rustc"));
+    Command::new(rustc)
+        .arg("-vV")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| {
+            for l in s.lines() {
+                match l.strip_prefix("commit-hash: ") {
+                    Some(hash) => {
+                        return Some(hash.to_string());
+                    }
+                    _ => {}
+                }
+            }
+            None
+        })
+        .unwrap_or(None)
+}
+#[cfg(not(feature = "skip-toolchain-check"))]
+fn check_toolchain_version() {
+    std::env::set_var("CLICOLOR_FORCE", "1"); // make sure our coloring gets through to cargo
+
+    let current_hash = get_rustc_commit_hash().unwrap_or(String::from("<unknown>"));
+    if current_hash != REQUIRED_COMMIT_HASH {
+        eprintln!(
+            "{}: {} (found {}). Make sure you specify {} in your project's {} file",
+            "error".bright_red(),
+            "Wrong toolchain detected".bold(),
+            current_hash.bright_cyan(),
+            format!("channel=\"{}\"", REQUIRED_TOOLCHAIN).bright_cyan(),
+            "rust_toolchain".bright_cyan()
+        );
+        std::process::exit(1);
+    }
+}
+
+#[cfg(feature = "skip-toolchain-check")]
+fn check_toolchain_version() {}
+
+fn main() {
+    check_toolchain_version();
+}

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -60,16 +60,11 @@ Make sure your `rust_toolchain` file contains the following:
 }
 
 fn main() -> ExitCode {
-    if let Err(e) = check_toolchain_version() {
-        eprintln!(
-            "{}",
-            std::env::vars()
-                .map(|v| v.0 + "=" + &v.1)
-                .reduce(|a, b| a + "\n" + &b)
-                .unwrap_or_default()
-        );
-        eprint!("{}", e);
-        return ExitCode::FAILURE;
+    match check_toolchain_version() {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprint!("{}", e);
+            ExitCode::FAILURE
+        }
     }
-    ExitCode::SUCCESS
 }

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -12,6 +12,7 @@ description = "Helper for building shaders with rust-gpu"
 default = ["use-compiled-tools"]
 use-installed-tools = ["rustc_codegen_spirv/use-installed-tools"]
 use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
+skip-toolchain-check = ["rustc_codegen_spirv/skip-toolchain-check"]
 watch = ["notify"]
 
 [dependencies]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -7,3 +7,8 @@
 [toolchain]
 channel = "nightly-2022-08-29"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
+# commit_hash = ce36e88256f09078519f8bc6b21e4dc88f88f523
+
+# Whenever changing the nightly channel, update the commit hash above, and make
+# sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also.
+


### PR DESCRIPTION
Check can be disabled by specifying `skip-toolchain-check` feature on either `rustc_codegen_spirv` or `spirv_builder`