### PR TITLE
outputs: `⋯.spv` → `⋯.spv.json`, `⋯.spv.dir/⋯` → `⋯.spvs/⋯.spv` (or `⋯.spv`).

### DIFF
--- a/crates/rustc_codegen_spirv/src/target.rs
+++ b/crates/rustc_codegen_spirv/src/target.rs
@@ -81,7 +81,7 @@ impl SpirvTarget {
         o.allows_weak_linkage = false;
         o.crt_static_allows_dylibs = true;
         o.dll_prefix = "".into();
-        o.dll_suffix = ".spv".into();
+        o.dll_suffix = ".spv.json".into();
         o.dynamic_linking = true;
         o.emit_debug_gdb_scripts = false;
         o.linker_flavor = LinkerFlavor::Unix(Cc::No);


### PR DESCRIPTION
### Before
```console
$ cargo run -p example-runner-wgpu && cargo run -p multibuilder
$ jq .module target/spirv-builder/spirv-unknown-vulkan1.1/release/sky_shader.spv | sed "s:$PWD:⋯:"
"⋯/target/spirv-builder/spirv-unknown-vulkan1.1/release/deps/sky_shader.spv.dir/module"
$ jq .module target/spirv-unknown-spv1.3/release/sky_shader.spv | sed "s:$PWD:⋯:"
{
  "main_fs": "⋯/target/spirv-unknown-spv1.3/release/deps/sky_shader.spv.dir/main_fs",
  "main_vs": "⋯/target/spirv-unknown-spv1.3/release/deps/sky_shader.spv.dir/main_vs"
}
```
### After
```console
$ cargo run -p example-runner-wgpu && cargo run -p multibuilder
$ jq .module target/spirv-builder/spirv-unknown-vulkan1.1/release/sky_shader.spv.json | sed "s:$PWD:⋯:"
"⋯/target/spirv-builder/spirv-unknown-vulkan1.1/release/deps/sky_shader.spv"
$ jq .module target/spirv-unknown-spv1.3/release/sky_shader.spv.json | sed "s:$PWD:⋯:"
{
  "main_fs": "⋯/target/spirv-unknown-spv1.3/release/deps/sky_shader.spvs/main_fs.spv",
  "main_vs": "⋯/target/spirv-unknown-spv1.3/release/deps/sky_shader.spvs/main_vs.spv"
}
```

---

While this shouldn't impact users (who have to go through `SpirvBuilder` to get any of this information *anyway*), the existing organization wasn't very intuitive, and it's not unheard of to end up e.g. trying to `spirv-dis` a `.spv` file that actually had JSON in it (and *not* SPIR-V).

After this PR:
* extensions are accurate: SPIR-V files always have the `.spv` extension, and our JSON metadata file is now `.json` (`.spv.json`, to be more precise, maybe it should be `.rustgpu.json`?)
* the multi-module directory is now `foo.spvs` instead of `foo.spv.dir` (feel free to bikeshed this part)
* the single-module mode produces `foo.spv` instead of `foo.spv.dir/module` (which was pretty bad UX IME)

I didn't set out to fix this, but I had inadvertently changed some of these details while working on a PR to improve the `--dump-*` filenames (coming up soon), and wanted to pull them out into their own PR.