### PR TITLE
Update to 0.4.0-alpha.17 and version fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0-alpha.17]
+
+### Changed 🛠️
+
+- Fixed rust-gpu crates not referring to each-other by exact version
+- Fixed `spirv-std` referring to an older version of `spirv-std-macros`
+
 ## [0.4.0-alpha.16]
 
 ### Added ⭐

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 dependencies = [
  "ar",
  "bimap",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "rustc_codegen_spirv-types"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 dependencies = [
  "rspirv",
  "serde",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-builder"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 dependencies = [
  "memchr",
  "notify",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 dependencies = [
  "bitflags",
  "glam",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-types"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 
 [[package]]
 name = "spirv-tools"

--- a/crates/rustc_codegen_spirv-types/Cargo.toml
+++ b/crates/rustc_codegen_spirv-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc_codegen_spirv-types"
 description = "SPIR-V backend types shared between rustc_codegen_spirv and spirv-builder"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -59,7 +59,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = { version = "1.6.1", features = ["union"] }
 spirv-tools = { version = "0.9", default-features = false }
-rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.16" }
+rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "=0.4.0-alpha.17" }
 
 [dev-dependencies]
 pipe = "0.4"

--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-builder"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ memchr = "2.4"
 raw-string = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "0.4.0-alpha.16" }
+rustc_codegen_spirv-types = { path = "../rustc_codegen_spirv-types", version = "=0.4.0-alpha.17" }
 # See comment in lib.rs invoke_rustc for why this is here
-rustc_codegen_spirv = { path = "../rustc_codegen_spirv", version = "0.4.0-alpha.16", default-features = false }
+rustc_codegen_spirv = { path = "../rustc_codegen_spirv", version = "=0.4.0-alpha.17", default-features = false }
 
 notify = { version = "5.0.0-pre.11", optional = true }

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,8 +10,8 @@ description = "Standard functions and types for SPIR-V"
 [dependencies]
 bitflags = "1.2.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
-spirv-std-types = { path = "./shared", version = "0.4.0-alpha.16" }
-spirv-std-macros = { path = "./macros", version = "0.4.0-alpha.13" }
+spirv-std-types = { path = "./shared", version = "=0.4.0-alpha.17" }
+spirv-std-macros = { path = "./macros", version = "=0.4.0-alpha.17" }
 glam = { version = "0.22", default-features = false, features = ["libm"], optional = true }
 
 [features]

--- a/crates/spirv-std/macros/Cargo.toml
+++ b/crates/spirv-std/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ description = "Macros for spirv-std"
 proc-macro = true
 
 [dependencies]
-spirv-std-types = { path = "../shared", version = "0.4.0-alpha.16" }
+spirv-std-types = { path = "../shared", version = "=0.4.0-alpha.17" }
 proc-macro2 = "1.0.24"
 quote = "1.0.8"
 syn = { version = "1.0.58", features=["full"] }

--- a/crates/spirv-std/shared/Cargo.toml
+++ b/crates/spirv-std/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spirv-std-types"
 description = "SPIR-V types shared between spirv-std and spirv-std-macros"
-version = "0.4.0-alpha.16"
+version = "0.4.0-alpha.17"
 authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,5 +14,5 @@ use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
 
 [dependencies]
 compiletest = { version = "0.7.0", package = "compiletest_rs" }
-rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", version = "0.4.0-alpha.16", default-features = false }
+rustc_codegen_spirv = { path = "../crates/rustc_codegen_spirv", version = "=0.4.0-alpha.17", default-features = false }
 structopt = "0.3.21"


### PR DESCRIPTION
* Specified exact versioning for crates within rust-gpu
* Fixed spirv-std referring to an older version of spirv-std-macros