### PR TITLE
linker/zombies: stop compilation after zombie errors.

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -182,7 +182,7 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
 
     {
         let _timer = sess.timer("link_remove_zombies");
-        zombies::remove_zombies(sess, &mut output);
+        zombies::remove_zombies(sess, &mut output)?;
     }
 
     {

--- a/tests/ui/lang/consts/nested-ref-in-composite.stderr
+++ b/tests/ui/lang/consts/nested-ref-in-composite.stderr
@@ -18,10 +18,5 @@ error: constant arrays/structs cannot contain pointers to other constants
            nested_ref_in_composite::main_array3
            main_array3
 
-error: error:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
-  |
-  = note: spirv-val failed
-  = note: module `$TEST_BUILD_DIR/lang/consts/nested-ref-in-composite.stage-id.spv.dir/module`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -4,10 +4,5 @@ error: pointer has non-null integer address
           allocate_const_scalar::main
           main
 
-error: error:0:0 - No OpEntryPoint instruction was found. This is only allowed if the Linkage capability is being used.
-  |
-  = note: spirv-val failed
-  = note: module `$TEST_BUILD_DIR/lang/core/ptr/allocate_const_scalar.stage-id.spv.dir/module`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 


### PR DESCRIPTION
It's a bit silly to get `spirv-val` validation errors when we already decided compilation won't succeed.
(IIRC I did this in a context where this prevents other code from crashing due to invalid SPIR-V)