### PR TITLE
Changed the location of some `use` statements in tests

### DIFF
--- a/tests/ui/arch/all.rs
+++ b/tests/ui/arch/all.rs
@@ -1,6 +1,6 @@
-use spirv_std::spirv;
-
 // build-pass
+
+use spirv_std::spirv;
 
 #[spirv(fragment)]
 pub fn main() {

--- a/tests/ui/arch/any.rs
+++ b/tests/ui/arch/any.rs
@@ -1,6 +1,6 @@
-use spirv_std::spirv;
-
 // build-pass
+
+use spirv_std::spirv;
 
 #[spirv(fragment)]
 pub fn main() {

--- a/tests/ui/arch/convert_u_to_acceleration_structure_khr.rs
+++ b/tests/ui/arch/convert_u_to_acceleration_structure_khr.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+RayTracingKHR,+ext:SPV_KHR_ray_tracing
+
+use spirv_std::spirv;
 
 #[spirv(ray_generation)]
 pub fn main(#[spirv(ray_payload)] payload: &mut glam::Vec3) {

--- a/tests/ui/arch/demote_to_helper_invocation.rs
+++ b/tests/ui/arch/demote_to_helper_invocation.rs
@@ -1,8 +1,8 @@
-use spirv_std::spirv;
-
 // build-pass
 //
 // compile-flags: -C target-feature=+DemoteToHelperInvocationEXT,+ext:SPV_EXT_demote_to_helper_invocation
+
+use spirv_std::spirv;
 
 #[spirv(fragment)]
 pub fn main() {

--- a/tests/ui/arch/emit_stream_vertex.rs
+++ b/tests/ui/arch/emit_stream_vertex.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -C target-feature=+GeometryStreams
+
+use spirv_std::spirv;
 
 #[spirv(geometry(input_lines = 2, output_points = 2))]
 pub fn main() {

--- a/tests/ui/arch/emit_vertex.rs
+++ b/tests/ui/arch/emit_vertex.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+Geometry
+
+use spirv_std::spirv;
 
 #[spirv(geometry(input_lines = 2, output_points = 2))]
 pub fn main() {

--- a/tests/ui/arch/end_primitive.rs
+++ b/tests/ui/arch/end_primitive.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+Geometry
+
+use spirv_std::spirv;
 
 #[spirv(geometry(input_lines = 2, output_points = 2))]
 pub fn main() {

--- a/tests/ui/arch/end_stream_primitive.rs
+++ b/tests/ui/arch/end_stream_primitive.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -C target-feature=+GeometryStreams
+
+use spirv_std::spirv;
 
 #[spirv(geometry(input_lines = 2, output_points = 2))]
 pub fn main() {

--- a/tests/ui/arch/execute_callable.rs
+++ b/tests/ui/arch/execute_callable.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+RayTracingKHR,+ext:SPV_KHR_ray_tracing
+
+use spirv_std::spirv;
 
 #[spirv(ray_generation)]
 // Rustfmt will eat long attributes (https://github.com/rust-lang/rustfmt/issues/4579)

--- a/tests/ui/arch/ignore_intersection_khr.rs
+++ b/tests/ui/arch/ignore_intersection_khr.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+RayTracingKHR,+ext:SPV_KHR_ray_tracing
+
+use spirv_std::spirv;
 
 #[spirv(any_hit)]
 pub fn main() {

--- a/tests/ui/arch/kill.rs
+++ b/tests/ui/arch/kill.rs
@@ -1,6 +1,6 @@
-use spirv_std::spirv;
-
 // build-pass
+
+use spirv_std::spirv;
 
 #[spirv(fragment)]
 pub fn main() {

--- a/tests/ui/arch/report_intersection_khr.rs
+++ b/tests/ui/arch/report_intersection_khr.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+RayTracingKHR,+ext:SPV_KHR_ray_tracing
+
+use spirv_std::spirv;
 
 #[spirv(intersection)]
 pub fn main() {

--- a/tests/ui/arch/terminate_ray_khr.rs
+++ b/tests/ui/arch/terminate_ray_khr.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+RayTracingKHR,+ext:SPV_KHR_ray_tracing
+
+use spirv_std::spirv;
 
 #[spirv(any_hit)]
 pub fn main() {

--- a/tests/ui/arch/trace_ray_khr.rs
+++ b/tests/ui/arch/trace_ray_khr.rs
@@ -1,7 +1,7 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -Ctarget-feature=+RayTracingKHR,+ext:SPV_KHR_ray_tracing
+
+use spirv_std::spirv;
 
 #[spirv(ray_generation)]
 // Rustfmt will eat long attributes (https://github.com/rust-lang/rustfmt/issues/4579)

--- a/tests/ui/image/issue_527.rs
+++ b/tests/ui/image/issue_527.rs
@@ -1,9 +1,8 @@
-use spirv_std::spirv;
-
 // build-pass
 // compile-flags: -C target-feature=+StorageImageWriteWithoutFormat
 
 use glam::*;
+use spirv_std::spirv;
 
 #[spirv(compute(threads(1)))]
 pub fn main_cs(


### PR DESCRIPTION
See https://github.com/EmbarkStudios/rust-gpu/pull/926#pullrequestreview-1147204065

Basically, not very nice to put the `use spirv_std::spirv;` on the top line before some test comments.