### PR TITLE
Prepare invalid-target test for #926

### DIFF
--- a/tests/ui/spirv-attr/invalid-target.rs
+++ b/tests/ui/spirv-attr/invalid-target.rs
@@ -30,6 +30,8 @@
 //   * 6 on `_entry_param`
 //   * 1 on `_closure`
 
+//use spirv_std::spirv;
+
 #[spirv(
     sampler, block, sampled_image, generic_image_type, // struct-only
     vertex, // fn-only

--- a/tests/ui/spirv-attr/invalid-target.stderr
+++ b/tests/ui/spirv-attr/invalid-target.stderr
@@ -1,2839 +1,2839 @@
 error: attribute is only valid on a struct, not on a macro def
-  --> $DIR/invalid-target.rs:34:5
+  --> $DIR/invalid-target.rs:36:5
    |
-34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+36 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a macro def
-  --> $DIR/invalid-target.rs:34:14
+  --> $DIR/invalid-target.rs:36:14
    |
-34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+36 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a macro def
-  --> $DIR/invalid-target.rs:34:21
+  --> $DIR/invalid-target.rs:36:21
    |
-34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+36 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a macro def
-  --> $DIR/invalid-target.rs:34:36
+  --> $DIR/invalid-target.rs:36:36
    |
-34 |     sampler, block, sampled_image, generic_image_type, // struct-only
+36 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a macro def
-  --> $DIR/invalid-target.rs:35:5
+  --> $DIR/invalid-target.rs:37:5
    |
-35 |     vertex, // fn-only
+37 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a macro def
-  --> $DIR/invalid-target.rs:36:5
+  --> $DIR/invalid-target.rs:38:5
    |
-36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+38 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a macro def
-  --> $DIR/invalid-target.rs:36:14
+  --> $DIR/invalid-target.rs:38:14
    |
-36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+38 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a macro def
-  --> $DIR/invalid-target.rs:36:24
+  --> $DIR/invalid-target.rs:38:24
    |
-36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+38 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a macro def
-  --> $DIR/invalid-target.rs:36:44
+  --> $DIR/invalid-target.rs:38:44
    |
-36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+38 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a macro def
-  --> $DIR/invalid-target.rs:36:57
+  --> $DIR/invalid-target.rs:38:57
    |
-36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+38 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a macro def
-  --> $DIR/invalid-target.rs:36:63
+  --> $DIR/invalid-target.rs:38:63
    |
-36 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+38 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a macro def
-  --> $DIR/invalid-target.rs:37:5
+  --> $DIR/invalid-target.rs:39:5
    |
-37 |     unroll_loops, // fn/closure-only
+39 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:44:5
+  --> $DIR/invalid-target.rs:46:5
    |
-44 |     sampler, block, sampled_image, generic_image_type, // struct-only
+46 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:44:14
+  --> $DIR/invalid-target.rs:46:14
    |
-44 |     sampler, block, sampled_image, generic_image_type, // struct-only
+46 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:44:21
+  --> $DIR/invalid-target.rs:46:21
    |
-44 |     sampler, block, sampled_image, generic_image_type, // struct-only
+46 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a extern crate
-  --> $DIR/invalid-target.rs:44:36
+  --> $DIR/invalid-target.rs:46:36
    |
-44 |     sampler, block, sampled_image, generic_image_type, // struct-only
+46 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a extern crate
-  --> $DIR/invalid-target.rs:45:5
+  --> $DIR/invalid-target.rs:47:5
    |
-45 |     vertex, // fn-only
+47 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:46:5
+  --> $DIR/invalid-target.rs:48:5
    |
-46 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:46:14
+  --> $DIR/invalid-target.rs:48:14
    |
-46 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:46:24
+  --> $DIR/invalid-target.rs:48:24
    |
-46 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:46:44
+  --> $DIR/invalid-target.rs:48:44
    |
-46 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:46:57
+  --> $DIR/invalid-target.rs:48:57
    |
-46 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a extern crate
-  --> $DIR/invalid-target.rs:46:63
+  --> $DIR/invalid-target.rs:48:63
    |
-46 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+48 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a extern crate
-  --> $DIR/invalid-target.rs:47:5
+  --> $DIR/invalid-target.rs:49:5
    |
-47 |     unroll_loops, // fn/closure-only
+49 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:52:5
+  --> $DIR/invalid-target.rs:54:5
    |
-52 |     sampler, block, sampled_image, generic_image_type, // struct-only
+54 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:52:14
+  --> $DIR/invalid-target.rs:54:14
    |
-52 |     sampler, block, sampled_image, generic_image_type, // struct-only
+54 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:52:21
+  --> $DIR/invalid-target.rs:54:21
    |
-52 |     sampler, block, sampled_image, generic_image_type, // struct-only
+54 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a use
-  --> $DIR/invalid-target.rs:52:36
+  --> $DIR/invalid-target.rs:54:36
    |
-52 |     sampler, block, sampled_image, generic_image_type, // struct-only
+54 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a use
-  --> $DIR/invalid-target.rs:53:5
+  --> $DIR/invalid-target.rs:55:5
    |
-53 |     vertex, // fn-only
+55 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:54:5
+  --> $DIR/invalid-target.rs:56:5
    |
-54 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+56 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:54:14
+  --> $DIR/invalid-target.rs:56:14
    |
-54 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+56 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:54:24
+  --> $DIR/invalid-target.rs:56:24
    |
-54 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+56 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:54:44
+  --> $DIR/invalid-target.rs:56:44
    |
-54 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+56 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:54:57
+  --> $DIR/invalid-target.rs:56:57
    |
-54 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+56 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a use
-  --> $DIR/invalid-target.rs:54:63
+  --> $DIR/invalid-target.rs:56:63
    |
-54 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+56 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a use
-  --> $DIR/invalid-target.rs:55:5
+  --> $DIR/invalid-target.rs:57:5
    |
-55 |     unroll_loops, // fn/closure-only
+57 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:60:5
+  --> $DIR/invalid-target.rs:62:5
    |
-60 |     sampler, block, sampled_image, generic_image_type, // struct-only
+62 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:60:14
+  --> $DIR/invalid-target.rs:62:14
    |
-60 |     sampler, block, sampled_image, generic_image_type, // struct-only
+62 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:60:21
+  --> $DIR/invalid-target.rs:62:21
    |
-60 |     sampler, block, sampled_image, generic_image_type, // struct-only
+62 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a module
-  --> $DIR/invalid-target.rs:60:36
+  --> $DIR/invalid-target.rs:62:36
    |
-60 |     sampler, block, sampled_image, generic_image_type, // struct-only
+62 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a module
-  --> $DIR/invalid-target.rs:61:5
+  --> $DIR/invalid-target.rs:63:5
    |
-61 |     vertex, // fn-only
+63 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:62:5
+  --> $DIR/invalid-target.rs:64:5
    |
-62 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+64 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:62:14
+  --> $DIR/invalid-target.rs:64:14
    |
-62 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+64 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:62:24
+  --> $DIR/invalid-target.rs:64:24
    |
-62 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+64 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:62:44
+  --> $DIR/invalid-target.rs:64:44
    |
-62 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+64 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:62:57
+  --> $DIR/invalid-target.rs:64:57
    |
-62 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+64 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a module
-  --> $DIR/invalid-target.rs:62:63
+  --> $DIR/invalid-target.rs:64:63
    |
-62 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+64 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a module
-  --> $DIR/invalid-target.rs:63:5
+  --> $DIR/invalid-target.rs:65:5
    |
-63 |     unroll_loops, // fn/closure-only
+65 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:68:5
+  --> $DIR/invalid-target.rs:70:5
    |
-68 |     sampler, block, sampled_image, generic_image_type, // struct-only
+70 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:68:14
+  --> $DIR/invalid-target.rs:70:14
    |
-68 |     sampler, block, sampled_image, generic_image_type, // struct-only
+70 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |              ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:68:21
+  --> $DIR/invalid-target.rs:70:21
    |
-68 |     sampler, block, sampled_image, generic_image_type, // struct-only
+70 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign module
-  --> $DIR/invalid-target.rs:68:36
+  --> $DIR/invalid-target.rs:70:36
    |
-68 |     sampler, block, sampled_image, generic_image_type, // struct-only
+70 |     sampler, block, sampled_image, generic_image_type, // struct-only
    |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign module
-  --> $DIR/invalid-target.rs:69:5
+  --> $DIR/invalid-target.rs:71:5
    |
-69 |     vertex, // fn-only
+71 |     vertex, // fn-only
    |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:5
+  --> $DIR/invalid-target.rs:72:5
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+72 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:14
+  --> $DIR/invalid-target.rs:72:14
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+72 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:24
+  --> $DIR/invalid-target.rs:72:24
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+72 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:44
+  --> $DIR/invalid-target.rs:72:44
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+72 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:57
+  --> $DIR/invalid-target.rs:72:57
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+72 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign module
-  --> $DIR/invalid-target.rs:70:63
+  --> $DIR/invalid-target.rs:72:63
    |
-70 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+72 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign module
-  --> $DIR/invalid-target.rs:71:5
+  --> $DIR/invalid-target.rs:73:5
    |
-71 |     unroll_loops, // fn/closure-only
+73 |     unroll_loops, // fn/closure-only
    |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:100:5
+   --> $DIR/invalid-target.rs:102:5
     |
-100 |     sampler, block, sampled_image, generic_image_type, // struct-only
+102 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:100:14
+   --> $DIR/invalid-target.rs:102:14
     |
-100 |     sampler, block, sampled_image, generic_image_type, // struct-only
+102 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:100:21
+   --> $DIR/invalid-target.rs:102:21
     |
-100 |     sampler, block, sampled_image, generic_image_type, // struct-only
+102 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a static item
-   --> $DIR/invalid-target.rs:100:36
+   --> $DIR/invalid-target.rs:102:36
     |
-100 |     sampler, block, sampled_image, generic_image_type, // struct-only
+102 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a static item
-   --> $DIR/invalid-target.rs:101:5
+   --> $DIR/invalid-target.rs:103:5
     |
-101 |     vertex, // fn-only
+103 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:102:5
+   --> $DIR/invalid-target.rs:104:5
     |
-102 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+104 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:102:14
+   --> $DIR/invalid-target.rs:104:14
     |
-102 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+104 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:102:24
+   --> $DIR/invalid-target.rs:104:24
     |
-102 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+104 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:102:44
+   --> $DIR/invalid-target.rs:104:44
     |
-102 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+104 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:102:57
+   --> $DIR/invalid-target.rs:104:57
     |
-102 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+104 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a static item
-   --> $DIR/invalid-target.rs:102:63
+   --> $DIR/invalid-target.rs:104:63
     |
-102 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+104 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a static item
-   --> $DIR/invalid-target.rs:103:5
+   --> $DIR/invalid-target.rs:105:5
     |
-103 |     unroll_loops, // fn/closure-only
+105 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:108:5
+   --> $DIR/invalid-target.rs:110:5
     |
-108 |     sampler, block, sampled_image, generic_image_type, // struct-only
+110 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:108:14
+   --> $DIR/invalid-target.rs:110:14
     |
-108 |     sampler, block, sampled_image, generic_image_type, // struct-only
+110 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:108:21
+   --> $DIR/invalid-target.rs:110:21
     |
-108 |     sampler, block, sampled_image, generic_image_type, // struct-only
+110 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a constant item
-   --> $DIR/invalid-target.rs:108:36
+   --> $DIR/invalid-target.rs:110:36
     |
-108 |     sampler, block, sampled_image, generic_image_type, // struct-only
+110 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a constant item
-   --> $DIR/invalid-target.rs:109:5
+   --> $DIR/invalid-target.rs:111:5
     |
-109 |     vertex, // fn-only
+111 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:110:5
+   --> $DIR/invalid-target.rs:112:5
     |
-110 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+112 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:110:14
+   --> $DIR/invalid-target.rs:112:14
     |
-110 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+112 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:110:24
+   --> $DIR/invalid-target.rs:112:24
     |
-110 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+112 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:110:44
+   --> $DIR/invalid-target.rs:112:44
     |
-110 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+112 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:110:57
+   --> $DIR/invalid-target.rs:112:57
     |
-110 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+112 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a constant item
-   --> $DIR/invalid-target.rs:110:63
+   --> $DIR/invalid-target.rs:112:63
     |
-110 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+112 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a constant item
-   --> $DIR/invalid-target.rs:111:5
+   --> $DIR/invalid-target.rs:113:5
     |
-111 |     unroll_loops, // fn/closure-only
+113 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:116:5
-    |
-116 |     sampler, block, sampled_image, generic_image_type, // struct-only
-    |     ^^^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:116:14
-    |
-116 |     sampler, block, sampled_image, generic_image_type, // struct-only
-    |              ^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:116:21
-    |
-116 |     sampler, block, sampled_image, generic_image_type, // struct-only
-    |                     ^^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:116:36
-    |
-116 |     sampler, block, sampled_image, generic_image_type, // struct-only
-    |                                    ^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function, not on a type alias
-   --> $DIR/invalid-target.rs:117:5
-    |
-117 |     vertex, // fn-only
-    |     ^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
    --> $DIR/invalid-target.rs:118:5
     |
-118 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+118 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
-error: attribute is only valid on a function parameter, not on a type alias
+error: attribute is only valid on a struct, not on a type alias
    --> $DIR/invalid-target.rs:118:14
     |
-118 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |              ^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:118:24
-    |
-118 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                        ^^^^^^^^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:118:44
-    |
-118 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                            ^^^^^^^^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:118:57
-    |
-118 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                         ^^^^
-
-error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:118:63
-    |
-118 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
-    |                                                               ^^^^^^^^^
-
-error: attribute is only valid on a function or closure, not on a type alias
-   --> $DIR/invalid-target.rs:119:5
-    |
-119 |     unroll_loops, // fn/closure-only
-    |     ^^^^^^^^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:124:5
-    |
-124 |     sampler, block, sampled_image, generic_image_type, // struct-only
-    |     ^^^^^^^
-
-error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:124:14
-    |
-124 |     sampler, block, sampled_image, generic_image_type, // struct-only
+118 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:124:21
+   --> $DIR/invalid-target.rs:118:21
     |
-124 |     sampler, block, sampled_image, generic_image_type, // struct-only
+118 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type alias
-   --> $DIR/invalid-target.rs:124:36
+   --> $DIR/invalid-target.rs:118:36
     |
-124 |     sampler, block, sampled_image, generic_image_type, // struct-only
+118 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a type alias
-   --> $DIR/invalid-target.rs:125:5
+   --> $DIR/invalid-target.rs:119:5
     |
-125 |     vertex, // fn-only
+119 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:126:5
+   --> $DIR/invalid-target.rs:120:5
     |
-126 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:126:14
+   --> $DIR/invalid-target.rs:120:14
     |
-126 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:126:24
+   --> $DIR/invalid-target.rs:120:24
     |
-126 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:126:44
+   --> $DIR/invalid-target.rs:120:44
     |
-126 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:126:57
+   --> $DIR/invalid-target.rs:120:57
     |
-126 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a type alias
-   --> $DIR/invalid-target.rs:126:63
+   --> $DIR/invalid-target.rs:120:63
     |
-126 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+120 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a type alias
+   --> $DIR/invalid-target.rs:121:5
+    |
+121 |     unroll_loops, // fn/closure-only
+    |     ^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:126:5
+    |
+126 |     sampler, block, sampled_image, generic_image_type, // struct-only
+    |     ^^^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:126:14
+    |
+126 |     sampler, block, sampled_image, generic_image_type, // struct-only
+    |              ^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:126:21
+    |
+126 |     sampler, block, sampled_image, generic_image_type, // struct-only
+    |                     ^^^^^^^^^^^^^
+
+error: attribute is only valid on a struct, not on a type alias
+   --> $DIR/invalid-target.rs:126:36
+    |
+126 |     sampler, block, sampled_image, generic_image_type, // struct-only
+    |                                    ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function, not on a type alias
    --> $DIR/invalid-target.rs:127:5
     |
-127 |     unroll_loops, // fn/closure-only
+127 |     vertex, // fn-only
+    |     ^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:128:5
+    |
+128 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |     ^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:128:14
+    |
+128 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |              ^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:128:24
+    |
+128 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                        ^^^^^^^^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:128:44
+    |
+128 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                            ^^^^^^^^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:128:57
+    |
+128 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                         ^^^^
+
+error: attribute is only valid on a function parameter, not on a type alias
+   --> $DIR/invalid-target.rs:128:63
+    |
+128 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+    |                                                               ^^^^^^^^^
+
+error: attribute is only valid on a function or closure, not on a type alias
+   --> $DIR/invalid-target.rs:129:5
+    |
+129 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:136:5
+   --> $DIR/invalid-target.rs:138:5
     |
-136 |     sampler, block, sampled_image, generic_image_type, // struct-only
+138 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:136:14
+   --> $DIR/invalid-target.rs:138:14
     |
-136 |     sampler, block, sampled_image, generic_image_type, // struct-only
+138 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:136:21
+   --> $DIR/invalid-target.rs:138:21
     |
-136 |     sampler, block, sampled_image, generic_image_type, // struct-only
+138 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum
-   --> $DIR/invalid-target.rs:136:36
+   --> $DIR/invalid-target.rs:138:36
     |
-136 |     sampler, block, sampled_image, generic_image_type, // struct-only
+138 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a enum
-   --> $DIR/invalid-target.rs:137:5
+   --> $DIR/invalid-target.rs:139:5
     |
-137 |     vertex, // fn-only
+139 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:138:5
+   --> $DIR/invalid-target.rs:140:5
     |
-138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+140 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:138:14
+   --> $DIR/invalid-target.rs:140:14
     |
-138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+140 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:138:24
+   --> $DIR/invalid-target.rs:140:24
     |
-138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+140 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:138:44
+   --> $DIR/invalid-target.rs:140:44
     |
-138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+140 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:138:57
+   --> $DIR/invalid-target.rs:140:57
     |
-138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+140 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a enum
-   --> $DIR/invalid-target.rs:138:63
+   --> $DIR/invalid-target.rs:140:63
     |
-138 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+140 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a enum
-   --> $DIR/invalid-target.rs:139:5
+   --> $DIR/invalid-target.rs:141:5
     |
-139 |     unroll_loops, // fn/closure-only
+141 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:143:9
+   --> $DIR/invalid-target.rs:145:9
     |
-143 |         sampler, block, sampled_image, generic_image_type, // struct-only
+145 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:143:18
+   --> $DIR/invalid-target.rs:145:18
     |
-143 |         sampler, block, sampled_image, generic_image_type, // struct-only
+145 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:143:25
+   --> $DIR/invalid-target.rs:145:25
     |
-143 |         sampler, block, sampled_image, generic_image_type, // struct-only
+145 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a enum variant
-   --> $DIR/invalid-target.rs:143:40
+   --> $DIR/invalid-target.rs:145:40
     |
-143 |         sampler, block, sampled_image, generic_image_type, // struct-only
+145 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a enum variant
-   --> $DIR/invalid-target.rs:144:9
+   --> $DIR/invalid-target.rs:146:9
     |
-144 |         vertex, // fn-only
+146 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:145:9
+   --> $DIR/invalid-target.rs:147:9
     |
-145 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+147 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:145:18
+   --> $DIR/invalid-target.rs:147:18
     |
-145 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+147 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:145:28
+   --> $DIR/invalid-target.rs:147:28
     |
-145 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+147 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:145:48
+   --> $DIR/invalid-target.rs:147:48
     |
-145 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+147 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:145:61
+   --> $DIR/invalid-target.rs:147:61
     |
-145 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+147 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a enum variant
-   --> $DIR/invalid-target.rs:145:67
+   --> $DIR/invalid-target.rs:147:67
     |
-145 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+147 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a enum variant
-   --> $DIR/invalid-target.rs:146:9
+   --> $DIR/invalid-target.rs:148:9
     |
-146 |         unroll_loops, // fn/closure-only
+148 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:150:13
+   --> $DIR/invalid-target.rs:152:13
     |
-150 |             sampler, block, sampled_image, generic_image_type, // struct-only
+152 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:150:22
+   --> $DIR/invalid-target.rs:152:22
     |
-150 |             sampler, block, sampled_image, generic_image_type, // struct-only
+152 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:150:29
+   --> $DIR/invalid-target.rs:152:29
     |
-150 |             sampler, block, sampled_image, generic_image_type, // struct-only
+152 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:150:44
+   --> $DIR/invalid-target.rs:152:44
     |
-150 |             sampler, block, sampled_image, generic_image_type, // struct-only
+152 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct field
-   --> $DIR/invalid-target.rs:151:13
+   --> $DIR/invalid-target.rs:153:13
     |
-151 |             vertex, // fn-only
+153 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:152:13
+   --> $DIR/invalid-target.rs:154:13
     |
-152 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+154 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:152:22
+   --> $DIR/invalid-target.rs:154:22
     |
-152 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+154 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:152:32
+   --> $DIR/invalid-target.rs:154:32
     |
-152 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+154 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:152:52
+   --> $DIR/invalid-target.rs:154:52
     |
-152 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+154 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:152:65
+   --> $DIR/invalid-target.rs:154:65
     |
-152 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+154 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:152:71
+   --> $DIR/invalid-target.rs:154:71
     |
-152 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+154 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
-   --> $DIR/invalid-target.rs:153:13
+   --> $DIR/invalid-target.rs:155:13
     |
-153 |             unroll_loops, // fn/closure-only
+155 |             unroll_loops, // fn/closure-only
     |             ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:160:5
+   --> $DIR/invalid-target.rs:162:5
     |
-160 |     sampler, block, sampled_image, generic_image_type, // struct-only
+162 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:160:14
+   --> $DIR/invalid-target.rs:162:14
     |
-160 |     sampler, block, sampled_image, generic_image_type, // struct-only
+162 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:160:21
+   --> $DIR/invalid-target.rs:162:21
     |
-160 |     sampler, block, sampled_image, generic_image_type, // struct-only
+162 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a union
-   --> $DIR/invalid-target.rs:160:36
+   --> $DIR/invalid-target.rs:162:36
     |
-160 |     sampler, block, sampled_image, generic_image_type, // struct-only
+162 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a union
-   --> $DIR/invalid-target.rs:161:5
+   --> $DIR/invalid-target.rs:163:5
     |
-161 |     vertex, // fn-only
+163 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:162:5
+   --> $DIR/invalid-target.rs:164:5
     |
-162 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+164 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:162:14
+   --> $DIR/invalid-target.rs:164:14
     |
-162 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+164 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:162:24
+   --> $DIR/invalid-target.rs:164:24
     |
-162 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+164 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:162:44
+   --> $DIR/invalid-target.rs:164:44
     |
-162 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+164 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:162:57
+   --> $DIR/invalid-target.rs:164:57
     |
-162 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+164 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a union
-   --> $DIR/invalid-target.rs:162:63
+   --> $DIR/invalid-target.rs:164:63
     |
-162 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+164 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a union
-   --> $DIR/invalid-target.rs:163:5
+   --> $DIR/invalid-target.rs:165:5
     |
-163 |     unroll_loops, // fn/closure-only
+165 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:167:9
+   --> $DIR/invalid-target.rs:169:9
     |
-167 |         sampler, block, sampled_image, generic_image_type, // struct-only
+169 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:167:18
+   --> $DIR/invalid-target.rs:169:18
     |
-167 |         sampler, block, sampled_image, generic_image_type, // struct-only
+169 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:167:25
+   --> $DIR/invalid-target.rs:169:25
     |
-167 |         sampler, block, sampled_image, generic_image_type, // struct-only
+169 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:167:40
+   --> $DIR/invalid-target.rs:169:40
     |
-167 |         sampler, block, sampled_image, generic_image_type, // struct-only
+169 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct field
-   --> $DIR/invalid-target.rs:168:9
+   --> $DIR/invalid-target.rs:170:9
     |
-168 |         vertex, // fn-only
+170 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:169:9
+   --> $DIR/invalid-target.rs:171:9
     |
-169 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+171 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:169:18
+   --> $DIR/invalid-target.rs:171:18
     |
-169 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+171 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:169:28
+   --> $DIR/invalid-target.rs:171:28
     |
-169 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+171 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:169:48
+   --> $DIR/invalid-target.rs:171:48
     |
-169 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+171 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:169:61
+   --> $DIR/invalid-target.rs:171:61
     |
-169 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+171 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:169:67
+   --> $DIR/invalid-target.rs:171:67
     |
-169 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+171 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
-   --> $DIR/invalid-target.rs:170:9
+   --> $DIR/invalid-target.rs:172:9
     |
-170 |         unroll_loops, // fn/closure-only
+172 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct
-   --> $DIR/invalid-target.rs:176:5
+   --> $DIR/invalid-target.rs:178:5
     |
-176 |     vertex, // fn-only
+178 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:177:5
+   --> $DIR/invalid-target.rs:179:5
     |
-177 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+179 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:177:14
+   --> $DIR/invalid-target.rs:179:14
     |
-177 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+179 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:177:24
+   --> $DIR/invalid-target.rs:179:24
     |
-177 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+179 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:177:44
+   --> $DIR/invalid-target.rs:179:44
     |
-177 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+179 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:177:57
+   --> $DIR/invalid-target.rs:179:57
     |
-177 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+179 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct
-   --> $DIR/invalid-target.rs:177:63
+   --> $DIR/invalid-target.rs:179:63
     |
-177 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+179 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct
-   --> $DIR/invalid-target.rs:178:5
+   --> $DIR/invalid-target.rs:180:5
     |
-178 |     unroll_loops, // fn/closure-only
+180 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:182:9
+   --> $DIR/invalid-target.rs:184:9
     |
-182 |         sampler, block, sampled_image, generic_image_type, // struct-only
+184 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:182:18
+   --> $DIR/invalid-target.rs:184:18
     |
-182 |         sampler, block, sampled_image, generic_image_type, // struct-only
+184 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:182:25
+   --> $DIR/invalid-target.rs:184:25
     |
-182 |         sampler, block, sampled_image, generic_image_type, // struct-only
+184 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a struct field
-   --> $DIR/invalid-target.rs:182:40
+   --> $DIR/invalid-target.rs:184:40
     |
-182 |         sampler, block, sampled_image, generic_image_type, // struct-only
+184 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a struct field
-   --> $DIR/invalid-target.rs:183:9
+   --> $DIR/invalid-target.rs:185:9
     |
-183 |         vertex, // fn-only
+185 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:184:9
+   --> $DIR/invalid-target.rs:186:9
     |
-184 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:184:18
+   --> $DIR/invalid-target.rs:186:18
     |
-184 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:184:28
+   --> $DIR/invalid-target.rs:186:28
     |
-184 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:184:48
+   --> $DIR/invalid-target.rs:186:48
     |
-184 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:184:61
+   --> $DIR/invalid-target.rs:186:61
     |
-184 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a struct field
-   --> $DIR/invalid-target.rs:184:67
+   --> $DIR/invalid-target.rs:186:67
     |
-184 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+186 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a struct field
-   --> $DIR/invalid-target.rs:185:9
+   --> $DIR/invalid-target.rs:187:9
     |
-185 |         unroll_loops, // fn/closure-only
+187 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:191:5
+   --> $DIR/invalid-target.rs:193:5
     |
-191 |     sampler, block, sampled_image, generic_image_type, // struct-only
+193 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:191:14
+   --> $DIR/invalid-target.rs:193:14
     |
-191 |     sampler, block, sampled_image, generic_image_type, // struct-only
+193 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:191:21
+   --> $DIR/invalid-target.rs:193:21
     |
-191 |     sampler, block, sampled_image, generic_image_type, // struct-only
+193 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:191:36
+   --> $DIR/invalid-target.rs:193:36
     |
-191 |     sampler, block, sampled_image, generic_image_type, // struct-only
+193 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a implementation block
-   --> $DIR/invalid-target.rs:192:5
+   --> $DIR/invalid-target.rs:194:5
     |
-192 |     vertex, // fn-only
+194 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:193:5
+   --> $DIR/invalid-target.rs:195:5
     |
-193 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+195 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:193:14
+   --> $DIR/invalid-target.rs:195:14
     |
-193 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+195 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:193:24
+   --> $DIR/invalid-target.rs:195:24
     |
-193 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+195 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:193:44
+   --> $DIR/invalid-target.rs:195:44
     |
-193 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+195 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:193:57
+   --> $DIR/invalid-target.rs:195:57
     |
-193 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+195 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:193:63
+   --> $DIR/invalid-target.rs:195:63
     |
-193 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+195 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a implementation block
-   --> $DIR/invalid-target.rs:194:5
+   --> $DIR/invalid-target.rs:196:5
     |
-194 |     unroll_loops, // fn/closure-only
+196 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:213:5
+   --> $DIR/invalid-target.rs:215:5
     |
-213 |     sampler, block, sampled_image, generic_image_type, // struct-only
+215 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:213:14
+   --> $DIR/invalid-target.rs:215:14
     |
-213 |     sampler, block, sampled_image, generic_image_type, // struct-only
+215 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:213:21
+   --> $DIR/invalid-target.rs:215:21
     |
-213 |     sampler, block, sampled_image, generic_image_type, // struct-only
+215 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait alias
-   --> $DIR/invalid-target.rs:213:36
+   --> $DIR/invalid-target.rs:215:36
     |
-213 |     sampler, block, sampled_image, generic_image_type, // struct-only
+215 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a trait alias
-   --> $DIR/invalid-target.rs:214:5
+   --> $DIR/invalid-target.rs:216:5
     |
-214 |     vertex, // fn-only
+216 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:215:5
+   --> $DIR/invalid-target.rs:217:5
     |
-215 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+217 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:215:14
+   --> $DIR/invalid-target.rs:217:14
     |
-215 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+217 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:215:24
+   --> $DIR/invalid-target.rs:217:24
     |
-215 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+217 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:215:44
+   --> $DIR/invalid-target.rs:217:44
     |
-215 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+217 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:215:57
+   --> $DIR/invalid-target.rs:217:57
     |
-215 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+217 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a trait alias
-   --> $DIR/invalid-target.rs:215:63
+   --> $DIR/invalid-target.rs:217:63
     |
-215 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+217 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a trait alias
-   --> $DIR/invalid-target.rs:216:5
+   --> $DIR/invalid-target.rs:218:5
     |
-216 |     unroll_loops, // fn/closure-only
+218 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:221:5
+   --> $DIR/invalid-target.rs:223:5
     |
-221 |     sampler, block, sampled_image, generic_image_type, // struct-only
+223 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:221:14
+   --> $DIR/invalid-target.rs:223:14
     |
-221 |     sampler, block, sampled_image, generic_image_type, // struct-only
+223 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:221:21
+   --> $DIR/invalid-target.rs:223:21
     |
-221 |     sampler, block, sampled_image, generic_image_type, // struct-only
+223 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a trait
-   --> $DIR/invalid-target.rs:221:36
+   --> $DIR/invalid-target.rs:223:36
     |
-221 |     sampler, block, sampled_image, generic_image_type, // struct-only
+223 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a trait
-   --> $DIR/invalid-target.rs:222:5
+   --> $DIR/invalid-target.rs:224:5
     |
-222 |     vertex, // fn-only
+224 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:223:5
+   --> $DIR/invalid-target.rs:225:5
     |
-223 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+225 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:223:14
+   --> $DIR/invalid-target.rs:225:14
     |
-223 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+225 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:223:24
+   --> $DIR/invalid-target.rs:225:24
     |
-223 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+225 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:223:44
+   --> $DIR/invalid-target.rs:225:44
     |
-223 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+225 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:223:57
+   --> $DIR/invalid-target.rs:225:57
     |
-223 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+225 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a trait
-   --> $DIR/invalid-target.rs:223:63
+   --> $DIR/invalid-target.rs:225:63
     |
-223 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+225 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a trait
-   --> $DIR/invalid-target.rs:224:5
+   --> $DIR/invalid-target.rs:226:5
     |
-224 |     unroll_loops, // fn/closure-only
+226 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:259:5
+   --> $DIR/invalid-target.rs:261:5
     |
-259 |     sampler, block, sampled_image, generic_image_type, // struct-only
+261 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:259:14
+   --> $DIR/invalid-target.rs:261:14
     |
-259 |     sampler, block, sampled_image, generic_image_type, // struct-only
+261 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:259:21
+   --> $DIR/invalid-target.rs:261:21
     |
-259 |     sampler, block, sampled_image, generic_image_type, // struct-only
+261 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a implementation block
-   --> $DIR/invalid-target.rs:259:36
+   --> $DIR/invalid-target.rs:261:36
     |
-259 |     sampler, block, sampled_image, generic_image_type, // struct-only
+261 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a implementation block
-   --> $DIR/invalid-target.rs:260:5
+   --> $DIR/invalid-target.rs:262:5
     |
-260 |     vertex, // fn-only
+262 |     vertex, // fn-only
     |     ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:261:5
+   --> $DIR/invalid-target.rs:263:5
     |
-261 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:261:14
+   --> $DIR/invalid-target.rs:263:14
     |
-261 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:261:24
+   --> $DIR/invalid-target.rs:263:24
     |
-261 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:261:44
+   --> $DIR/invalid-target.rs:263:44
     |
-261 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:261:57
+   --> $DIR/invalid-target.rs:263:57
     |
-261 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a implementation block
-   --> $DIR/invalid-target.rs:261:63
+   --> $DIR/invalid-target.rs:263:63
     |
-261 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+263 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a implementation block
-   --> $DIR/invalid-target.rs:262:5
+   --> $DIR/invalid-target.rs:264:5
     |
-262 |     unroll_loops, // fn/closure-only
+264 |     unroll_loops, // fn/closure-only
     |     ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:289:5
+   --> $DIR/invalid-target.rs:291:5
     |
-289 |     sampler, block, sampled_image, generic_image_type, // struct-only
+291 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |     ^^^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:289:14
+   --> $DIR/invalid-target.rs:291:14
     |
-289 |     sampler, block, sampled_image, generic_image_type, // struct-only
+291 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |              ^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:289:21
+   --> $DIR/invalid-target.rs:291:21
     |
-289 |     sampler, block, sampled_image, generic_image_type, // struct-only
+291 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                     ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function
-   --> $DIR/invalid-target.rs:289:36
+   --> $DIR/invalid-target.rs:291:36
     |
-289 |     sampler, block, sampled_image, generic_image_type, // struct-only
+291 |     sampler, block, sampled_image, generic_image_type, // struct-only
     |                                    ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:290:5
+   --> $DIR/invalid-target.rs:292:5
     |
-290 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+292 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |     ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:290:14
+   --> $DIR/invalid-target.rs:292:14
     |
-290 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+292 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |              ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:290:24
+   --> $DIR/invalid-target.rs:292:24
     |
-290 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+292 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:290:44
+   --> $DIR/invalid-target.rs:292:44
     |
-290 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+292 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                            ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:290:57
+   --> $DIR/invalid-target.rs:292:57
     |
-290 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+292 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                         ^^^^
 
 error: attribute is only valid on a function parameter, not on a function
-   --> $DIR/invalid-target.rs:290:63
+   --> $DIR/invalid-target.rs:292:63
     |
-290 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+292 |     uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                               ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:294:9
+   --> $DIR/invalid-target.rs:296:9
     |
-294 |         sampler, block, sampled_image, generic_image_type, // struct-only
+296 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:294:18
+   --> $DIR/invalid-target.rs:296:18
     |
-294 |         sampler, block, sampled_image, generic_image_type, // struct-only
+296 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:294:25
+   --> $DIR/invalid-target.rs:296:25
     |
-294 |         sampler, block, sampled_image, generic_image_type, // struct-only
+296 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a function param
-   --> $DIR/invalid-target.rs:294:40
+   --> $DIR/invalid-target.rs:296:40
     |
-294 |         sampler, block, sampled_image, generic_image_type, // struct-only
+296 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a function param
-   --> $DIR/invalid-target.rs:295:9
+   --> $DIR/invalid-target.rs:297:9
     |
-295 |         vertex, // fn-only
+297 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function or closure, not on a function param
-   --> $DIR/invalid-target.rs:296:9
+   --> $DIR/invalid-target.rs:298:9
     |
-296 |         unroll_loops, // fn/closure-only
+298 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:301:9
+   --> $DIR/invalid-target.rs:303:9
     |
-301 |         sampler, block, sampled_image, generic_image_type, // struct-only
+303 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:301:18
+   --> $DIR/invalid-target.rs:303:18
     |
-301 |         sampler, block, sampled_image, generic_image_type, // struct-only
+303 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:301:25
+   --> $DIR/invalid-target.rs:303:25
     |
-301 |         sampler, block, sampled_image, generic_image_type, // struct-only
+303 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a statement
-   --> $DIR/invalid-target.rs:301:40
+   --> $DIR/invalid-target.rs:303:40
     |
-301 |         sampler, block, sampled_image, generic_image_type, // struct-only
+303 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a statement
-   --> $DIR/invalid-target.rs:302:9
+   --> $DIR/invalid-target.rs:304:9
     |
-302 |         vertex, // fn-only
+304 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:303:9
+   --> $DIR/invalid-target.rs:305:9
     |
-303 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+305 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:303:18
+   --> $DIR/invalid-target.rs:305:18
     |
-303 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+305 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:303:28
+   --> $DIR/invalid-target.rs:305:28
     |
-303 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+305 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:303:48
+   --> $DIR/invalid-target.rs:305:48
     |
-303 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+305 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:303:61
+   --> $DIR/invalid-target.rs:305:61
     |
-303 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+305 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a statement
-   --> $DIR/invalid-target.rs:303:67
+   --> $DIR/invalid-target.rs:305:67
     |
-303 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+305 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a statement
-   --> $DIR/invalid-target.rs:304:9
+   --> $DIR/invalid-target.rs:306:9
     |
-304 |         unroll_loops, // fn/closure-only
+306 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:309:13
+   --> $DIR/invalid-target.rs:311:13
     |
-309 |             sampler, block, sampled_image, generic_image_type, // struct-only
+311 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:309:22
+   --> $DIR/invalid-target.rs:311:22
     |
-309 |             sampler, block, sampled_image, generic_image_type, // struct-only
+311 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:309:29
+   --> $DIR/invalid-target.rs:311:29
     |
-309 |             sampler, block, sampled_image, generic_image_type, // struct-only
+311 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a closure
-   --> $DIR/invalid-target.rs:309:44
+   --> $DIR/invalid-target.rs:311:44
     |
-309 |             sampler, block, sampled_image, generic_image_type, // struct-only
+311 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a closure
-   --> $DIR/invalid-target.rs:310:13
+   --> $DIR/invalid-target.rs:312:13
     |
-310 |             vertex, // fn-only
+312 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:311:13
+   --> $DIR/invalid-target.rs:313:13
     |
-311 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+313 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:311:22
+   --> $DIR/invalid-target.rs:313:22
     |
-311 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+313 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:311:32
+   --> $DIR/invalid-target.rs:313:32
     |
-311 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+313 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:311:52
+   --> $DIR/invalid-target.rs:313:52
     |
-311 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+313 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:311:65
+   --> $DIR/invalid-target.rs:313:65
     |
-311 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+313 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a closure
-   --> $DIR/invalid-target.rs:311:71
+   --> $DIR/invalid-target.rs:313:71
     |
-311 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+313 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:317:13
+   --> $DIR/invalid-target.rs:319:13
     |
-317 |             sampler, block, sampled_image, generic_image_type, // struct-only
+319 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:317:22
+   --> $DIR/invalid-target.rs:319:22
     |
-317 |             sampler, block, sampled_image, generic_image_type, // struct-only
+319 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:317:29
+   --> $DIR/invalid-target.rs:319:29
     |
-317 |             sampler, block, sampled_image, generic_image_type, // struct-only
+319 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a expression
-   --> $DIR/invalid-target.rs:317:44
+   --> $DIR/invalid-target.rs:319:44
     |
-317 |             sampler, block, sampled_image, generic_image_type, // struct-only
+319 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a expression
-   --> $DIR/invalid-target.rs:318:13
+   --> $DIR/invalid-target.rs:320:13
     |
-318 |             vertex, // fn-only
+320 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:319:13
+   --> $DIR/invalid-target.rs:321:13
     |
-319 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+321 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:319:22
+   --> $DIR/invalid-target.rs:321:22
     |
-319 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+321 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:319:32
+   --> $DIR/invalid-target.rs:321:32
     |
-319 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+321 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:319:52
+   --> $DIR/invalid-target.rs:321:52
     |
-319 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+321 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:319:65
+   --> $DIR/invalid-target.rs:321:65
     |
-319 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+321 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a expression
-   --> $DIR/invalid-target.rs:319:71
+   --> $DIR/invalid-target.rs:321:71
     |
-319 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+321 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a expression
-   --> $DIR/invalid-target.rs:320:13
+   --> $DIR/invalid-target.rs:322:13
     |
-320 |             unroll_loops, // fn/closure-only
+322 |             unroll_loops, // fn/closure-only
     |             ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:327:13
+   --> $DIR/invalid-target.rs:329:13
     |
-327 |             sampler, block, sampled_image, generic_image_type, // struct-only
+329 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:327:22
+   --> $DIR/invalid-target.rs:329:22
     |
-327 |             sampler, block, sampled_image, generic_image_type, // struct-only
+329 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:327:29
+   --> $DIR/invalid-target.rs:329:29
     |
-327 |             sampler, block, sampled_image, generic_image_type, // struct-only
+329 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:327:44
+   --> $DIR/invalid-target.rs:329:44
     |
-327 |             sampler, block, sampled_image, generic_image_type, // struct-only
+329 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a match arm
-   --> $DIR/invalid-target.rs:328:13
+   --> $DIR/invalid-target.rs:330:13
     |
-328 |             vertex, // fn-only
+330 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:329:13
+   --> $DIR/invalid-target.rs:331:13
     |
-329 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+331 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:329:22
+   --> $DIR/invalid-target.rs:331:22
     |
-329 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+331 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:329:32
+   --> $DIR/invalid-target.rs:331:32
     |
-329 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+331 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:329:52
+   --> $DIR/invalid-target.rs:331:52
     |
-329 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+331 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:329:65
+   --> $DIR/invalid-target.rs:331:65
     |
-329 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+331 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:329:71
+   --> $DIR/invalid-target.rs:331:71
     |
-329 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+331 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a match arm
-   --> $DIR/invalid-target.rs:330:13
+   --> $DIR/invalid-target.rs:332:13
     |
-330 |             unroll_loops, // fn/closure-only
+332 |             unroll_loops, // fn/closure-only
     |             ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:9
+   --> $DIR/invalid-target.rs:340:9
     |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+340 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:18
+   --> $DIR/invalid-target.rs:340:18
     |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+340 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:25
+   --> $DIR/invalid-target.rs:340:25
     |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+340 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:338:40
+   --> $DIR/invalid-target.rs:340:40
     |
-338 |         sampler, block, sampled_image, generic_image_type, // struct-only
+340 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:339:9
+   --> $DIR/invalid-target.rs:341:9
     |
-339 |         vertex, // fn-only
+341 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:9
+   --> $DIR/invalid-target.rs:342:9
     |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+342 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:18
+   --> $DIR/invalid-target.rs:342:18
     |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+342 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:28
+   --> $DIR/invalid-target.rs:342:28
     |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+342 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:48
+   --> $DIR/invalid-target.rs:342:48
     |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+342 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:61
+   --> $DIR/invalid-target.rs:342:61
     |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+342 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:340:67
+   --> $DIR/invalid-target.rs:342:67
     |
-340 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+342 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:341:9
+   --> $DIR/invalid-target.rs:343:9
     |
-341 |         unroll_loops, // fn/closure-only
+343 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:9
+   --> $DIR/invalid-target.rs:346:9
     |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+346 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:18
+   --> $DIR/invalid-target.rs:346:18
     |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+346 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:25
+   --> $DIR/invalid-target.rs:346:25
     |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+346 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:344:40
+   --> $DIR/invalid-target.rs:346:40
     |
-344 |         sampler, block, sampled_image, generic_image_type, // struct-only
+346 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a type parameter
-   --> $DIR/invalid-target.rs:345:9
+   --> $DIR/invalid-target.rs:347:9
     |
-345 |         vertex, // fn-only
+347 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:9
+   --> $DIR/invalid-target.rs:348:9
     |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+348 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:18
+   --> $DIR/invalid-target.rs:348:18
     |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+348 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:28
+   --> $DIR/invalid-target.rs:348:28
     |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+348 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:48
+   --> $DIR/invalid-target.rs:348:48
     |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+348 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:61
+   --> $DIR/invalid-target.rs:348:61
     |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+348 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:346:67
+   --> $DIR/invalid-target.rs:348:67
     |
-346 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+348 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a type parameter
-   --> $DIR/invalid-target.rs:347:9
+   --> $DIR/invalid-target.rs:349:9
     |
-347 |         unroll_loops, // fn/closure-only
+349 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:9
+   --> $DIR/invalid-target.rs:352:9
     |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+352 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:18
+   --> $DIR/invalid-target.rs:352:18
     |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+352 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:25
+   --> $DIR/invalid-target.rs:352:25
     |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+352 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:350:40
+   --> $DIR/invalid-target.rs:352:40
     |
-350 |         sampler, block, sampled_image, generic_image_type, // struct-only
+352 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a const parameter
-   --> $DIR/invalid-target.rs:351:9
+   --> $DIR/invalid-target.rs:353:9
     |
-351 |         vertex, // fn-only
+353 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:9
+   --> $DIR/invalid-target.rs:354:9
     |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+354 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:18
+   --> $DIR/invalid-target.rs:354:18
     |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+354 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:28
+   --> $DIR/invalid-target.rs:354:28
     |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+354 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:48
+   --> $DIR/invalid-target.rs:354:48
     |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+354 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:61
+   --> $DIR/invalid-target.rs:354:61
     |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+354 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:352:67
+   --> $DIR/invalid-target.rs:354:67
     |
-352 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+354 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a const parameter
-   --> $DIR/invalid-target.rs:353:9
+   --> $DIR/invalid-target.rs:355:9
     |
-353 |         unroll_loops, // fn/closure-only
+355 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:228:9
+   --> $DIR/invalid-target.rs:230:9
     |
-228 |         sampler, block, sampled_image, generic_image_type, // struct-only
+230 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:228:18
+   --> $DIR/invalid-target.rs:230:18
     |
-228 |         sampler, block, sampled_image, generic_image_type, // struct-only
+230 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:228:25
+   --> $DIR/invalid-target.rs:230:25
     |
-228 |         sampler, block, sampled_image, generic_image_type, // struct-only
+230 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:228:40
+   --> $DIR/invalid-target.rs:230:40
     |
-228 |         sampler, block, sampled_image, generic_image_type, // struct-only
+230 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated type
-   --> $DIR/invalid-target.rs:229:9
+   --> $DIR/invalid-target.rs:231:9
     |
-229 |         vertex, // fn-only
+231 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:230:9
+   --> $DIR/invalid-target.rs:232:9
     |
-230 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+232 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:230:18
+   --> $DIR/invalid-target.rs:232:18
     |
-230 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+232 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:230:28
+   --> $DIR/invalid-target.rs:232:28
     |
-230 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+232 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:230:48
+   --> $DIR/invalid-target.rs:232:48
     |
-230 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+232 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:230:61
+   --> $DIR/invalid-target.rs:232:61
     |
-230 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+232 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:230:67
+   --> $DIR/invalid-target.rs:232:67
     |
-230 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+232 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated type
-   --> $DIR/invalid-target.rs:231:9
+   --> $DIR/invalid-target.rs:233:9
     |
-231 |         unroll_loops, // fn/closure-only
+233 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:236:9
+   --> $DIR/invalid-target.rs:238:9
     |
-236 |         sampler, block, sampled_image, generic_image_type, // struct-only
+238 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:236:18
+   --> $DIR/invalid-target.rs:238:18
     |
-236 |         sampler, block, sampled_image, generic_image_type, // struct-only
+238 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:236:25
+   --> $DIR/invalid-target.rs:238:25
     |
-236 |         sampler, block, sampled_image, generic_image_type, // struct-only
+238 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:236:40
+   --> $DIR/invalid-target.rs:238:40
     |
-236 |         sampler, block, sampled_image, generic_image_type, // struct-only
+238 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated const
-   --> $DIR/invalid-target.rs:237:9
+   --> $DIR/invalid-target.rs:239:9
     |
-237 |         vertex, // fn-only
+239 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:238:9
+   --> $DIR/invalid-target.rs:240:9
     |
-238 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+240 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:238:18
+   --> $DIR/invalid-target.rs:240:18
     |
-238 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+240 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:238:28
+   --> $DIR/invalid-target.rs:240:28
     |
-238 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+240 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:238:48
+   --> $DIR/invalid-target.rs:240:48
     |
-238 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+240 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:238:61
+   --> $DIR/invalid-target.rs:240:61
     |
-238 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+240 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:238:67
+   --> $DIR/invalid-target.rs:240:67
     |
-238 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+240 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
-   --> $DIR/invalid-target.rs:239:9
+   --> $DIR/invalid-target.rs:241:9
     |
-239 |         unroll_loops, // fn/closure-only
+241 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a required trait method
-   --> $DIR/invalid-target.rs:244:9
+   --> $DIR/invalid-target.rs:246:9
     |
-244 |         sampler, block, sampled_image, generic_image_type, // struct-only
+246 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a required trait method
-   --> $DIR/invalid-target.rs:244:18
+   --> $DIR/invalid-target.rs:246:18
     |
-244 |         sampler, block, sampled_image, generic_image_type, // struct-only
+246 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a required trait method
-   --> $DIR/invalid-target.rs:244:25
+   --> $DIR/invalid-target.rs:246:25
     |
-244 |         sampler, block, sampled_image, generic_image_type, // struct-only
+246 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a required trait method
-   --> $DIR/invalid-target.rs:244:40
+   --> $DIR/invalid-target.rs:246:40
     |
-244 |         sampler, block, sampled_image, generic_image_type, // struct-only
+246 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a required trait method
-   --> $DIR/invalid-target.rs:245:9
+   --> $DIR/invalid-target.rs:247:9
     |
-245 |         vertex, // fn-only
+247 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a required trait method
-   --> $DIR/invalid-target.rs:246:9
+   --> $DIR/invalid-target.rs:248:9
     |
-246 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+248 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a required trait method
-   --> $DIR/invalid-target.rs:246:18
+   --> $DIR/invalid-target.rs:248:18
     |
-246 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+248 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a required trait method
-   --> $DIR/invalid-target.rs:246:28
+   --> $DIR/invalid-target.rs:248:28
     |
-246 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+248 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a required trait method
-   --> $DIR/invalid-target.rs:246:48
+   --> $DIR/invalid-target.rs:248:48
     |
-246 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+248 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a required trait method
-   --> $DIR/invalid-target.rs:246:61
+   --> $DIR/invalid-target.rs:248:61
     |
-246 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+248 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a required trait method
-   --> $DIR/invalid-target.rs:246:67
+   --> $DIR/invalid-target.rs:248:67
     |
-246 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+248 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a required trait method
-   --> $DIR/invalid-target.rs:247:9
+   --> $DIR/invalid-target.rs:249:9
     |
-247 |         unroll_loops, // fn/closure-only
+249 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:252:9
+   --> $DIR/invalid-target.rs:254:9
     |
-252 |         sampler, block, sampled_image, generic_image_type, // struct-only
+254 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:252:18
+   --> $DIR/invalid-target.rs:254:18
     |
-252 |         sampler, block, sampled_image, generic_image_type, // struct-only
+254 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:252:25
+   --> $DIR/invalid-target.rs:254:25
     |
-252 |         sampler, block, sampled_image, generic_image_type, // struct-only
+254 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:252:40
+   --> $DIR/invalid-target.rs:254:40
     |
-252 |         sampler, block, sampled_image, generic_image_type, // struct-only
+254 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:253:9
+   --> $DIR/invalid-target.rs:255:9
     |
-253 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+255 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:253:18
+   --> $DIR/invalid-target.rs:255:18
     |
-253 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+255 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:253:28
+   --> $DIR/invalid-target.rs:255:28
     |
-253 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+255 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:253:48
+   --> $DIR/invalid-target.rs:255:48
     |
-253 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+255 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:253:61
+   --> $DIR/invalid-target.rs:255:61
     |
-253 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+255 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:253:67
+   --> $DIR/invalid-target.rs:255:67
     |
-253 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+255 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:198:9
+   --> $DIR/invalid-target.rs:200:9
     |
-198 |         sampler, block, sampled_image, generic_image_type, // struct-only
+200 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:198:18
+   --> $DIR/invalid-target.rs:200:18
     |
-198 |         sampler, block, sampled_image, generic_image_type, // struct-only
+200 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:198:25
+   --> $DIR/invalid-target.rs:200:25
     |
-198 |         sampler, block, sampled_image, generic_image_type, // struct-only
+200 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:198:40
+   --> $DIR/invalid-target.rs:200:40
     |
-198 |         sampler, block, sampled_image, generic_image_type, // struct-only
+200 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated const
-   --> $DIR/invalid-target.rs:199:9
+   --> $DIR/invalid-target.rs:201:9
     |
-199 |         vertex, // fn-only
+201 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:200:9
+   --> $DIR/invalid-target.rs:202:9
     |
-200 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:200:18
+   --> $DIR/invalid-target.rs:202:18
     |
-200 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:200:28
+   --> $DIR/invalid-target.rs:202:28
     |
-200 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:200:48
+   --> $DIR/invalid-target.rs:202:48
     |
-200 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:200:61
+   --> $DIR/invalid-target.rs:202:61
     |
-200 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:200:67
+   --> $DIR/invalid-target.rs:202:67
     |
-200 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+202 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
-   --> $DIR/invalid-target.rs:201:9
+   --> $DIR/invalid-target.rs:203:9
     |
-201 |         unroll_loops, // fn/closure-only
+203 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a inherent method
-   --> $DIR/invalid-target.rs:206:9
+   --> $DIR/invalid-target.rs:208:9
     |
-206 |         sampler, block, sampled_image, generic_image_type, // struct-only
+208 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a inherent method
-   --> $DIR/invalid-target.rs:206:18
+   --> $DIR/invalid-target.rs:208:18
     |
-206 |         sampler, block, sampled_image, generic_image_type, // struct-only
+208 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a inherent method
-   --> $DIR/invalid-target.rs:206:25
+   --> $DIR/invalid-target.rs:208:25
     |
-206 |         sampler, block, sampled_image, generic_image_type, // struct-only
+208 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a inherent method
-   --> $DIR/invalid-target.rs:206:40
+   --> $DIR/invalid-target.rs:208:40
     |
-206 |         sampler, block, sampled_image, generic_image_type, // struct-only
+208 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a inherent method
-   --> $DIR/invalid-target.rs:207:9
+   --> $DIR/invalid-target.rs:209:9
     |
-207 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+209 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a inherent method
-   --> $DIR/invalid-target.rs:207:18
+   --> $DIR/invalid-target.rs:209:18
     |
-207 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+209 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a inherent method
-   --> $DIR/invalid-target.rs:207:28
+   --> $DIR/invalid-target.rs:209:28
     |
-207 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+209 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a inherent method
-   --> $DIR/invalid-target.rs:207:48
+   --> $DIR/invalid-target.rs:209:48
     |
-207 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+209 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a inherent method
-   --> $DIR/invalid-target.rs:207:61
+   --> $DIR/invalid-target.rs:209:61
     |
-207 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+209 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a inherent method
-   --> $DIR/invalid-target.rs:207:67
+   --> $DIR/invalid-target.rs:209:67
     |
-207 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+209 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:266:9
+   --> $DIR/invalid-target.rs:268:9
     |
-266 |         sampler, block, sampled_image, generic_image_type, // struct-only
+268 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:266:18
+   --> $DIR/invalid-target.rs:268:18
     |
-266 |         sampler, block, sampled_image, generic_image_type, // struct-only
+268 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:266:25
+   --> $DIR/invalid-target.rs:268:25
     |
-266 |         sampler, block, sampled_image, generic_image_type, // struct-only
+268 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type
-   --> $DIR/invalid-target.rs:266:40
+   --> $DIR/invalid-target.rs:268:40
     |
-266 |         sampler, block, sampled_image, generic_image_type, // struct-only
+268 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated type
-   --> $DIR/invalid-target.rs:267:9
+   --> $DIR/invalid-target.rs:269:9
     |
-267 |         vertex, // fn-only
+269 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:268:9
+   --> $DIR/invalid-target.rs:270:9
     |
-268 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+270 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:268:18
+   --> $DIR/invalid-target.rs:270:18
     |
-268 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+270 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:268:28
+   --> $DIR/invalid-target.rs:270:28
     |
-268 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+270 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:268:48
+   --> $DIR/invalid-target.rs:270:48
     |
-268 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+270 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:268:61
+   --> $DIR/invalid-target.rs:270:61
     |
-268 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+270 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated type
-   --> $DIR/invalid-target.rs:268:67
+   --> $DIR/invalid-target.rs:270:67
     |
-268 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+270 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated type
-   --> $DIR/invalid-target.rs:269:9
+   --> $DIR/invalid-target.rs:271:9
     |
-269 |         unroll_loops, // fn/closure-only
+271 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:274:9
+   --> $DIR/invalid-target.rs:276:9
     |
-274 |         sampler, block, sampled_image, generic_image_type, // struct-only
+276 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:274:18
+   --> $DIR/invalid-target.rs:276:18
     |
-274 |         sampler, block, sampled_image, generic_image_type, // struct-only
+276 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:274:25
+   --> $DIR/invalid-target.rs:276:25
     |
-274 |         sampler, block, sampled_image, generic_image_type, // struct-only
+276 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated const
-   --> $DIR/invalid-target.rs:274:40
+   --> $DIR/invalid-target.rs:276:40
     |
-274 |         sampler, block, sampled_image, generic_image_type, // struct-only
+276 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a associated const
-   --> $DIR/invalid-target.rs:275:9
+   --> $DIR/invalid-target.rs:277:9
     |
-275 |         vertex, // fn-only
+277 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:276:9
+   --> $DIR/invalid-target.rs:278:9
     |
-276 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+278 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:276:18
+   --> $DIR/invalid-target.rs:278:18
     |
-276 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+278 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:276:28
+   --> $DIR/invalid-target.rs:278:28
     |
-276 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+278 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:276:48
+   --> $DIR/invalid-target.rs:278:48
     |
-276 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+278 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:276:61
+   --> $DIR/invalid-target.rs:278:61
     |
-276 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+278 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a associated const
-   --> $DIR/invalid-target.rs:276:67
+   --> $DIR/invalid-target.rs:278:67
     |
-276 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+278 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a associated const
-   --> $DIR/invalid-target.rs:277:9
+   --> $DIR/invalid-target.rs:279:9
     |
-277 |         unroll_loops, // fn/closure-only
+279 |         unroll_loops, // fn/closure-only
     |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:282:9
+   --> $DIR/invalid-target.rs:284:9
     |
-282 |         sampler, block, sampled_image, generic_image_type, // struct-only
+284 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:282:18
+   --> $DIR/invalid-target.rs:284:18
     |
-282 |         sampler, block, sampled_image, generic_image_type, // struct-only
+284 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:282:25
+   --> $DIR/invalid-target.rs:284:25
     |
-282 |         sampler, block, sampled_image, generic_image_type, // struct-only
+284 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a provided trait method
-   --> $DIR/invalid-target.rs:282:40
+   --> $DIR/invalid-target.rs:284:40
     |
-282 |         sampler, block, sampled_image, generic_image_type, // struct-only
+284 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:283:9
+   --> $DIR/invalid-target.rs:285:9
     |
-283 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+285 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:283:18
+   --> $DIR/invalid-target.rs:285:18
     |
-283 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+285 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:283:28
+   --> $DIR/invalid-target.rs:285:28
     |
-283 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+285 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:283:48
+   --> $DIR/invalid-target.rs:285:48
     |
-283 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+285 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:283:61
+   --> $DIR/invalid-target.rs:285:61
     |
-283 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+285 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a provided trait method
-   --> $DIR/invalid-target.rs:283:67
+   --> $DIR/invalid-target.rs:285:67
     |
-283 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+285 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:75:9
+  --> $DIR/invalid-target.rs:77:9
    |
-75 |         sampler, block, sampled_image, generic_image_type, // struct-only
+77 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:75:18
+  --> $DIR/invalid-target.rs:77:18
    |
-75 |         sampler, block, sampled_image, generic_image_type, // struct-only
+77 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:75:25
+  --> $DIR/invalid-target.rs:77:25
    |
-75 |         sampler, block, sampled_image, generic_image_type, // struct-only
+77 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign type
-  --> $DIR/invalid-target.rs:75:40
+  --> $DIR/invalid-target.rs:77:40
    |
-75 |         sampler, block, sampled_image, generic_image_type, // struct-only
+77 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign type
-  --> $DIR/invalid-target.rs:76:9
+  --> $DIR/invalid-target.rs:78:9
    |
-76 |         vertex, // fn-only
+78 |         vertex, // fn-only
    |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:77:9
+  --> $DIR/invalid-target.rs:79:9
    |
-77 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+79 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:77:18
+  --> $DIR/invalid-target.rs:79:18
    |
-77 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+79 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:77:28
+  --> $DIR/invalid-target.rs:79:28
    |
-77 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+79 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:77:48
+  --> $DIR/invalid-target.rs:79:48
    |
-77 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+79 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:77:61
+  --> $DIR/invalid-target.rs:79:61
    |
-77 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+79 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign type
-  --> $DIR/invalid-target.rs:77:67
+  --> $DIR/invalid-target.rs:79:67
    |
-77 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+79 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign type
-  --> $DIR/invalid-target.rs:78:9
+  --> $DIR/invalid-target.rs:80:9
    |
-78 |         unroll_loops, // fn/closure-only
+80 |         unroll_loops, // fn/closure-only
    |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:83:9
+  --> $DIR/invalid-target.rs:85:9
    |
-83 |         sampler, block, sampled_image, generic_image_type, // struct-only
+85 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:83:18
+  --> $DIR/invalid-target.rs:85:18
    |
-83 |         sampler, block, sampled_image, generic_image_type, // struct-only
+85 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:83:25
+  --> $DIR/invalid-target.rs:85:25
    |
-83 |         sampler, block, sampled_image, generic_image_type, // struct-only
+85 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign static item
-  --> $DIR/invalid-target.rs:83:40
+  --> $DIR/invalid-target.rs:85:40
    |
-83 |         sampler, block, sampled_image, generic_image_type, // struct-only
+85 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign static item
-  --> $DIR/invalid-target.rs:84:9
+  --> $DIR/invalid-target.rs:86:9
    |
-84 |         vertex, // fn-only
+86 |         vertex, // fn-only
    |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:85:9
+  --> $DIR/invalid-target.rs:87:9
    |
-85 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:85:18
+  --> $DIR/invalid-target.rs:87:18
    |
-85 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:85:28
+  --> $DIR/invalid-target.rs:87:28
    |
-85 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:85:48
+  --> $DIR/invalid-target.rs:87:48
    |
-85 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:85:61
+  --> $DIR/invalid-target.rs:87:61
    |
-85 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign static item
-  --> $DIR/invalid-target.rs:85:67
+  --> $DIR/invalid-target.rs:87:67
    |
-85 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+87 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign static item
-  --> $DIR/invalid-target.rs:86:9
+  --> $DIR/invalid-target.rs:88:9
    |
-86 |         unroll_loops, // fn/closure-only
+88 |         unroll_loops, // fn/closure-only
    |         ^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:91:9
+  --> $DIR/invalid-target.rs:93:9
    |
-91 |         sampler, block, sampled_image, generic_image_type, // struct-only
+93 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:91:18
+  --> $DIR/invalid-target.rs:93:18
    |
-91 |         sampler, block, sampled_image, generic_image_type, // struct-only
+93 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:91:25
+  --> $DIR/invalid-target.rs:93:25
    |
-91 |         sampler, block, sampled_image, generic_image_type, // struct-only
+93 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a foreign function
-  --> $DIR/invalid-target.rs:91:40
+  --> $DIR/invalid-target.rs:93:40
    |
-91 |         sampler, block, sampled_image, generic_image_type, // struct-only
+93 |         sampler, block, sampled_image, generic_image_type, // struct-only
    |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a foreign function
-  --> $DIR/invalid-target.rs:92:9
+  --> $DIR/invalid-target.rs:94:9
    |
-92 |         vertex, // fn-only
+94 |         vertex, // fn-only
    |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:93:9
+  --> $DIR/invalid-target.rs:95:9
    |
-93 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+95 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:93:18
+  --> $DIR/invalid-target.rs:95:18
    |
-93 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+95 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:93:28
+  --> $DIR/invalid-target.rs:95:28
    |
-93 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+95 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:93:48
+  --> $DIR/invalid-target.rs:95:48
    |
-93 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+95 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:93:61
+  --> $DIR/invalid-target.rs:95:61
    |
-93 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+95 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a foreign function
-  --> $DIR/invalid-target.rs:93:67
+  --> $DIR/invalid-target.rs:95:67
    |
-93 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+95 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
    |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a function or closure, not on a foreign function
-  --> $DIR/invalid-target.rs:94:9
+  --> $DIR/invalid-target.rs:96:9
    |
-94 |         unroll_loops, // fn/closure-only
+96 |         unroll_loops, // fn/closure-only
    |         ^^^^^^^^^^^^
 
 error: aborting due to 473 previous errors


### PR DESCRIPTION
This PR adds the commented out `use spirv_std::spirv;` to `invalid-target.rs` in preparation for #926 