### PR TITLE
default.nix: add `wayland` runtime deps.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,12 @@ in with pkgs; stdenv.mkDerivation rec {
 
   # Runtime dependencies.
   LD_LIBRARY_PATH = with xorg; lib.makeLibraryPath [
-    libX11 libXcursor libXi libXrandr vulkan-loader
+    vulkan-loader
+
+    # NOTE(eddyb) winit really wants `libxkbcommon` on Wayland for some reason
+    # (see https://github.com/rust-windowing/winit/issues/1760 for more info).
+    wayland libxkbcommon
+
+    libX11 libXcursor libXi libXrandr
   ];
 }


### PR DESCRIPTION
I believe I came up with these changes while working on another PR:
* #925

But they're not really tied to the update, since wayland support predates that update (even if a bit buggier?).

I don't even need this locally (since it works just fine via X) but want to get this random change out of the way.