### PR TITLE
linker/test: prepare for SPIR-T compatibility.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -515,6 +515,7 @@ impl CodegenArgs {
             // FIXME(eddyb) deduplicate between `CodegenArgs` and `linker::Options`.
             emit_multiple_modules: module_output_type == ModuleOutputType::Multiple,
             spirv_metadata,
+            keep_link_exports: false,
 
             // NOTE(eddyb) these are debugging options that used to be env vars
             // (for more information see `docs/src/codegen-args.md`).

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -38,6 +38,12 @@ pub struct Options {
     pub emit_multiple_modules: bool,
     pub spirv_metadata: SpirvMetadata,
 
+    /// Whether to preserve `LinkageAttributes "..." Export` decorations,
+    /// even after resolving imports to exports.
+    ///
+    /// **Note**: currently only used for unit testing, and not exposed elsewhere.
+    pub keep_link_exports: bool,
+
     // NOTE(eddyb) these are debugging options that used to be env vars
     // (for more information see `docs/src/codegen-args.md`).
     pub dump_post_merge: Option<PathBuf>,
@@ -176,7 +182,7 @@ pub fn link(sess: &Session, mut inputs: Vec<Module>, opts: &Options) -> Result<L
     // find import / export pairs
     {
         let _timer = sess.timer("link_find_pairs");
-        import_export_link::run(sess, &mut output)?;
+        import_export_link::run(opts, sess, &mut output)?;
     }
 
     {

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -138,6 +138,7 @@ fn assemble_and_link(binaries: &[&[u8]]) -> Result<Module, PrettyString> {
     .map_err(PrettyString)
 }
 
+#[track_caller]
 fn without_header_eq(mut result: Module, expected: &str) {
     use rspirv::binary::Disassemble;
     //use rspirv::binary::Assemble;

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -400,9 +400,8 @@ fn use_exported_func_param_attr() {
         r#"OpCapability Kernel
             OpCapability Linkage
             OpDecorate %1 LinkageAttributes "foo" Import
-            OpDecorate %2 FuncParamAttr Zext
-            %2 = OpDecorationGroup
-            OpGroupDecorate %2 %3 %4
+            OpDecorate %3 FuncParamAttr Zext
+            OpDecorate %4 FuncParamAttr Zext
             %5 = OpTypeVoid
             %6 = OpTypeInt 32 0
             %7 = OpTypeFunction %5 %6
@@ -439,22 +438,20 @@ fn use_exported_func_param_attr() {
 
     let expect = r#"OpCapability Kernel
         OpDecorate %1 FuncParamAttr Zext
-        %1 = OpDecorationGroup
-        OpGroupDecorate %1 %2
-        OpDecorate %3 FuncParamAttr Sext
-        %4 = OpTypeVoid
-        %5 = OpTypeInt 32 0
-        %6 = OpTypeFunction %4 %5
-        %7 = OpFunction %4 None %6
-        %2 = OpFunctionParameter %5
-        %8 = OpLabel
-        %9 = OpLoad %5 %2
+        OpDecorate %2 FuncParamAttr Sext
+        %3 = OpTypeVoid
+        %4 = OpTypeInt 32 0
+        %5 = OpTypeFunction %3 %4
+        %6 = OpFunction %3 None %5
+        %1 = OpFunctionParameter %4
+        %7 = OpLabel
+        %8 = OpLoad %4 %1
         OpReturn
         OpFunctionEnd
-        %10 = OpFunction %4 None %6
-        %3 = OpFunctionParameter %5
-        %11 = OpLabel
-        %12 = OpLoad %5 %3
+        %9 = OpFunction %3 None %5
+        %2 = OpFunctionParameter %4
+        %10 = OpLabel
+        %11 = OpLoad %4 %2
         OpReturn
         OpFunctionEnd"#;
 
@@ -469,10 +466,9 @@ fn names_and_decorations() {
             OpName %1 "foo"
             OpName %3 "param"
             OpDecorate %1 LinkageAttributes "foo" Import
-            OpDecorate %2 Restrict
+            OpDecorate %3 Restrict
+            OpDecorate %4 Restrict
             OpDecorate %4 NonWritable
-            %2 = OpDecorationGroup
-            OpGroupDecorate %2 %3 %4
             %5 = OpTypeVoid
             %6 = OpTypeInt 32 0
             %9 = OpTypePointer Function %6
@@ -515,24 +511,22 @@ fn names_and_decorations() {
         OpName %1 "foo"
         OpName %2 "param"
         OpDecorate %3 Restrict
-        OpDecorate %4 NonWritable
-        %3 = OpDecorationGroup
-        OpGroupDecorate %3 %4
+        OpDecorate %3 NonWritable
         OpDecorate %2 Restrict
-        %5 = OpTypeVoid
-        %6 = OpTypeInt 32 0
-        %7 = OpTypePointer Function %6
-        %8 = OpTypeFunction %5 %7
-        %9 = OpFunction %5 None %8
-        %4 = OpFunctionParameter %7
-        %10 = OpLabel
-        %11 = OpLoad %6 %4
+        %4 = OpTypeVoid
+        %5 = OpTypeInt 32 0
+        %6 = OpTypePointer Function %5
+        %7 = OpTypeFunction %4 %6
+        %8 = OpFunction %4 None %7
+        %3 = OpFunctionParameter %6
+        %9 = OpLabel
+        %10 = OpLoad %5 %3
         OpReturn
         OpFunctionEnd
-        %1 = OpFunction %5 None %8
-        %2 = OpFunctionParameter %7
-        %12 = OpLabel
-        %13 = OpLoad %6 %2
+        %1 = OpFunction %4 None %7
+        %2 = OpFunctionParameter %6
+        %11 = OpLabel
+        %12 = OpLoad %5 %2
         OpReturn
         OpFunctionEnd"#;
 

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -176,6 +176,7 @@ fn without_header_eq(mut result: Module, expected: &str) {
 fn standard() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+        OpMemoryModel Logical OpenCL
         OpDecorate %1 LinkageAttributes "foo" Import
         %2 = OpTypeFloat 32
         %1 = OpVariable %2 Uniform
@@ -184,6 +185,7 @@ fn standard() {
 
     let b = assemble_spirv(
         r#"OpCapability Linkage
+        OpMemoryModel Logical OpenCL
         OpDecorate %1 LinkageAttributes "foo" Export
         %2 = OpTypeFloat 32
         %3 = OpConstant %2 42
@@ -192,7 +194,8 @@ fn standard() {
     );
 
     let result = assemble_and_link(&[&a, &b]).unwrap();
-    let expect = r#"%1 = OpTypeFloat 32
+    let expect = r#"OpMemoryModel Logical OpenCL
+        %1 = OpTypeFloat 32
         %2 = OpVariable %1 Input
         %3 = OpConstant %1 42.0
         %4 = OpVariable %1 Uniform %3"#;
@@ -204,13 +207,15 @@ fn standard() {
 fn not_a_lib_extra_exports() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             %2 = OpTypeFloat 32
             %1 = OpVariable %2 Uniform"#,
     );
 
     let result = assemble_and_link(&[&a]).unwrap();
-    let expect = r#"%1 = OpTypeFloat 32
+    let expect = r#"OpMemoryModel Logical OpenCL
+        %1 = OpTypeFloat 32
         %2 = OpVariable %1 Uniform"#;
     without_header_eq(result, expect);
 }
@@ -219,12 +224,16 @@ fn not_a_lib_extra_exports() {
 fn unresolved_symbol() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Import
             %2 = OpTypeFloat 32
             %1 = OpVariable %2 Uniform"#,
     );
 
-    let b = assemble_spirv("OpCapability Linkage");
+    let b = assemble_spirv(
+        "OpCapability Linkage
+        OpMemoryModel Logical OpenCL",
+    );
 
     let result = assemble_and_link(&[&a, &b]);
 
@@ -238,6 +247,7 @@ fn unresolved_symbol() {
 fn type_mismatch() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Import
             %2 = OpTypeFloat 32
             %1 = OpVariable %2 Uniform
@@ -246,6 +256,7 @@ fn type_mismatch() {
 
     let b = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             %2 = OpTypeInt 32 0
             %3 = OpConstant %2 42
@@ -264,6 +275,7 @@ fn type_mismatch() {
 fn multiple_definitions() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Import
             %2 = OpTypeFloat 32
             %1 = OpVariable %2 Uniform
@@ -273,6 +285,7 @@ fn multiple_definitions() {
     let b = assemble_spirv(
         r#"OpCapability Linkage
             OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             %2 = OpTypeFloat 32
             %3 = OpConstant %2 42
@@ -281,6 +294,7 @@ fn multiple_definitions() {
 
     let c = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             %2 = OpTypeFloat 32
             %3 = OpConstant %2 -1
@@ -298,6 +312,7 @@ fn multiple_definitions() {
 fn multiple_definitions_different_types() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Import
             %2 = OpTypeFloat 32
             %1 = OpVariable %2 Uniform
@@ -307,6 +322,7 @@ fn multiple_definitions_different_types() {
     let b = assemble_spirv(
         r#"OpCapability Linkage
             OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             %2 = OpTypeInt 32 0
             %3 = OpConstant %2 42
@@ -315,6 +331,7 @@ fn multiple_definitions_different_types() {
 
     let c = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             %2 = OpTypeFloat 32
             %3 = OpConstant %2 12
@@ -333,6 +350,7 @@ fn multiple_definitions_different_types() {
 fn decoration_mismatch() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+        OpMemoryModel Logical OpenCL
         OpDecorate %1 LinkageAttributes "foo" Import
         OpDecorate %2 Constant
         %2 = OpTypeFloat 32
@@ -342,6 +360,7 @@ fn decoration_mismatch() {
 
     let b = assemble_spirv(
         r#"OpCapability Linkage
+        OpMemoryModel Logical OpenCL
         OpDecorate %1 LinkageAttributes "foo" Export
         %2 = OpTypeFloat 32
         %3 = OpConstant %2 42
@@ -360,6 +379,7 @@ fn decoration_mismatch() {
 fn func_ctrl() {
     let a = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Import
             %2 = OpTypeVoid
             %3 = OpTypeFunction %2
@@ -371,6 +391,7 @@ fn func_ctrl() {
 
     let b = assemble_spirv(
         r#"OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             %2 = OpTypeVoid
             %3 = OpTypeFunction %2
@@ -382,7 +403,8 @@ fn func_ctrl() {
 
     let result = assemble_and_link(&[&a, &b]).unwrap();
 
-    let expect = r#"%1 = OpTypeVoid
+    let expect = r#"OpMemoryModel Logical OpenCL
+            %1 = OpTypeVoid
             %2 = OpTypeFunction %1
             %3 = OpTypeFloat 32
             %4 = OpVariable %3 Uniform
@@ -399,6 +421,7 @@ fn use_exported_func_param_attr() {
     let a = assemble_spirv(
         r#"OpCapability Kernel
             OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Import
             OpDecorate %3 FuncParamAttr Zext
             OpDecorate %4 FuncParamAttr Zext
@@ -420,6 +443,7 @@ fn use_exported_func_param_attr() {
     let b = assemble_spirv(
         r#"OpCapability Kernel
             OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpDecorate %1 LinkageAttributes "foo" Export
             OpDecorate %2 FuncParamAttr Sext
             %3 = OpTypeVoid
@@ -437,6 +461,7 @@ fn use_exported_func_param_attr() {
     let result = assemble_and_link(&[&a, &b]).unwrap();
 
     let expect = r#"OpCapability Kernel
+        OpMemoryModel Logical OpenCL
         OpDecorate %1 FuncParamAttr Zext
         OpDecorate %2 FuncParamAttr Sext
         %3 = OpTypeVoid
@@ -463,6 +488,7 @@ fn names_and_decorations() {
     let a = assemble_spirv(
         r#"OpCapability Kernel
             OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpName %1 "foo"
             OpName %3 "param"
             OpDecorate %1 LinkageAttributes "foo" Import
@@ -488,6 +514,7 @@ fn names_and_decorations() {
     let b = assemble_spirv(
         r#"OpCapability Kernel
             OpCapability Linkage
+            OpMemoryModel Logical OpenCL
             OpName %1 "foo"
             OpName %2 "param"
             OpDecorate %1 LinkageAttributes "foo" Export
@@ -508,6 +535,7 @@ fn names_and_decorations() {
     let result = assemble_and_link(&[&a, &b]).unwrap();
 
     let expect = r#"OpCapability Kernel
+        OpMemoryModel Logical OpenCL
         OpName %1 "foo"
         OpName %2 "param"
         OpDecorate %3 Restrict


### PR DESCRIPTION
This is a prerequisite for:
* https://github.com/EmbarkStudios/rust-gpu/pull/940#issuecomment-1323128422
<sup>(the link goes to my comment explanation the plan that this PR is a part of)</sup>

Each commit is an individual step and can be reviewed as such, but the notable ones are:
* removed "decoration groups" (we don't generate them, they're deprecated, SPIR-T does not support them)
* added a mechanism to keep `Export`s around long enough so SPIR-T can understand what these tests want
* flipped on DCE (which will remove otherwise-unused definitions) and added more `Export`s to keep things alive

Overall I really have not liked these tests and they're the main reason the SPIR-T PR got delayed so much.
I opened an issue about moving away from these unit tests, but sadly I don't know how much effort it'd be:
* https://github.com/EmbarkStudios/rust-gpu/issues/957