### PR TITLE
linker/test: create `Session` manually to inject a custom diagnostic writer.

### DIFF
--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -17,6 +17,7 @@
 //! [`spirv-tools-sys`]: https://embarkstudios.github.io/rust-gpu/api/spirv_tools_sys
 #![feature(rustc_private)]
 #![feature(assert_matches)]
+#![feature(result_flattening)]
 #![feature(once_cell)]
 // crate-specific exceptions:
 #![allow(


### PR DESCRIPTION
This allows us to work around this upstream change (@oisyn ran into it while trying to update the nightly):
* https://github.com/rust-lang/rust/pull/102992

(Note that the first commit is from my SPIR-T integration PR, where I already needed that change)

**EDIT**: opened an issue for moving us off these awkward unit tests:
* https://github.com/EmbarkStudios/rust-gpu/issues/957