### PR TITLE
Use `Span`s to detect "system crate"s, for error deferral (zombie) purposes.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -1473,7 +1473,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 .with_type(dest_ty);
 
             if val_is_ptr || dest_is_ptr {
-                if self.is_system_crate() {
+                if self.is_system_crate(self.span()) {
                     self.zombie(
                         result.def(self),
                         &format!(

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -149,7 +149,7 @@ impl SpirvValue {
             }
 
             SpirvValueKind::FnAddr { .. } => {
-                if cx.is_system_crate() {
+                if cx.is_system_crate(span) {
                     cx.builder
                         .const_to_id
                         .borrow()
@@ -160,9 +160,10 @@ impl SpirvValue {
                         .expect("FnAddr didn't go through proper undef registration")
                         .val
                 } else {
-                    cx.tcx
-                        .sess
-                        .err("Cannot use this function pointer for anything other than calls");
+                    cx.tcx.sess.span_err(
+                        span,
+                        "Cannot use this function pointer for anything other than calls",
+                    );
                     // Because we never get beyond compilation (into e.g. linking),
                     // emitting an invalid ID reference here is OK.
                     0
@@ -174,7 +175,7 @@ impl SpirvValue {
                 original_pointee_ty,
                 zombie_target_undef,
             } => {
-                if cx.is_system_crate() {
+                if cx.is_system_crate(span) {
                     cx.zombie_with_span(
                         zombie_target_undef,
                         span,

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -3,6 +3,12 @@ error: Cannot memcpy dynamically sized data
      |
 2431 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
+     |
+     = note: Stack:
+             core::intrinsics::copy::<f32>
+             ptr_copy::copy_via_raw_ptr
+             ptr_copy::main
+             main
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Before this PR, the distinction between "user code" and "system code" (e.g. `core` APIs) was based on the crate "doing the codegen", but `#[inline]`/generic `fn`s (and even macros) can cause e.g. `core` internals to be codegen'd *during the compilation of an user crate*.

This used to not be a big issue, because "zombies" (i.e. deferred errors) only get silenced when they're in unused code, so they mostly served to hide errors in e.g. `core` internals that *would not* be codegen'd at all, had they had `#[inline]`.

*However*, we've accumulated several features which rely on *hiding* various potentially-zombie things (such as the panic entry-point hijacking, or the "unused `fn` params" weakening), so we need to be using "zombies" (i.e. deferring errors) as much as possible, in order to actually take advantage of that infrastructure.

(I could've gone further and *removed* `is_system_crate`, forcing `zombie_even_in_user_code`'s behavior always, but that might lead to confusing outcomes, so I decided against it - for now, anyway)