### PR TITLE
Switch to Rust 2021.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 🛠️
 - [PR#982](https://github.com/EmbarkStudios/rust-gpu/pull/982) updated toolchain to `nightly-2022-12-18`
+- [PR#953](https://github.com/EmbarkStudios/rust-gpu/pull/953) migrated to the Rust 2021 edition, and fixed Rust 2021 support for shader crates to be on par with Rust 2018 (discrepancies having been limited to/caused by `panic!` changes in Rust 2021)
 
 ## [0.4.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 [workspace.package]
 version = "0.4.0"
 authors = ["Embark <opensource@embark-studios.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/rust-gpu"
 

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -612,7 +612,7 @@ fn trans_aggregate<'tcx>(cx: &CodegenCx<'tcx>, span: Span, ty: TyAndLayout<'tcx>
             ty
         ),
         FieldsShape::Union(_) => {
-            assert!(!ty.is_unsized(), "{:#?}", ty);
+            assert!(!ty.is_unsized(), "{ty:#?}");
             if ty.size.bytes() == 0 {
                 create_zst(cx, span, ty)
             } else {

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -616,10 +616,14 @@ impl<'tcx> BuilderSpirv<'tcx> {
         SpirvValue { kind, ty }
     }
 
+    pub fn lookup_const_by_id(&self, id: Word) -> Option<SpirvConst<'tcx>> {
+        Some(self.id_to_const.borrow().get(&id)?.val)
+    }
+
     pub fn lookup_const(&self, def: SpirvValue) -> Option<SpirvConst<'tcx>> {
         match def.kind {
             SpirvValueKind::Def(id) | SpirvValueKind::IllegalConst(id) => {
-                Some(self.id_to_const.borrow().get(&id)?.val)
+                self.lookup_const_by_id(id)
             }
             _ => None,
         }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -181,8 +181,7 @@ impl<'tcx> CodegenCx<'tcx> {
             .contains_key(&MonoItem::Static(def_id));
         assert!(
             !defined_in_current_codegen_unit,
-            "get_static() should always hit the cache for statics defined in the same CGU, but did not for `{:?}`",
-            def_id
+            "get_static() should always hit the cache for statics defined in the same CGU, but did not for `{def_id:?}`"
         );
 
         let ty = instance.ty(self.tcx, ParamEnv::reveal_all());

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -149,11 +149,21 @@ impl<'tcx> CodegenCx<'tcx> {
             }
         }
 
-        if Some(instance_def_id) == self.tcx.lang_items().panic_fn() {
-            self.panic_fn_id.set(Some(fn_id));
+        if [
+            self.tcx.lang_items().panic_fn(),
+            self.tcx.lang_items().panic_fmt(),
+            self.tcx.lang_items().panic_display(),
+            self.tcx.lang_items().panic_bounds_check_fn(),
+        ]
+        .contains(&Some(instance_def_id))
+        {
+            self.panic_entry_point_ids.borrow_mut().insert(fn_id);
         }
-        if Some(instance_def_id) == self.tcx.lang_items().panic_bounds_check_fn() {
-            self.panic_bounds_check_fn_id.set(Some(fn_id));
+
+        // HACK(eddyb) there is no good way to identify this definition
+        // (e.g. no `#[lang = "..."]` attribute), but this works well enough.
+        if demangled_symbol_name == "<core::fmt::Arguments>::new_v1" {
+            self.fmt_args_new_fn_ids.borrow_mut().insert(fn_id);
         }
 
         declared

--- a/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
+++ b/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
@@ -95,7 +95,7 @@ pub fn outgoing_edges(block: &Block) -> impl Iterator<Item = Word> + '_ {
         | Op::Unreachable
         | Op::IgnoreIntersectionKHR
         | Op::TerminateRayKHR => (0..0).step_by(1),
-        _ => panic!("Invalid block terminator: {:?}", terminator),
+        _ => panic!("Invalid block terminator: {terminator:?}"),
     };
     operand_indices.map(move |i| terminator.operands[i].unwrap_id_ref())
 }

--- a/crates/rustc_codegen_spirv/src/linker/specializer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/specializer.rs
@@ -2308,8 +2308,7 @@ impl<'a, S: Specialization> Expander<'a, S> {
             let func_id = inst.operands[1].unwrap_id_ref();
             assert!(
                 !self.specializer.generics.contains_key(&func_id),
-                "entry-point %{} shouldn't be \"generic\"",
-                func_id
+                "entry-point %{func_id} shouldn't be \"generic\""
             );
 
             for interface_operand in &mut inst.operands[3..] {

--- a/crates/rustc_codegen_spirv/src/linker/structurizer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/structurizer.rs
@@ -226,7 +226,7 @@ impl Structurizer<'_> {
 
                     self.selection_merge_regions(block, &child_regions)
                 }
-                _ => panic!("Invalid block terminator: {:?}", terminator),
+                _ => panic!("Invalid block terminator: {terminator:?}"),
             };
 
             // Peel off deferred exits which have all their edges accounted for

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -396,7 +396,7 @@ fn find_rustc_codegen_spirv() -> PathBuf {
             return path;
         }
     }
-    panic!("Could not find {} in library path", filename);
+    panic!("Could not find {filename} in library path");
 }
 
 /// Joins strings together while ensuring none of the strings contain the separator.
@@ -404,12 +404,7 @@ fn find_rustc_codegen_spirv() -> PathBuf {
 fn join_checking_for_separators(strings: Vec<impl Borrow<str>>, sep: &str) -> String {
     for s in &strings {
         let s = s.borrow();
-        assert!(
-            !s.contains(sep),
-            "{:?} may not contain separator {:?}",
-            s,
-            sep
-        );
+        assert!(!s.contains(sep), "{s:?} may not contain separator {sep:?}");
     }
     strings.join(sep)
 }
@@ -575,8 +570,7 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         get_sole_artifact(&stdout).ok_or_else(|| {
             eprintln!("--- build output ---\n{stdout}");
             panic!(
-                "`{}` artifact not found in (supposedly successful) build output (see above)",
-                ARTIFACT_SUFFIX
+                "`{ARTIFACT_SUFFIX}` artifact not found in (supposedly successful) build output (see above)"
             );
         })
     } else {

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -880,7 +880,7 @@ impl RenderCtx {
                     self.recreate_swapchain();
                     return;
                 }
-                Err(err) => panic!("failed to acquire next image: {:?}", err),
+                Err(err) => panic!("failed to acquire next image: {err:?}"),
             }
         };
 
@@ -912,7 +912,7 @@ impl RenderCtx {
             {
                 Err(vk::Result::ERROR_OUT_OF_DATE_KHR) | Ok(true) => self.recreate_swapchain(),
                 Ok(false) => {}
-                Err(err) => panic!("failed to present queue: {:?}", err),
+                Err(err) => panic!("failed to present queue: {err:?}"),
             };
         }
     }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -395,5 +395,5 @@ fn find_rustc_codegen_spirv() -> PathBuf {
             return path;
         }
     }
-    panic!("Could not find {} in library path", filename);
+    panic!("Could not find {filename} in library path");
 }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -105,7 +105,7 @@ impl Runner {
                     .iter()
                     .map(|dir| format!("-L dependency={}", dir.display()))
                     .fold(String::new(), |a, b| b + " " + &a),
-                "--edition 2018",
+                "--edition 2021",
                 &*format!("--extern noprelude:core={}", deps.core.display()),
                 &*format!(
                     "--extern noprelude:compiler_builtins={}",


### PR DESCRIPTION
*This PR is built on the following PRs: (**EDIT**: now all of them merged)*
* #949
* #952
  * itself required #950
* #951

---

~~Sadly, this is not ready. The big issue here is that Rust 2021 makes `panic!("...")` go through the same `format_args!("...")` machinery as everything else (i.e. its special-casing was removed - this means that e.g. `panic!("foo: {}")` no long bypasses format string checks, and actually errors).~~

~~While we *should* have the ability to ignore such things, there's enough going on that our panic entry-point special-casing (plus the `fn` param weakening, maybe?) doesn't actually bypass the "zombie" systems enough.~~

~~My best guess so far is that, unlike a string literal constant, `format_args!` actually needs local variables, and the "zombie" system's concept of "dead code" might not include them.~~

~~So far my efforts have focused on improving the granularity of the "zombie" system (hence the other PRs), to better debug such failure modes (when I started, it kept pointing at `ptr::metadata`, which is pretty useless).~~

---

**EDIT**: the new Rust 2021 `panic!` (which always uses `format_args!`) is now supported (by removing simple invocations of `format_args!` feeding directly into a panic entry-point)