### PR TITLE
CI/android: Select wgpu example by package name instead of manifest path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Build WGPU example for Android"
-          cargo apk build --manifest-path examples/runners/wgpu/Cargo.toml --features use-installed-tools --no-default-features
+          cargo apk build -p example-runner-wgpu --features use-installed-tools --no-default-features
           echo "::endgroup::"
 
   lint:


### PR DESCRIPTION
Specifying a manifest path still allows `cargo` and `cargo-apk` to find the workspace a package belongs to. We've decided that properly implementing [package selection](https://doc.rust-lang.org/cargo/commands/cargo-build.html#package-selection) between `cargo-apk` and `cargo-subcommand` would be [nontrivial](https://github.com/dvc94ch/cargo-subcommand/pull/23/files#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80R53-R57) and ended up requiring the package to be selected explicitly via `-p` for now.