### PR TITLE
Update docs for manual shader crate building

### DIFF
--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -116,14 +116,17 @@ Now we need to add our `.cargo/config` file. This is a configuration file that
 tells cargo how to build for SPIR-V. You need provide the target you're
 compiling for (see [platform support](./platform-support.md)) and provide a path
 to your built `rustc_codegen_spirv` dynamic library. We have to also provide
-`-Zbuild-std`.
+some additional options.
 
 ```toml
 [build]
 target = "spirv-unknown-spv1.3"
 rustflags = [
-   "-Zcodegen-backend=<path_to_librustc_codegen_spirv>",
-   "-Csymbol-mangling-version=v0"
+    "-Zcodegen-backend=<path_to_librustc_codegen_spirv>",
+    "-Zbinary-dep-depinfo",
+    "-Csymbol-mangling-version=v0",
+    "-Zcrate-attr=feature(register_tool)",
+    "-Zcrate-attr=register_tool(rust_gpu)"
 ]
 
 [unstable]


### PR DESCRIPTION
Add some additional flags based on [crates/spirv-builder/src/lib.rs](https://github.com/EmbarkStudios/rust-gpu/blob/8fcb61e82a3bd74df67204c9b4fb1f6f71d20c73/crates/spirv-builder/src/lib.rs#L429-L438) which weren't updated here yet. (causing compilation errors) Also update the wording so it doesn't seem like the user is supposed to call `cargo -Zbuild-std`.