### PR TITLE
Optimise CI with faster Linux machines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: ubuntu-20.04-16core
             target: x86_64-unknown-linux-gnu
-          - os: windows-latest
+          - os: windows-2022-16core
             target: x86_64-pc-windows-msvc
           - os: macOS-latest
             target: x86_64-apple-darwin
@@ -118,7 +118,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-16core
     steps:
       # Note that we are explicitly NOT checking out submodules, to validate
       # that we haven't accidentally enabled spirv-tools native compilation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: ubuntu-20.04-16core
             target: x86_64-unknown-linux-gnu
-          - os: windows-2022-16core
+          - os: windows-latest
             target: x86_64-pc-windows-msvc
           - os: macOS-latest
             target: x86_64-apple-darwin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04-16core
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
           - os: macOS-latest
             target: x86_64-apple-darwin
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04-16core
             target: aarch64-linux-android
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Build on 16 vCPU machine instead of the default 4 vCPU, using GitHub Action's beta of GitHub-hosted larger runner.

They have support for Windows machines also, but got a some weird compiletest failures on that so disabled that for now (any ideas what could cause that failure?):
- https://github.com/EmbarkStudios/rust-gpu/actions/runs/3160216480/jobs/5144407978

Mac agents remain the main bottleneck for PRs though, and that they do not have hosted agents for. We could potentially disable the Mac builds if we want to improve the PR iteration time. 

But at least with this change we reduce the Linux & Android build times significantly: 

- Android build: 10m 54s -> 5m 13s
- Linux build: total build: 11m 36s -> 4m 43s