### PR TITLE
Include identifying information (e.g. crate names) in `--dump-*` filenames.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#959](https://github.com/EmbarkStudios/rust-gpu/pull/959) added two `spirv-builder` environment variables to customize *only* the `rustc` invocations for shader crates and their dependencies:
   - `RUSTGPU_RUSTFLAGS="..."` for shader `RUSTFLAGS="..."`
   - `RUSTGPU_CODEGEN_ARGS="..."` for shader "codegen args" (i.e. `RUSTFLAGS=-Cllvm-args="..."`)  
-    (check out ["codegen args" docs](docs/src/codegen-args.md), or run with `RUSTGPU_CODEGEN_ARGS=--help` to see the full list of options)
+    (check out [the "codegen args" docs](docs/src/codegen-args.md), or run with `RUSTGPU_CODEGEN_ARGS=--help` to see the full list of options)
 - [PR#940](https://github.com/EmbarkStudios/rust-gpu/pull/940) integrated the experimental [`SPIR-🇹` shader IR framework](https://github.com/EmbarkStudios/spirt) into the linker  
   (opt-in via `RUSTGPU_CODEGEN_ARGS=--spirt`, see also [the `--spirt` docs](docs/src/codegen-args.md#--spirt), for more details)
 
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#958](https://github.com/EmbarkStudios/rust-gpu/pull/958) updated toolchain to `nightly-2022-10-29`
 - [PR#941](https://github.com/EmbarkStudios/rust-gpu/pull/941) applied workspace inheritance to `Cargo.toml` files
 - [PR#959](https://github.com/EmbarkStudios/rust-gpu/pull/959) moved `rustc_codegen_spirv` debugging functionality from environment variables to "codegen args" options/flags (see [the updated docs](docs/src/codegen-args.md) for more details)
+- [PR#967](https://github.com/EmbarkStudios/rust-gpu/pull/967) made `--dump-*` ["codegen args"](docs/src/codegen-args.md) include identifying information (e.g. crate names) in the names of files they emit
 
 ### Removed 🔥
 - [PR#946](https://github.com/EmbarkStudios/rust-gpu/pull/946) removed the `fn`/closure `#[spirv(unroll_loops)]` attribute, as it has no users, is becoming non-trivial to support, and requires redesign for better ergonomics (e.g. `#[spirv(unroll)]` applied to individual loops, not the whole `fn`/closure)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,9 +679,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elsa"
@@ -2011,6 +2011,7 @@ name = "rustc_codegen_spirv"
 version = "0.4.0-alpha.17"
 dependencies = [
  "ar",
+ "either",
  "hashbrown",
  "indexmap",
  "libc",

--- a/crates/rustc_codegen_spirv-types/src/compile_result.rs
+++ b/crates/rustc_codegen_spirv-types/src/compile_result.rs
@@ -32,8 +32,8 @@ impl ModuleResult {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompileResult {
-    pub module: ModuleResult,
     pub entry_points: Vec<String>,
+    pub module: ModuleResult,
 }
 
 impl CompileResult {

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -47,6 +47,7 @@ regex = { version = "1", features = ["perf"] }
 
 # Normal dependencies.
 ar = "0.9.0"
+either = "1.8.0"
 indexmap = "1.6.0"
 rspirv = "0.11"
 rustc-demangle = "0.1.21"

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -362,8 +362,8 @@ impl CodegenArgs {
             opts.optopt(
                 "",
                 "dump-post-merge",
-                "dump the merged module immediately after merging, to FILE",
-                "FILE",
+                "dump the merged module immediately after merging, to a file in DIR",
+                "DIR",
             );
             opts.optopt(
                 "",
@@ -374,8 +374,8 @@ impl CodegenArgs {
             opts.optopt(
                 "",
                 "dump-spirt-passes",
-                "dump the SPIR-T module across passes, to FILE and FILE.html",
-                "FILE",
+                "dump the SPIR-T module across passes, to a (pair of) file(s) in DIR",
+                "DIR",
             );
             opts.optflag(
                 "",
@@ -532,9 +532,9 @@ impl CodegenArgs {
 
             // NOTE(eddyb) these are debugging options that used to be env vars
             // (for more information see `docs/src/codegen-args.md`).
-            dump_post_merge: matches_opt_path("dump-post-merge"),
+            dump_post_merge: matches_opt_dump_dir_path("dump-post-merge"),
             dump_post_split: matches_opt_dump_dir_path("dump-post-split"),
-            dump_spirt_passes: matches_opt_path("dump-spirt-passes"),
+            dump_spirt_passes: matches_opt_dump_dir_path("dump-spirt-passes"),
             specializer_debug: matches.opt_present("specializer-debug"),
             specializer_dump_instances: matches_opt_path("specializer-dump-instances"),
             print_all_zombie: matches.opt_present("print-all-zombie"),

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -166,11 +166,11 @@ fn link_with_linker_opts(
                 )
             };
 
-            let res = link(&sess, modules, opts);
+            let res = link(&sess, modules, opts, Default::default());
             assert_eq!(sess.has_errors(), res.as_ref().err().copied());
             res.map(|res| match res {
                 LinkResult::SingleModule(m) => *m,
-                LinkResult::MultipleModules(_) => unreachable!(),
+                LinkResult::MultipleModules { .. } => unreachable!(),
             })
         })
     })

--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -72,9 +72,9 @@ for codegen, if the linker panics, this option does nothing, sadly.
 
 Dumps all input modules to the linker, to files in `DIR`, before the linker touches them at all.
 
-### `--dump-post-merge FILE`
+### `--dump-post-merge DIR`
 
-Dumps the merged module, to `FILE`, immediately after merging, but before the linker has done anything else
+Dumps the merged module, to a file in `DIR`, immediately after merging, but before the linker has done anything else
 (including, well, linking the methods - `LinkageAttributes` will still exist, etc.). This is very
 similar to `--dump-pre-link`, except it outputs only a single file, which might make grepping through
 for stuff easier.
@@ -149,7 +149,7 @@ Enables using the experimental [`SPIR-🇹` shader IR framework](https://github.
 
 For more information, also see [the `SPIR-🇹` repository](https://github.com/EmbarkStudios/spirt).
 
-### `--dump-spirt-passes FILE`
+### `--dump-spirt-passes DIR`
 
-Dump the `SPIR-🇹` module across passes (i.e. all of the versions before/after each pass), as a combined report, to `FILE` and `FILE.html`.  
-<sub>(the `.html` version of the report is the recommended form for viewing, as it uses tabling for versions, syntax-highlighting-like styling, and use->def linking)</sub>
+Dump the `SPIR-🇹` module across passes (i.e. all of the versions before/after each pass), as a combined report, to a pair of files (`.spirt` and `.spirt.html`) in `DIR`.  
+<sub>(the `.spirt.html` version of the report is the recommended form for viewing, as it uses tabling for versions, syntax-highlighting-like styling, and use->def linking)</sub>


### PR DESCRIPTION
### Before

```console
$ RUSTGPU_CODEGEN_ARGS="--dump-pre-link=$PWD/dumps/pre-link \
                        --dump-post-merge=$PWD/dumps/post-merge \
                        --dump-post-split=$PWD/dumps/post-split \
                        --dump-post-link=$PWD/dumps/post-link \
                        --spirt --dump-spirt-passes=$PWD/dumps/spirt-passes" \
  cargo run -p example-runner-wgpu
⋮
   Compiling sky-shader v0.0.0 (⋯/examples/shaders/sky-shader)
⋮
$ tree dumps
dumps
├── pre-link
│   ├── mod_0.spv
│   ├── mod_1.spv
│   ⋮
│   ├── mod_383.spv
│   └── mod_384.spv
├── post-merge
├── spirt-passes
├── spirt-passes.html
├── post-split
│   └── mod_0.spv
└── post-link
    └── module
```

### After

```console
$ RUSTGPU_CODEGEN_ARGS="--dump-pre-link=$PWD/dumps/pre-link \
                        --dump-post-merge=$PWD/dumps/post-merge \
                        --dump-post-split=$PWD/dumps/post-split \
                        --dump-post-link=$PWD/dumps/post-link \
                        --spirt --dump-spirt-passes=$PWD/dumps/spirt-passes" \
  cargo run -p example-runner-wgpu
⋮
   Compiling sky-shader v0.0.0 (⋯/examples/shaders/sky-shader)
⋮
$ tree dumps
dumps
├── pre-link
│   ├── bitflags-8e60e58c2f5bbf61.bitflags.066dfbae-cgu.0.rcgu.spv
│   ├── bytemuck-b3e7e930e0f4de73.bytemuck.2753b143-cgu.0.rcgu.spv
│   ⋮
│   ├── shared-6aad9625adbcf25a.3o3jyhwfr4jh2s1n.rcgu.spv
│   ├── sky_shader.19029ydyojn6ny4z.rcgu.spv
│   ├── spirv_std-ebcff9dfacf15505.3zchoimcc4ql6s81.rcgu.spv
│   ⋮
│   ├── spirv_std-ebcff9dfacf15505.gw065rptpzqehcz.rcgu.spv
│   └── spirv_std_types-2758271e2b6a2802.2k6ghdgur5korza1.rcgu.spv
├── post-merge
│   └── sky_shader.spv
├── spirt-passes
│   ├── sky_shader.spirt
│   └── sky_shader.spirt.html
├── post-split
│   └── sky_shader.spv
└── post-link
    └── sky_shader.spv
```

```console
$ RUSTGPU_CODEGEN_ARGS="--dump-pre-link=$PWD/dumps/pre-link \
                        --dump-post-merge=$PWD/dumps/post-merge \
                        --dump-post-split=$PWD/dumps/post-split \
                        --dump-post-link=$PWD/dumps/post-link \
                        --spirt --dump-spirt-passes=$PWD/dumps/spirt-passes" \
  cargo run -p multibuilder
⋮
   Compiling sky-shader v0.0.0 (⋯/examples/shaders/sky-shader)
⋮
$ tree dumps
dumps
├── pre-link
│   ⋮
├── post-merge
│   └── sky_shader.spv
├── spirt-passes
│   ├── sky_shader.spirt
│   └── sky_shader.spirt.html
├── post-split
│   ├── sky_shader.main_fs.spv
│   └── sky_shader.main_vs.spv
└── post-link
    ├── sky_shader.main_fs.spv
    └── sky_shader.main_vs.spv
```
(`dumps/pre-link` omitted as it's identical between the single-module and multi-module modes)

---

This idea first came up in the context of `--dump-spirt-passes` (from #940) - which we want to be able to set *once* for shader builders that build several shaders (or potentially even *the entire test suite*, heh), but it turns out that pretty much all existing `--dump-*` also have the problem of not being able to tell anything apart.

Hopefully the above before/after comparison speaks for itself!