### PR TITLE
Update to nightly-2022-10-29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 🛠️
 
-- Updated toolchain to `nightly-2022-10-15`
+- Updated toolchain to `nightly-2022-10-29`
 - Applied workspace inheritance to Cargo.toml files
 
 ### Removed 🔥

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -10,9 +10,9 @@ use std::process::{Command, ExitCode};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2022-10-15"
+channel = "nightly-2022-10-29"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = bf15a9e5263fcea065a7ae9c179b2d24c2deb670"#;
+# commit_hash = 9565dfeb4e6225177bbe78f18cd48a7982f34401"#;
 
 fn get_rustc_commit_hash() -> Result<String, Box<dyn Error>> {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -575,7 +575,7 @@ fn dig_scalar_pointee<'tcx>(
             let new_pointee = dig_scalar_pointee(cx, field, offset - field_offset);
             match pointee {
                 Some(old_pointee) if old_pointee != new_pointee => {
-                    cx.tcx.sess.fatal(&format!(
+                    cx.tcx.sess.fatal(format!(
                         "dig_scalar_pointee: unsupported Pointer with different \
                          pointee types ({:?} vs {:?}) at offset {:?} in {:#?}",
                         old_pointee, new_pointee, offset, layout
@@ -860,7 +860,7 @@ fn trans_intrinsic_type<'tcx>(
                     None => Err(cx
                         .tcx
                         .sess
-                        .err(&format!("Invalid value for Image const generic: {}", value))),
+                        .err(format!("Invalid value for Image const generic: {}", value))),
                 }
             }
 

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -146,7 +146,7 @@ impl AggregatedSpirvAttributes {
             let (span, parsed_attr) = match parse_attr_result {
                 Ok(span_and_parsed_attr) => span_and_parsed_attr,
                 Err((span, msg)) => {
-                    cx.tcx.sess.delay_span_bug(span, &msg);
+                    cx.tcx.sess.delay_span_bug(span, msg);
                     continue;
                 }
             };
@@ -158,7 +158,7 @@ impl AggregatedSpirvAttributes {
                 }) => {
                     cx.tcx
                         .sess
-                        .delay_span_bug(span, &format!("multiple {} attributes", category));
+                        .delay_span_bug(span, format!("multiple {} attributes", category));
                 }
             }
         }
@@ -264,7 +264,7 @@ impl CheckSpirvAttrVisitor<'_> {
             let (span, parsed_attr) = match parse_attr_result {
                 Ok(span_and_parsed_attr) => span_and_parsed_attr,
                 Err((span, msg)) => {
-                    self.tcx.sess.span_err(span, &msg);
+                    self.tcx.sess.span_err(span, msg);
                     continue;
                 }
             };
@@ -333,7 +333,7 @@ impl CheckSpirvAttrVisitor<'_> {
                                 if let Err(msg) = valid {
                                     self.tcx.sess.span_err(
                                         span,
-                                        &format!("`{:?}` storage class {}", storage_class, msg),
+                                        format!("`{:?}` storage class {}", storage_class, msg),
                                     );
                                 }
                             }
@@ -354,7 +354,7 @@ impl CheckSpirvAttrVisitor<'_> {
                 Err(Expected(expected_target)) => {
                     self.tcx.sess.span_err(
                         span,
-                        &format!(
+                        format!(
                             "attribute is only valid on a {}, not on a {}",
                             expected_target, target
                         ),

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -1159,10 +1159,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                         Some(Token::Placeholder(_, span)) => {
                             self.tcx.sess.span_err(
                                 span,
-                                format!(
-                                    "expected a literal, not a dynamic value for a {:?}",
-                                    kind
-                                ),
+                                format!("expected a literal, not a dynamic value for a {:?}", kind),
                             );
                         }
                         Some(Token::Typeof(_, span, _)) => {

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -105,7 +105,7 @@ impl<'a, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'tcx> {
                     if let Some(modifier) = modifier {
                         self.tcx.sess.span_err(
                             span,
-                            &format!("asm modifiers are not supported: {}", modifier),
+                            format!("asm modifiers are not supported: {}", modifier),
                         );
                     }
                     let line = tokens.last_mut().unwrap();
@@ -577,7 +577,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             ));
         }
         if tokens.next().is_some() {
-            self.tcx.sess.err(&format!(
+            self.tcx.sess.err(format!(
                 "too many operands to instruction: {}",
                 instruction.class.opname
             ));
@@ -792,7 +792,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             _ => {
                 self.tcx
                     .sess
-                    .span_err(span, &format!("invalid register: {}", reg));
+                    .span_err(span, format!("invalid register: {}", reg));
             }
         }
     }
@@ -916,7 +916,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                             other => {
                                 self.tcx.sess.span_err(
                                     span,
-                                    &format!(
+                                    format!(
                                         "cannot use typeof* on non-pointer type: {}",
                                         other.debug(ty, self)
                                     ),
@@ -938,7 +938,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                             other => {
                                 self.tcx.sess.span_err(
                                     span,
-                                    &format!(
+                                    format!(
                                         "out register type not pointer: {}",
                                         other.debug(place.llval.ty, self)
                                     ),
@@ -1159,7 +1159,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                         Some(Token::Placeholder(_, span)) => {
                             self.tcx.sess.span_err(
                                 span,
-                                &format!(
+                                format!(
                                     "expected a literal, not a dynamic value for a {:?}",
                                     kind
                                 ),
@@ -1168,7 +1168,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                         Some(Token::Typeof(_, span, _)) => {
                             self.tcx.sess.span_err(
                                 span,
-                                &format!("expected a literal, not a type for a {:?}", kind),
+                                format!("expected a literal, not a type for a {:?}", kind),
                             );
                         }
                         None => {
@@ -1373,13 +1373,13 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                 Token::Placeholder(_, span) => {
                     self.tcx.sess.span_err(
                         span,
-                        &format!("expected a literal, not a dynamic value for a {:?}", kind),
+                        format!("expected a literal, not a dynamic value for a {:?}", kind),
                     );
                 }
                 Token::Typeof(_, span, _) => {
                     self.tcx.sess.span_err(
                         span,
-                        &format!("expected a literal, not a type for a {:?}", kind),
+                        format!("expected a literal, not a type for a {:?}", kind),
                     );
                 }
             },

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -66,14 +66,14 @@ impl<'tcx> CodegenCx<'tcx> {
                 _ => self
                     .tcx
                     .sess
-                    .fatal(&format!("Invalid constant value for bool: {}", val)),
+                    .fatal(format!("Invalid constant value for bool: {}", val)),
             },
             SpirvType::Integer(128, _) => {
                 let result = self.undef(ty);
                 self.zombie_no_span(result.def_cx(self), "u128 constant");
                 result
             }
-            other => self.tcx.sess.fatal(&format!(
+            other => self.tcx.sess.fatal(format!(
                 "constant_int invalid on type {}",
                 other.debug(ty, self)
             )),
@@ -94,7 +94,7 @@ impl<'tcx> CodegenCx<'tcx> {
         match self.lookup_type(ty) {
             SpirvType::Float(32) => self.def_constant(ty, SpirvConst::F32((val as f32).to_bits())),
             SpirvType::Float(64) => self.def_constant(ty, SpirvConst::F64(val.to_bits())),
-            other => self.tcx.sess.fatal(&format!(
+            other => self.tcx.sess.fatal(format!(
                 "constant_float invalid on type {}",
                 other.debug(ty, self)
             )),
@@ -233,9 +233,9 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
                             _ => self
                                 .tcx
                                 .sess
-                                .fatal(&format!("Invalid constant value for bool: {}", data)),
+                                .fatal(format!("Invalid constant value for bool: {}", data)),
                         },
-                        other => self.tcx.sess.fatal(&format!(
+                        other => self.tcx.sess.fatal(format!(
                             "scalar_to_backend Primitive::Int not supported on type {}",
                             other.debug(ty, self)
                         )),
@@ -273,7 +273,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
                     GlobalAlloc::Memory(alloc) => {
                         let pointee = match self.lookup_type(ty) {
                             SpirvType::Pointer { pointee } => pointee,
-                            other => self.tcx.sess.fatal(&format!(
+                            other => self.tcx.sess.fatal(format!(
                                 "GlobalAlloc::Memory type not implemented: {}",
                                 other.debug(ty, self)
                             )),
@@ -293,7 +293,7 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
                             .unwrap_memory();
                         let pointee = match self.lookup_type(ty) {
                             SpirvType::Pointer { pointee } => pointee,
-                            other => self.tcx.sess.fatal(&format!(
+                            other => self.tcx.sess.fatal(format!(
                                 "GlobalAlloc::VTable type not implemented: {}",
                                 other.debug(ty, self)
                             )),
@@ -426,7 +426,7 @@ impl<'tcx> CodegenCx<'tcx> {
                             other => {
                                 self.tcx
                                     .sess
-                                    .fatal(&format!("invalid size for integer: {}", other));
+                                    .fatal(format!("invalid size for integer: {}", other));
                             }
                         };
                         Primitive::Int(integer, int_signedness)
@@ -437,7 +437,7 @@ impl<'tcx> CodegenCx<'tcx> {
                         other => {
                             self.tcx
                                 .sess
-                                .fatal(&format!("invalid size for float: {}", other));
+                                .fatal(format!("invalid size for float: {}", other));
                         }
                     },
                     SpirvType::Pointer { .. } => Primitive::Pointer,

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -141,7 +141,7 @@ impl<'tcx> CodegenCx<'tcx> {
                         self.libm_intrinsics.borrow_mut().insert(fn_id, intrinsic);
                     }
                     None => {
-                        self.tcx.sess.err(&format!(
+                        self.tcx.sess.err(format!(
                             "missing libm intrinsic {}, which is {}",
                             symbol_name, instance
                         ));
@@ -214,7 +214,7 @@ impl<'tcx> PreDefineMethods<'tcx> for CodegenCx<'tcx> {
             Linkage::External => Some(LinkageType::Export),
             Linkage::Internal => None,
             other => {
-                self.tcx.sess.err(&format!(
+                self.tcx.sess.err(format!(
                     "TODO: Linkage type {:?} not supported yet for static var symbol {}",
                     other, symbol_name
                 ));
@@ -244,7 +244,7 @@ impl<'tcx> PreDefineMethods<'tcx> for CodegenCx<'tcx> {
             Linkage::External | Linkage::WeakAny => Some(LinkageType::Export),
             Linkage::Internal => None,
             other => {
-                self.tcx.sess.err(&format!(
+                self.tcx.sess.err(format!(
                     "TODO: Linkage type {:?} not supported yet for function symbol {}",
                     other, symbol_name
                 ));
@@ -277,7 +277,7 @@ impl<'tcx> StaticMethods for CodegenCx<'tcx> {
         };
         let value_ty = match self.lookup_type(g.ty) {
             SpirvType::Pointer { pointee } => pointee,
-            other => self.tcx.sess.fatal(&format!(
+            other => self.tcx.sess.fatal(format!(
                 "global had non-pointer type {}",
                 other.debug(g.ty, self)
             )),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -38,7 +38,7 @@ impl<'tcx> CodegenCx<'tcx> {
             } else {
                 self.tcx
                     .sess
-                    .span_err(span, &format!("Cannot declare {} as an entry point", name));
+                    .span_err(span, format!("Cannot declare {} as an entry point", name));
                 return;
             };
             let body = self
@@ -57,7 +57,7 @@ impl<'tcx> CodegenCx<'tcx> {
                     if !matches!(arg_abi.layout.ty.kind(), ty::Ref(..)) {
                         self.tcx.sess.span_err(
                             hir_param.ty_span,
-                            &format!(
+                            format!(
                                 "entry point parameter type not yet supported \
                                  (`{}` has `ScalarPair` ABI but is not a `&T`)",
                                 arg_abi.layout.ty
@@ -69,7 +69,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 // is any validation concern, it should be done on the types.
                 PassMode::Ignore => self.tcx.sess.span_fatal(
                     hir_param.ty_span,
-                    &format!(
+                    format!(
                         "entry point parameter type not yet supported \
                         (`{}` has size `0`)",
                         arg_abi.layout.ty
@@ -87,7 +87,7 @@ impl<'tcx> CodegenCx<'tcx> {
         } else {
             self.tcx.sess.span_err(
                 span,
-                &format!(
+                format!(
                     "entry point should return `()`, not `{}`",
                     fn_abi.ret.layout.ty
                 ),
@@ -206,7 +206,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 } else {
                     self.tcx.sess.span_err(
                         hir_param.ty_span,
-                        &format!(
+                        format!(
                             "entry parameter type must be by-reference: `&{}`",
                             layout.ty,
                         ),
@@ -232,7 +232,7 @@ impl<'tcx> CodegenCx<'tcx> {
             if !is_ref {
                 self.tcx.sess.span_fatal(
                     hir_param.ty_span,
-                    &format!(
+                    format!(
                         "invalid entry param type `{}` for storage class `{:?}` \
                          (expected `&{}T`)",
                         layout.ty,
@@ -281,7 +281,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 (true, hir::Mutability::Mut) => StorageClass::Output,
                 (true, hir::Mutability::Not) => self.tcx.sess.span_fatal(
                     hir_param.ty_span,
-                    &format!(
+                    format!(
                         "invalid entry param type `{}` (expected `{}` or `&mut {1}`)",
                         layout.ty, value_ty
                     ),
@@ -404,7 +404,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 if is_unsized {
                     self.tcx.sess.span_fatal(
                         hir_param.ty_span,
-                        &format!(
+                        format!(
                             "unsized types are not supported for storage class {:?}",
                             storage_class
                         ),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -98,7 +98,7 @@ impl<'tcx> CodegenCx<'tcx> {
             .map(|s| s.parse())
             .collect::<Result<_, String>>()
             .unwrap_or_else(|error| {
-                tcx.sess.err(&error);
+                tcx.sess.err(error);
                 Vec::new()
             });
 
@@ -247,7 +247,7 @@ impl CodegenArgs {
     pub fn from_session(sess: &Session) -> Self {
         match CodegenArgs::parse(&sess.opts.cg.llvm_args) {
             Ok(ok) => ok,
-            Err(err) => sess.fatal(&format!("Unable to parse llvm-args: {}", err)),
+            Err(err) => sess.fatal(format!("Unable to parse llvm-args: {}", err)),
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -249,10 +249,10 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
     fn vector_length(&self, ty: Self::Type) -> usize {
         match self.lookup_type(ty) {
             SpirvType::Vector { count, .. } => count as usize,
-            ty => self.tcx.sess.fatal(format!(
-                "vector_length called on non-vector type: {:?}",
-                ty
-            )),
+            ty => self
+                .tcx
+                .sess
+                .fatal(format!("vector_length called on non-vector type: {:?}", ty)),
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -19,7 +19,7 @@ impl<'tcx> LayoutOfHelpers<'tcx> for CodegenCx<'tcx> {
     #[inline]
     fn handle_layout_err(&self, err: LayoutError<'tcx>, span: Span, ty: Ty<'tcx>) -> ! {
         if let LayoutError::SizeOverflow(_) = err {
-            self.tcx.sess.span_fatal(span, &err.to_string())
+            self.tcx.sess.span_fatal(span, err.to_string())
         } else {
             span_bug!(span, "failed to get layout for `{}`: {}", ty, err)
         }
@@ -37,7 +37,7 @@ impl<'tcx> FnAbiOfHelpers<'tcx> for CodegenCx<'tcx> {
         fn_abi_request: FnAbiRequest<'tcx>,
     ) -> ! {
         if let FnAbiError::Layout(LayoutError::SizeOverflow(_)) = err {
-            self.tcx.sess.span_fatal(span, &err.to_string())
+            self.tcx.sess.span_fatal(span, err.to_string())
         } else {
             match fn_abi_request {
                 FnAbiRequest::OfFnPtr { sig, extra_args } => {
@@ -209,7 +209,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
                 other => self
                     .tcx
                     .sess
-                    .fatal(&format!("Invalid float width in type_kind: {}", other)),
+                    .fatal(format!("Invalid float width in type_kind: {}", other)),
             },
             SpirvType::Adt { .. } | SpirvType::InterfaceBlock { .. } => {
                 TypeKind::Struct
@@ -238,7 +238,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
         match self.lookup_type(ty) {
             SpirvType::Pointer { pointee } => pointee,
             SpirvType::Vector { element, .. } => element,
-            spirv_type => self.tcx.sess.fatal(&format!(
+            spirv_type => self.tcx.sess.fatal(format!(
                 "element_type called on invalid type: {:?}",
                 spirv_type
             )),
@@ -249,7 +249,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
     fn vector_length(&self, ty: Self::Type) -> usize {
         match self.lookup_type(ty) {
             SpirvType::Vector { count, .. } => count as usize,
-            ty => self.tcx.sess.fatal(&format!(
+            ty => self.tcx.sess.fatal(format!(
                 "vector_length called on non-vector type: {:?}",
                 ty
             )),
@@ -262,7 +262,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             ty => self
                 .tcx
                 .sess
-                .fatal(&format!("float_width called on non-float type: {:?}", ty)),
+                .fatal(format!("float_width called on non-float type: {:?}", ty)),
         }
     }
 
@@ -273,7 +273,7 @@ impl<'tcx> BaseTypeMethods<'tcx> for CodegenCx<'tcx> {
             ty => self
                 .tcx
                 .sess
-                .fatal(&format!("int_width called on non-integer type: {:?}", ty)),
+                .fatal(format!("int_width called on non-integer type: {:?}", ty)),
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -66,7 +66,7 @@ pub fn link<'a>(
                     link_exe(sess, crate_type, &out_filename, codegen_results);
                 }
                 other => {
-                    sess.err(&format!("CrateType {:?} not supported yet", other));
+                    sess.err(format!("CrateType {:?} not supported yet", other));
                 }
             }
         }
@@ -99,7 +99,7 @@ fn link_rlib(sess: &Session, codegen_results: &CodegenResults, out_filename: &Pa
             | NativeLibKind::Unspecified => continue,
         }
         if let Some(name) = lib.name {
-            sess.err(&format!(
+            sess.err(format!(
                 "Adding native library to rlib not supported yet: {}",
                 name
             ));
@@ -236,7 +236,7 @@ fn post_link_single_module(
                 (optlevel, false) => format!("optlevel={:?}", optlevel),
                 (optlevel, true) => format!("optlevel={:?}, debuginfo=None", optlevel),
             };
-            sess.warn(&format!(
+            sess.warn(format!(
                 "spirv-opt should have ran ({}) but was disabled by NO_SPIRV_OPT",
                 reason
             ));
@@ -420,11 +420,11 @@ fn add_upstream_native_libraries(
                 continue;
             }
             match lib.kind {
-                NativeLibKind::Dylib { .. } | NativeLibKind::Unspecified => sess.fatal(&format!(
+                NativeLibKind::Dylib { .. } | NativeLibKind::Unspecified => sess.fatal(format!(
                     "TODO: dylib nativelibkind not supported yet: {}",
                     name
                 )),
-                NativeLibKind::Framework { .. } => sess.fatal(&format!(
+                NativeLibKind::Framework { .. } => sess.fatal(format!(
                     "TODO: framework nativelibkind not supported yet: {}",
                     name
                 )),
@@ -433,7 +433,7 @@ fn add_upstream_native_libraries(
                     ..
                 } => {
                     if data[cnum.as_usize() - 1] == Linkage::Static {
-                        sess.fatal(&format!(
+                        sess.fatal(format!(
                             "TODO: staticnobundle nativelibkind not supported yet: {}",
                             name
                         ))
@@ -444,9 +444,9 @@ fn add_upstream_native_libraries(
                     ..
                 } => {}
                 NativeLibKind::RawDylib => {
-                    sess.fatal(&format!("raw_dylib feature not yet implemented: {}", name))
+                    sess.fatal(format!("raw_dylib feature not yet implemented: {}", name))
                 }
-                NativeLibKind::LinkArg => sess.fatal(&format!(
+                NativeLibKind::LinkArg => sess.fatal(format!(
                     "TODO: linkarg nativelibkind not supported yet: {}",
                     name
                 )),

--- a/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
+++ b/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
@@ -56,7 +56,7 @@ fn find_import_export_pairs_and_killed_params(
         };
         let type_id = *type_map.get(&id).expect("Unexpected op");
         if exports.insert(name, (id, type_id)).is_some() {
-            return Err(sess.err(&format!("Multiple exports found for {:?}", name)));
+            return Err(sess.err(format!("Multiple exports found for {:?}", name)));
         }
     }
     let mut any_err = None;
@@ -68,7 +68,7 @@ fn find_import_export_pairs_and_killed_params(
         };
         let (export_id, export_type) = match exports.get(name) {
             None => {
-                any_err = Some(sess.err(&format!("Unresolved symbol {:?}", name)));
+                any_err = Some(sess.err(format!("Unresolved symbol {:?}", name)));
                 continue;
             }
             Some(&x) => x,

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -51,7 +51,7 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
     if !inlined_dont_inlines.is_empty() {
         let names = get_names(module);
         for f in inlined_dont_inlines {
-            sess.warn(&format!(
+            sess.warn(format!(
                 "`#[inline(never)]` function `{}` needs to be inlined \
                  because it has illegal argument or return types",
                 get_name(&names, f)
@@ -122,7 +122,7 @@ fn deny_recursion_in_module(sess: &Session, module: &Module) -> super::Result<()
                 let names = get_names(module);
                 let current_name = get_name(&names, module.functions[current].def_id().unwrap());
                 let next_name = get_name(&names, module.functions[next].def_id().unwrap());
-                *has_recursion = Some(sess.err(&format!(
+                *has_recursion = Some(sess.err(format!(
                     "module has recursion, which is not allowed: `{}` calls `{}`",
                     current_name, next_name
                 )));

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -123,7 +123,7 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
             bound += module.header.as_ref().unwrap().bound - 1;
             let this_version = module.header.as_ref().unwrap().version();
             if version != this_version {
-                sess.fatal(&format!(
+                sess.fatal(format!(
                     "cannot link two modules with different SPIR-V versions: v{}.{} and v{}.{}",
                     version.0, version.1, this_version.0, this_version.1
                 ))

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -3,7 +3,8 @@ use crate::codegen_cx::SpirvMetadata;
 use pipe::pipe;
 use rspirv::dr::{Loader, Module};
 use rustc_errors::registry::Registry;
-use std::io::Read;
+use rustc_span::edition::Edition;
+use std::{io::Read, thread};
 
 // https://github.com/colin-kiegel/rust-pretty-assertions/issues/24
 #[derive(PartialEq, Eq)]
@@ -54,6 +55,43 @@ fn load(bytes: &[u8]) -> Module {
     loader.module()
 }
 
+// HACK(shesp) This function was taken from `rustc_interface::util` since it's
+// no longer public. It's the non-parallel version since it's simpler and good
+// enough for our tests.
+fn run_in_thread_pool_with_globals<F: FnOnce() -> R + Send, R: Send>(
+    edition: Edition,
+    _threads: usize,
+    f: F,
+) -> R {
+    // The "thread pool" is a single spawned thread in the non-parallel
+    // compiler. We run on a spawned thread instead of the main thread (a) to
+    // provide control over the stack size, and (b) to increase similarity with
+    // the parallel compiler, in particular to ensure there is no accidental
+    // sharing of data between the main thread and the compilation thread
+    // (which might cause problems for the parallel compiler).
+    let mut builder = thread::Builder::new().name("rustc".to_string());
+    const STACK_SIZE: usize = 8 * 1024 * 1024;
+    builder = builder.stack_size(STACK_SIZE);
+
+    // We build the session globals and run `f` on the spawned thread, because
+    // `SessionGlobals` does not impl `Send` in the non-parallel compiler.
+    thread::scope(|s| {
+        // `unwrap` is ok here because `spawn_scoped` only panics if the thread
+        // name contains null bytes.
+        let r = builder
+            .spawn_scoped(s, move || {
+                rustc_span::create_session_globals_then(edition, f)
+            })
+            .unwrap()
+            .join();
+
+        match r {
+            Ok(v) => v,
+            Err(e) => std::panic::resume_unwind(e),
+        }
+    })
+}
+
 fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, PrettyString> {
     let modules = binaries.iter().cloned().map(load).collect::<Vec<_>>();
 
@@ -80,67 +118,62 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, PrettyString> {
         let matches = rustc_driver::handle_options(&["".to_string(), "x.rs".to_string()]).unwrap();
         let sopts = rustc_session::config::build_session_options(&matches);
 
-        rustc_interface::util::run_in_thread_pool_with_globals(
-            sopts.edition,
-            sopts.unstable_opts.threads,
-            || {
-                let mut sess = rustc_session::build_session(
-                    sopts,
-                    None,
-                    None,
-                    Registry::new(&[]),
-                    rustc_session::DiagnosticOutput::Default,
-                    Default::default(),
-                    None,
-                    None,
-                );
+        run_in_thread_pool_with_globals(sopts.edition, sopts.unstable_opts.threads, || {
+            let mut sess = rustc_session::build_session(
+                sopts,
+                None,
+                None,
+                Registry::new(&[]),
+                Default::default(),
+                None,
+                None,
+            );
 
-                // HACK(eddyb) inject `write_diags` into `sess`, to work around
-                // the removals in https://github.com/rust-lang/rust/pull/102992.
-                sess.parse_sess.span_diagnostic = {
-                    let fallback_bundle = {
-                        extern crate rustc_error_messages;
-                        rustc_error_messages::fallback_fluent_bundle(
-                            rustc_errors::DEFAULT_LOCALE_RESOURCES,
-                            sess.opts.unstable_opts.translate_directionality_markers,
-                        )
-                    };
-                    let emitter = rustc_errors::emitter::EmitterWriter::new(
-                        Box::new(write_diags),
-                        Some(sess.parse_sess.clone_source_map()),
-                        None,
-                        fallback_bundle,
-                        false,
-                        false,
-                        false,
-                        None,
-                        false,
-                    );
-
-                    rustc_errors::Handler::with_emitter_and_flags(
-                        Box::new(emitter),
-                        sess.opts.unstable_opts.diagnostic_handler_flags(true),
+            // HACK(eddyb) inject `write_diags` into `sess`, to work around
+            // the removals in https://github.com/rust-lang/rust/pull/102992.
+            sess.parse_sess.span_diagnostic = {
+                let fallback_bundle = {
+                    extern crate rustc_error_messages;
+                    rustc_error_messages::fallback_fluent_bundle(
+                        rustc_errors::DEFAULT_LOCALE_RESOURCES,
+                        sess.opts.unstable_opts.translate_directionality_markers,
                     )
                 };
-
-                let res = link(
-                    &sess,
-                    modules,
-                    &Options {
-                        compact_ids: true,
-                        dce: false,
-                        structurize: false,
-                        emit_multiple_modules: false,
-                        spirv_metadata: SpirvMetadata::None,
-                    },
+                let emitter = rustc_errors::emitter::EmitterWriter::new(
+                    Box::new(write_diags),
+                    Some(sess.parse_sess.clone_source_map()),
+                    None,
+                    fallback_bundle,
+                    false,
+                    false,
+                    false,
+                    None,
+                    false,
                 );
-                assert_eq!(sess.has_errors(), res.as_ref().err().copied());
-                res.map(|res| match res {
-                    LinkResult::SingleModule(m) => *m,
-                    LinkResult::MultipleModules(_) => unreachable!(),
-                })
-            },
-        )
+
+                rustc_errors::Handler::with_emitter_and_flags(
+                    Box::new(emitter),
+                    sess.opts.unstable_opts.diagnostic_handler_flags(true),
+                )
+            };
+
+            let res = link(
+                &sess,
+                modules,
+                &Options {
+                    compact_ids: true,
+                    dce: false,
+                    structurize: false,
+                    emit_multiple_modules: false,
+                    spirv_metadata: SpirvMetadata::None,
+                },
+            );
+            assert_eq!(sess.has_errors(), res.as_ref().err().copied());
+            res.map(|res| match res {
+                LinkResult::SingleModule(m) => *m,
+                LinkResult::MultipleModules(_) => unreachable!(),
+            })
+        })
     })
     .flatten()
     .map_err(|_e| read_diags_thread.join().unwrap())

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -304,7 +304,7 @@ impl SpirvType<'_> {
             ref other => cx
                 .tcx
                 .sess
-                .fatal(&format!("def_with_id invalid for type {:?}", other)),
+                .fatal(format!("def_with_id invalid for type {:?}", other)),
         };
         cx.type_cache_def(result, self.tcx_arena_alloc_slices(cx), def_span);
         result

--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -564,7 +564,7 @@ fn debug_printf_inner(input: DebugPrintfInput) -> TokenStream {
     if format_arguments.len() != variables.len() {
         return syn::Error::new(
             span,
-            &format!(
+            format!(
                 "{} % arguments were found, but {} variables were given",
                 format_arguments.len(),
                 variables.len()

--- a/examples/runners/wgpu/builder/src/main.rs
+++ b/examples/runners/wgpu/builder/src/main.rs
@@ -12,7 +12,7 @@ fn build_shader(path_to_crate: &str, codegen_names: bool) -> Result<(), Box<dyn 
         let out_dir = env::var_os("OUT_DIR").unwrap();
         let dest_path = Path::new(&out_dir).join("entry_points.rs");
         fs::create_dir_all(&out_dir).unwrap();
-        fs::write(&dest_path, result.codegen_entry_point_strings()).unwrap();
+        fs::write(dest_path, result.codegen_entry_point_strings()).unwrap();
     }
     Ok(())
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,9 +5,9 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2022-10-15"
+channel = "nightly-2022-10-29"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = bf15a9e5263fcea065a7ae9c179b2d24c2deb670
+# commit_hash = 9565dfeb4e6225177bbe78f18cd48a7982f34401
 
 # Whenever changing the nightly channel, update the commit hash above, and make
 # sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also.

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,7 +1,7 @@
 error: Cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2431:9
+    --> $CORE_SRC/intrinsics.rs:2449:9
      |
-2431 |         copy(src, dst, count)
+2449 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1122 8
+OpLine %8 1139 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1122 8
+OpLine %8 1139 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1316 8
+OpLine %11 1336 8
 OpStore %6 %9
 OpLine %8 8 1
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1316 8
+OpLine %11 1336 8
 OpStore %6 %9
 OpLine %8 8 1
 OpReturn


### PR DESCRIPTION
With this we are on schedule for Rust 1.66 to be released on stable on 15 December.