### PR TITLE
examples/runner/cpu: switch to workspace inheritance.

### DIFF
--- a/examples/runners/cpu/Cargo.toml
+++ b/examples/runners/cpu/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "example-runner-cpu"
 version = "0.0.0"
-authors = ["Embark <opensource@embark-studios.com>"]
-edition = "2018"
-license = "MIT OR Apache-2.0"
 publish = false
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 minifb = "0.20.0"


### PR DESCRIPTION
Looks like @oisyn missed this originally?