### PR TITLE
Add codegen backend dylib back into depinfo (.d) post-rust-lang/rust#93969.

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -419,6 +419,10 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
 
     let mut rustflags = vec![
         format!("-Zcodegen-backend={}", rustc_codegen_spirv.display()),
+        // Ensure the codegen backend is emitted in `.d` files to force Cargo
+        // to rebuild crates compiled with it when it changes (this used to be
+        // the default until https://github.com/rust-lang/rust/pull/93969).
+        "-Zbinary-dep-depinfo".to_string(),
         "-Csymbol-mangling-version=v0".to_string(),
     ];
 

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -323,6 +323,10 @@ fn rust_flags(codegen_backend_path: &Path) -> String {
 
     [
         &*format!("-Zcodegen-backend={}", codegen_backend_path.display()),
+        // Ensure the codegen backend is emitted in `.d` files to force Cargo
+        // to rebuild crates compiled with it when it changes (this used to be
+        // the default until https://github.com/rust-lang/rust/pull/93969).
+        "-Zbinary-dep-depinfo",
         "-Coverflow-checks=off",
         "-Cdebug-assertions=off",
         "-Cdebuginfo=2",


### PR DESCRIPTION
This unbreaks the ability of Cargo to know to rebuild shader dependencies when `rustc_codegen_spirv` changes - after this PR, attempting to e.g. run one of the example runners, or `cargo compiletest`, after making a change in `rustc_codegen_spirv`, will cause all SPIR-V target dependencies (`core`, `spirv-std` etc.) to be rebuilt.

We apparently used to be enjoying this by default until:
* https://github.com/rust-lang/rust/pull/93969

And never got around to updating to set the opt-in flag (sorry, @bjorn3!).