### PR TITLE
mouse-shader: remove sharp cutoff in drag distortion.

### DIFF
--- a/examples/shaders/mouse-shader/src/lib.rs
+++ b/examples/shaders/mouse-shader/src/lib.rs
@@ -163,7 +163,7 @@ pub fn main_fs(
         let to_frag = v - from_coord(drag_start);
         let start_to_end = from_coord(drag_end) - from_coord(drag_start);
         let det = to_frag.perp_dot(start_to_end).abs();
-        distance /= 1.0 + det.min(1.0).powf(2.0);
+        distance /= 1.0 + det.powf(2.0);
         let t = constants.time;
         let rot = move |factor: f32| {
             (Mat2::from_angle((t / 3.0 + distance * factor).sin() * 3.0) * v).normalize()


### PR DESCRIPTION
The mouse¹ shader is supposed to have a "distortion" effect (of its colorful spiraly background) as a result of mouse dragging, which is proportional to the "drag distance" (and there's a "drag arrow" UI).

<sup>¹ (which you sadly can't even test without locally reverting #854, because `naga` seems to silently miscompile it? or at least no pixels are drawn over the initial green color - maybe we just need to try updating the version of `wgpu` we use and see if that fixes bugs like this)</sup>

However, I'm not sure why but I ended up with clamping the distortion divisor to `[1, 2]` (instead of letting it freely range in `[1, ∞)`), and not only is that not necessary (or at least I can't cause any edge cases, and don't see why any would occur, since the drag distance is finite - maybe some `NaN` thing?), but *also ugly*.

The result was that there was always a sharp cutoff, after which lengthening the drag distance would not cause more "stretching", but unpleasantly noticeable lines where the pattern abruptly changed direction (in part because of interactions in how the distorted value is later used).

Removing the clamping makes the "stretching" far away result in a smoother (if less interesting) pattern:
| Before | After |
| ------ | ----- |
|<img src="https://user-images.githubusercontent.com/77424/192782655-c65c79bb-87fd-41c7-a7d8-62bd26c0993a.png"/>|<img src="https://user-images.githubusercontent.com/77424/192782839-686c600c-6397-427b-8e34-ae96deff1485.png"/>|

<sup>(the ugly cutoff lines in the "**Before**" image are almost parallel to the white line that indicates the "drag arrow")</sup>