### PR TITLE
linker/inline: handle `OpPhi`s.

### DIFF
--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 #![feature(result_flattening)]
+#![feature(lint_reasons)]
 #![feature(once_cell)]
 // crate-specific exceptions:
 #![allow(


### PR DESCRIPTION
This is a prerequisite for:
* https://github.com/EmbarkStudios/rust-gpu/pull/940#issuecomment-1323128422
<sup>(the link goes to my comment explanation the plan that this PR is a part of)</sup>

The problem this PR solves is that the inliner did not support "φ nodes" (`OpPhi` in SPIR-V), as they did not exist at the point where it was ran (i.e. all passes that would introduce `OpPhi`s ran *after* the inliner).
This manifested as broken `OpPhi`s, since the *sources* of control-flow edges (i.e. the side with the branch instruction) changed without the `OpPhi`s in the *destinations* being updated to reflect the CFG change.

But with SPIR-T, we want the speedups that come from being able run the inliner *after* passes that create `OpPhi`s (as the SPIR-T CFG structurizer can handle `OpPhi`s just fine, unlike our existing one).
More specifically, in #940, we end up with two `mem2reg` passes, trying to do as much as possible before, and the rest after, inlining (though *ideally* they it should be interleaved with inlining, as per https://github.com/EmbarkStudios/spirt/issues/6).

Thankfully most of the changes (in the big `inline_block` function) were only for readability, and the bulk of the additions just change some basic-block IDs *in place*, they don't do any complicated analysis or rewriting, so it felt straight-forward enough to have it in the existing inliner, instead of trying to replace it with a SPIR-T one.