### PR TITLE
Use `spirt 0.1.0` from crates.io.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,8 @@ dependencies = [
 [[package]]
 name = "spirt"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/spirt.git?rev=cda161b7e7b336685448ab0a7f8cfe96bd90e752#cda161b7e7b336685448ab0a7f8cfe96bd90e752"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06834ebbbbc6f86448fd5dc7ccbac80e36f52f8d66838683752e19d3cae9a459"
 dependencies = [
  "arrayvec",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,3 @@ codegen-units = 256
 opt-level = 3
 incremental = true
 codegen-units = 256
-
-[patch.crates-io]
-# HACK(eddyb) only needed until `spirt 0.1.0` is released.
-spirt = { git = "https://github.com/EmbarkStudios/spirt.git", rev = "cda161b7e7b336685448ab0a7f8cfe96bd90e752" }


### PR DESCRIPTION
I've just released [`spirt 0.1.0`](https://docs.rs/spirt/0.1.0) on crates.io ([after some "release candidate" churn](https://github.com/EmbarkStudios/spirt/commits/0.1.0)).

Notable recent improvements:
* https://github.com/EmbarkStudios/spirt/pull/14
* https://github.com/EmbarkStudios/spirt/pull/16

Sadly, I had to revert this (mostly aesthetic/"SPIR-V output size" improvement):
* https://github.com/EmbarkStudios/spirt/pull/10
  (revert commit has more details in added comments: https://github.com/EmbarkStudios/spirt/commit/2b07460da448e3c18e64e2cf186d61dcf1e12e39)

Once we land this, releasing Rust-GPU `0.4.0` should have no more "technical" blockers (as the lack of a crates.io `spirt 0.1.0` release meant Rust-GPU could not release on crates.io), though @oisyn might still be working on some documentation for the release.