### PR TITLE
Replace `bimap` dependency with a more efficient pair of maps, and arena-allocate slices.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,12 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bimap"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ae17cabbc8a38a1e3e4c1a6a664e9a09672dc14d0896fa8d865d3a5a446b07"
-
-[[package]]
 name = "bindgen"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,7 +1992,6 @@ name = "rustc_codegen_spirv"
 version = "0.4.0-alpha.17"
 dependencies = [
  "ar",
- "bimap",
  "hashbrown",
  "indexmap",
  "libc",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -47,7 +47,6 @@ regex = { version = "1", features = ["perf"] }
 
 # Normal dependencies.
 ar = "0.9.0"
-bimap = "0.6"
 indexmap = "1.6.0"
 rspirv = "0.11"
 rustc-demangle = "0.1.21"

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -1081,7 +1081,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             (OperandKind::LiteralContextDependentNumber, Some(word)) => {
                 assert!(matches!(inst.class.opcode, Op::Constant | Op::SpecConstant));
                 let ty = inst.result_type.unwrap();
-                fn parse(ty: SpirvType, w: &str) -> Result<dr::Operand, String> {
+                fn parse(ty: SpirvType<'_>, w: &str) -> Result<dr::Operand, String> {
                     fn fmt(x: impl ToString) -> String {
                         x.to_string()
                     }

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -232,6 +232,7 @@ pub enum SpirvConst {
     // different functions, but of the same type, don't overlap their zombies.
     ZombieUndefForFnAddr,
 
+    // FIXME(eddyb) use `tcx.arena.dropless` to get `&'tcx [_]`, instead of `Rc`.
     Composite(Rc<[Word]>),
 
     /// Pointer to constant data, i.e. `&pointee`, represented as an `OpVariable`

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -12,34 +12,38 @@ use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::{self, AddressSpace, HasDataLayout, Integer, Primitive, Size};
 
 impl<'tcx> CodegenCx<'tcx> {
+    pub fn def_constant(&self, ty: Word, val: SpirvConst<'_>) -> SpirvValue {
+        self.builder.def_constant_cx(ty, val, self)
+    }
+
     pub fn constant_u8(&self, span: Span, val: u8) -> SpirvValue {
         let ty = SpirvType::Integer(8, false).def(span, self);
-        self.builder.def_constant(ty, SpirvConst::U32(val as u32))
+        self.def_constant(ty, SpirvConst::U32(val as u32))
     }
 
     pub fn constant_i16(&self, span: Span, val: i16) -> SpirvValue {
         let ty = SpirvType::Integer(16, true).def(span, self);
-        self.builder.def_constant(ty, SpirvConst::U32(val as u32))
+        self.def_constant(ty, SpirvConst::U32(val as u32))
     }
 
     pub fn constant_u16(&self, span: Span, val: u16) -> SpirvValue {
         let ty = SpirvType::Integer(16, false).def(span, self);
-        self.builder.def_constant(ty, SpirvConst::U32(val as u32))
+        self.def_constant(ty, SpirvConst::U32(val as u32))
     }
 
     pub fn constant_i32(&self, span: Span, val: i32) -> SpirvValue {
         let ty = SpirvType::Integer(32, true).def(span, self);
-        self.builder.def_constant(ty, SpirvConst::U32(val as u32))
+        self.def_constant(ty, SpirvConst::U32(val as u32))
     }
 
     pub fn constant_u32(&self, span: Span, val: u32) -> SpirvValue {
         let ty = SpirvType::Integer(32, false).def(span, self);
-        self.builder.def_constant(ty, SpirvConst::U32(val))
+        self.def_constant(ty, SpirvConst::U32(val))
     }
 
     pub fn constant_u64(&self, span: Span, val: u64) -> SpirvValue {
         let ty = SpirvType::Integer(64, false).def(span, self);
-        self.builder.def_constant(ty, SpirvConst::U64(val))
+        self.def_constant(ty, SpirvConst::U64(val))
     }
 
     pub fn constant_int(&self, ty: Word, val: u64) -> SpirvValue {
@@ -47,7 +51,7 @@ impl<'tcx> CodegenCx<'tcx> {
             SpirvType::Integer(bits @ 8..=32, signed) => {
                 let size = Size::from_bits(bits);
                 let val = val as u128;
-                self.builder.def_constant(
+                self.def_constant(
                     ty,
                     SpirvConst::U32(if signed {
                         size.sign_extend(val)
@@ -56,9 +60,9 @@ impl<'tcx> CodegenCx<'tcx> {
                     } as u32),
                 )
             }
-            SpirvType::Integer(64, _) => self.builder.def_constant(ty, SpirvConst::U64(val)),
+            SpirvType::Integer(64, _) => self.def_constant(ty, SpirvConst::U64(val)),
             SpirvType::Bool => match val {
-                0 | 1 => self.builder.def_constant(ty, SpirvConst::Bool(val != 0)),
+                0 | 1 => self.def_constant(ty, SpirvConst::Bool(val != 0)),
                 _ => self
                     .tcx
                     .sess
@@ -78,24 +82,18 @@ impl<'tcx> CodegenCx<'tcx> {
 
     pub fn constant_f32(&self, span: Span, val: f32) -> SpirvValue {
         let ty = SpirvType::Float(32).def(span, self);
-        self.builder
-            .def_constant(ty, SpirvConst::F32(val.to_bits()))
+        self.def_constant(ty, SpirvConst::F32(val.to_bits()))
     }
 
     pub fn constant_f64(&self, span: Span, val: f64) -> SpirvValue {
         let ty = SpirvType::Float(64).def(span, self);
-        self.builder
-            .def_constant(ty, SpirvConst::F64(val.to_bits()))
+        self.def_constant(ty, SpirvConst::F64(val.to_bits()))
     }
 
     pub fn constant_float(&self, ty: Word, val: f64) -> SpirvValue {
         match self.lookup_type(ty) {
-            SpirvType::Float(32) => self
-                .builder
-                .def_constant(ty, SpirvConst::F32((val as f32).to_bits())),
-            SpirvType::Float(64) => self
-                .builder
-                .def_constant(ty, SpirvConst::F64(val.to_bits())),
+            SpirvType::Float(32) => self.def_constant(ty, SpirvConst::F32((val as f32).to_bits())),
+            SpirvType::Float(64) => self.def_constant(ty, SpirvConst::F64(val.to_bits())),
             other => self.tcx.sess.fatal(&format!(
                 "constant_float invalid on type {}",
                 other.debug(ty, self)
@@ -105,20 +103,20 @@ impl<'tcx> CodegenCx<'tcx> {
 
     pub fn constant_bool(&self, span: Span, val: bool) -> SpirvValue {
         let ty = SpirvType::Bool.def(span, self);
-        self.builder.def_constant(ty, SpirvConst::Bool(val))
+        self.def_constant(ty, SpirvConst::Bool(val))
     }
 
     pub fn constant_composite(&self, ty: Word, fields: impl Iterator<Item = Word>) -> SpirvValue {
-        self.builder
-            .def_constant(ty, SpirvConst::Composite(fields.collect()))
+        // FIXME(eddyb) use `AccumulateVec`s just like `rustc` itself does.
+        self.def_constant(ty, SpirvConst::Composite(&fields.collect::<Vec<_>>()))
     }
 
     pub fn constant_null(&self, ty: Word) -> SpirvValue {
-        self.builder.def_constant(ty, SpirvConst::Null)
+        self.def_constant(ty, SpirvConst::Null)
     }
 
     pub fn undef(&self, ty: Word) -> SpirvValue {
-        self.builder.def_constant(ty, SpirvConst::Undef)
+        self.def_constant(ty, SpirvConst::Undef)
     }
 }
 
@@ -172,7 +170,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
             .spirv_type(DUMMY_SP, self);
         // FIXME(eddyb) include the actual byte data.
         (
-            self.builder.def_constant(
+            self.def_constant(
                 self.type_ptr_to(str_ty),
                 SpirvConst::PtrTo {
                     pointee: self.undef(str_ty).def_cx(self),
@@ -183,14 +181,15 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
     }
     fn const_struct(&self, elts: &[Self::Value], _packed: bool) -> Self::Value {
         // Presumably this will get bitcasted to the right type?
+        // FIXME(eddyb) use `AccumulateVec`s just like `rustc` itself does.
         let field_types = elts.iter().map(|f| f.ty).collect::<Vec<_>>();
         let (field_offsets, size, align) = crate::abi::auto_struct_layout(self, &field_types);
         let struct_ty = SpirvType::Adt {
             def_id: None,
             size,
             align,
-            field_types,
-            field_offsets,
+            field_types: &field_types,
+            field_offsets: &field_offsets,
             field_names: None,
         }
         .def(DUMMY_SP, self);

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -259,7 +259,7 @@ impl<'tcx> PreDefineMethods<'tcx> for CodegenCx<'tcx> {
 
 impl<'tcx> StaticMethods for CodegenCx<'tcx> {
     fn static_addr_of(&self, cv: Self::Value, _align: Align, _kind: Option<&str>) -> Self::Value {
-        self.builder.def_constant(
+        self.def_constant(
             self.type_ptr_to(cv.ty),
             SpirvConst::PtrTo {
                 pointee: cv.def_cx(self),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -125,7 +125,7 @@ impl<'tcx> CodegenCx<'tcx> {
             let void = SpirvType::Void.def(span, self);
             let fn_void_void = SpirvType::Function {
                 return_type: void,
-                arguments: vec![],
+                arguments: &[],
             }
             .def(span, self);
             let mut emit = self.emit_global();
@@ -666,7 +666,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 SpirvType::Bool => *has_bool = true,
                 SpirvType::Integer(_, _) | SpirvType::Float(64) => *must_be_flat = true,
                 SpirvType::Adt { field_types, .. } => {
-                    for f in field_types {
+                    for &f in field_types {
                         recurse(cx, f, has_bool, must_be_flat);
                     }
                 }
@@ -683,7 +683,7 @@ impl<'tcx> CodegenCx<'tcx> {
                     arguments,
                 } => {
                     recurse(cx, return_type, has_bool, must_be_flat);
-                    for a in arguments {
+                    for &a in arguments {
                         recurse(cx, a, has_bool, must_be_flat);
                     }
                 }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -144,9 +144,11 @@ impl<'tcx> CodegenCx<'tcx> {
         self.builder.builder(cursor)
     }
 
+    // FIXME(eddyb) this should not clone the `SpirvType` back out, but we'd have
+    // to fix ~100 callsites (to add a `*` deref), if we change this signature.
     #[track_caller]
     pub fn lookup_type(&self, ty: Word) -> SpirvType {
-        self.type_cache.lookup(ty)
+        (*self.type_cache.lookup(ty)).clone()
     }
 
     pub fn debug_type<'cx>(&'cx self, ty: Word) -> SpirvTypePrinter<'cx, 'tcx> {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -180,18 +180,19 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
     fn type_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type {
         SpirvType::Function {
             return_type: ret,
-            arguments: args.to_vec(),
+            arguments: args,
         }
         .def(DUMMY_SP, self)
     }
     fn type_struct(&self, els: &[Self::Type], _packed: bool) -> Self::Type {
+        // FIXME(eddyb) use `AccumulateVec`s just like `rustc` itself does.
         let (field_offsets, size, align) = crate::abi::auto_struct_layout(self, els);
         SpirvType::Adt {
             def_id: None,
             align,
             size,
-            field_types: els.to_vec(),
-            field_offsets,
+            field_types: els,
+            field_offsets: &field_offsets,
             field_names: None,
         }
         .def(DUMMY_SP, self)

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -16,6 +16,7 @@ pub struct Symbols {
     // Used by `is_blocklisted_fn`.
     pub fmt_decimal: Symbol,
 
+    pub discriminant: Symbol,
     pub rust_gpu: Symbol,
     pub spirv: Symbol,
     pub spirv_std: Symbol,
@@ -24,9 +25,11 @@ pub struct Symbols {
     pub entry_point_name: Symbol,
     pub spv_intel_shader_integer_functions2: Symbol,
     pub spv_khr_vulkan_memory_model: Symbol,
+
     descriptor_set: Symbol,
     binding: Symbol,
     input_attachment_index: Symbol,
+
     attributes: FxHashMap<Symbol, SpirvAttribute>,
     execution_modes: FxHashMap<Symbol, (ExecutionMode, ExecutionModeExtraDim)>,
     pub libm_intrinsics: FxHashMap<Symbol, libm_intrinsics::LibmIntrinsic>,
@@ -373,6 +376,7 @@ impl Symbols {
         Self {
             fmt_decimal: Symbol::intern("fmt_decimal"),
 
+            discriminant: Symbol::intern("discriminant"),
             rust_gpu: Symbol::intern("rust_gpu"),
             spirv: Symbol::intern("spirv"),
             spirv_std: Symbol::intern("spirv_std"),
@@ -383,9 +387,11 @@ impl Symbols {
                 "SPV_INTEL_shader_integer_functions2",
             ),
             spv_khr_vulkan_memory_model: Symbol::intern("SPV_KHR_vulkan_memory_model"),
+
             descriptor_set: Symbol::intern("descriptor_set"),
             binding: Symbol::intern("binding"),
             input_attachment_index: Symbol::intern("input_attachment_index"),
+
             attributes,
             execution_modes,
             libm_intrinsics,

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -641,9 +641,7 @@ fn parse_entry_attrs(
                             return Err((
                                 attr_name.span,
                                 format!(
-                                    "#[spirv({}(..))] unknown attribute argument {}",
-                                    name.name.to_ident_string(),
-                                    attr_name.name.to_ident_string()
+                                    "#[spirv({name}(..))] unknown attribute argument {attr_name}"
                                 ),
                             ))
                         }
@@ -651,20 +649,13 @@ fn parse_entry_attrs(
                 } else {
                     return Err((
                         attr_name.span,
-                        format!(
-                            "#[spirv({}(..))] unknown attribute argument {}",
-                            name.name.to_ident_string(),
-                            attr_name.name.to_ident_string()
-                        ),
+                        format!("#[spirv({name}(..))] unknown attribute argument {attr_name}",),
                     ));
                 }
             } else {
                 return Err((
                     arg.span(),
-                    format!(
-                        "#[spirv({}(..))] attribute argument must be single identifier",
-                        name.name.to_ident_string()
-                    ),
+                    format!("#[spirv({name}(..))] attribute argument must be single identifier"),
                 ));
             }
         }


### PR DESCRIPTION
This originally was a prerequisite for introducing some asymmetry (for finer-grained zombies) in the maps, which `bimap` made impossible because it guarantees 1:1 (even when using `insert` instead of `insert_no_overwrite`, what it does is it removes any entries related to either side *first*, then adds the new pair of entries).

But it turned into a refactor of its own, once I realized I can get rid of per-entry allocations, using the power of `tcx.arena.dropless`. <sub>(an untyped arena that allows allocating individual values, or whole slices, as long as they're `!Drop` - this works great because there is no "drop to remember", which reduces overhead and soundness complexity - and by using the slice feature, at the very least `Vec`s can be replaced, and even entire data-recursive trees could be arena-allocated, even if it sadly doesn't generalize to e.g. `HashMap`/`BTreeMap`)</sub>

I haven't profiled this but it might be a bit faster? We were being pretty wasteful before, esp. `lookup_type` would `.clone()` variants of `SpirvType` that had `Vec`s in them, whereas now it's merely copying `&[T]`s.

Probably best to review each commit separately, matching the refactor stages.