### PR TITLE
Add rint & rintf libm intrinsics

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/libm_intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/libm_intrinsics.rs
@@ -167,6 +167,8 @@ pub const TABLE: &[(&str, LibmIntrinsic)] = &[
         "remquof",
         LibmIntrinsic::Custom(LibmCustomIntrinsic::RemQuo),
     ),
+    ("rint", LibmIntrinsic::GLOp(GLOp::RoundEven)),
+    ("rintf", LibmIntrinsic::GLOp(GLOp::RoundEven)),
     ("round", LibmIntrinsic::GLOp(GLOp::Round)),
     ("roundf", LibmIntrinsic::GLOp(GLOp::Round)),
     ("scalbn", LibmIntrinsic::Custom(LibmCustomIntrinsic::Scalbn)),


### PR DESCRIPTION
Hey, I added `rint` & `rintf` to fix compilation error with `libm` 2.0.6
Fixes #938

Also see https://github.com/rust-lang/libm/issues/273