### PR TITLE
Removed return type inference from `Image` API

### DIFF
--- a/crates/spirv-std/src/float.rs
+++ b/crates/spirv-std/src/float.rs
@@ -1,6 +1,6 @@
 //! Traits and helper functions related to floats.
 
-use crate::vector::Vector;
+use crate::vector::{Vector, VectorTypeRef};
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
 
@@ -71,7 +71,10 @@ struct F32x2 {
     x: f32,
     y: f32,
 }
-unsafe impl Vector<f32, 2> for F32x2 {}
+unsafe impl Vector<f32, 2> for F32x2 { type VectorTypeLib = F32x2TypeLib; }
+
+struct F32x2TypeLib;
+impl VectorTypeRef<f32, 2> for F32x2TypeLib { type Vector = F32x2; }
 
 /// Converts an f32 (float) into an f16 (half). The result is a u32, not a u16, due to GPU support
 /// for u16 not being universal - the upper 16 bits will always be zero.

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -18,7 +18,7 @@ use crate::{
     float::Float,
     integer::Integer,
     vector::{Vector, VectorTypeRef},
-    Sampler,
+    Sampler, VectorFromVector,
 };
 
 /// Re-export of primitive types to ensure the `Image` proc macro always points
@@ -124,10 +124,8 @@ impl<
     /// Fetch a single texel with a sampler set at compile time
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageFetch")]
-    pub fn fetch<I, C, const N: usize>(
-        &self,
-        coordinate: C,
-    ) -> <<C>::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    pub fn fetch<I, C, const N: usize>(&self, coordinate: C) -> VectorFromVector!(C, SampledType, 4)
+    //<<C>::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
     where
         I: Integer,
         C: ImageCoordinate<I, DIM, ARRAYED> + Vector<I, N>,
@@ -168,7 +166,7 @@ impl<
         sampler: Sampler,
         coordinate: C,
         component: u32,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         Self: HasGather,
         F: Float,
@@ -201,7 +199,7 @@ impl<
         &self,
         sampler: Sampler,
         coord: C,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, ARRAYED> + Vector<F, N>,
@@ -234,7 +232,7 @@ impl<
         sampler: Sampler,
         coord: C,
         bias: f32,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, ARRAYED> + Vector<F, N>,
@@ -269,7 +267,7 @@ impl<
         sampler: Sampler,
         coordinate: C,
         lod: f32,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, ARRAYED> + Vector<F, N>,
@@ -304,7 +302,7 @@ impl<
         coordinate: C,
         gradient_dx: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
         gradient_dy: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, ARRAYED> + Vector<F, N>,
@@ -463,7 +461,7 @@ impl<
         &self,
         sampler: Sampler,
         project_coordinate: C,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, { Arrayed::True as u32 }> + Vector<F, N>,
@@ -495,7 +493,7 @@ impl<
         sampler: Sampler,
         project_coordinate: C,
         lod: f32,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, { Arrayed::True as u32 }> + Vector<F, N>,
@@ -530,7 +528,7 @@ impl<
         project_coordinate: C,
         gradient_dx: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
         gradient_dy: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, { Arrayed::True as u32 }> + Vector<F, N>,
@@ -677,10 +675,7 @@ impl<
     /// Read a texel from an image without a sampler.
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageRead")]
-    pub fn read<I, C, const N: usize>(
-        &self,
-        coordinate: C,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    pub fn read<I, C, const N: usize>(&self, coordinate: C) -> VectorFromVector!(C, SampledType, 4)
     where
         I: Integer,
         C: ImageCoordinate<I, DIM, ARRAYED> + Vector<I, N>,
@@ -737,10 +732,7 @@ impl<
     /// Read a texel from an image without a sampler.
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageRead")]
-    pub fn read<I, C, const N: usize>(
-        &self,
-        coordinate: C,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    pub fn read<I, C, const N: usize>(&self, coordinate: C) -> VectorFromVector!(C, SampledType, 4)
     where
         I: Integer,
         C: ImageCoordinate<I, DIM, ARRAYED> + Vector<I, N>,
@@ -809,7 +801,7 @@ impl<
     pub fn read_subpass<I, C, const N: usize>(
         &self,
         coordinate: C,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         I: Integer,
         C: ImageCoordinateSubpassData<I, ARRAYED> + Vector<I, N>,
@@ -872,7 +864,7 @@ impl<
         &self,
         sampler: Sampler,
         coord: C,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 2>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 2)
     where
         Self: HasQueryLevels,
         C: ImageCoordinate<f32, DIM, { Arrayed::False as u32 }> + Vector<f32, N>,
@@ -1023,7 +1015,7 @@ impl<
     pub unsafe fn sample<F, C, const N: usize>(
         &self,
         coord: C,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, ARRAYED> + Vector<F, N>,
@@ -1052,7 +1044,7 @@ impl<
         &self,
         coord: C,
         lod: f32,
-    ) -> <C::VectorTypeLib as VectorTypeRef<SampledType, 4>>::Vector
+    ) -> VectorFromVector!(C, SampledType, 4)
     where
         F: Float,
         C: ImageCoordinate<F, DIM, ARRAYED> + Vector<F, N>,

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -22,9 +22,20 @@ pub unsafe trait Vector<T: crate::scalar::Scalar, const N: usize>: Default {
 /// wants to return a `Vector<f32,3>` of the same library of implementations, it can find it the
 /// concrete vector type by doing:
 ///     `<T::VectorTypeLib as VectorTypeRef<f32,3>>::Vector`
+/// Alternatively, using the `VectorFromVector!` macro:
+///     `VectorFromVector!(T, f32, 3)`
 pub trait VectorTypeRef<T: crate::scalar::Scalar, const N: usize> {
     /// Concrete type that implements the vector type with these generic parameters
     type Vector: Vector<T, N, VectorTypeLib = Self>;
+}
+
+/// Helper macro that allows you to find a vector type with certain generic parameters
+/// from the same 'vector type library' as another vector type.
+#[macro_export]
+macro_rules! VectorFromVector {
+    ($vec: ty, $comp: ty, $dim: expr) => {
+        <<$vec>::VectorTypeLib as VectorTypeRef<$comp, $dim>>::Vector
+    };
 }
 
 /// Glam vector type library. It implements all relevant VectorTypeRef<T,N>s

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -5,34 +5,131 @@
 /// # Safety
 /// Implementing this trait on non-simd-vector types breaks assumptions of other unsafe code, and
 /// should not be done.
-pub unsafe trait Vector<T: crate::scalar::Scalar, const N: usize>: Default {}
+pub unsafe trait Vector<T: crate::scalar::Scalar, const N: usize>: Default {
+    /// Refers to a helper type that implements all kinds of references to concrete vectors
+    /// within the same library
+    type VectorTypeLib: VectorTypeRef<T, N>;
+}
+
+/// Trait that refers to a concrete vector type with specific generic parameters, to aid generic
+/// functions in finding concrete vector types of different generic parameters implemented by
+/// the same library.
+///
+/// A type that implements such a trait, is expected to implement many concrete variants of this
+/// trait. Such a type is said to be a 'vector type library'.
+///
+/// For example, if a generic function has as input `T impl Vector<i3,2>` and it
+/// wants to return a `Vector<f32,3>` of the same library of implementations, it can find it the
+/// concrete vector type by doing:
+///     `<T::VectorTypeLib as VectorTypeRef<f32,3>>::Vector`
+pub trait VectorTypeRef<T: crate::scalar::Scalar, const N: usize> {
+    /// Concrete type that implements the vector type with these generic parameters
+    type Vector: Vector<T, N, VectorTypeLib = Self>;
+}
+
+/// Glam vector type library. It implements all relevant VectorTypeRef<T,N>s
+pub struct GlamVectorTypeLib;
 
 #[cfg(feature = "glam")]
-unsafe impl Vector<f32, 2> for glam::Vec2 {}
+unsafe impl Vector<f32, 2> for glam::Vec2 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<f32, 3> for glam::Vec3 {}
+unsafe impl Vector<f32, 3> for glam::Vec3 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<f32, 3> for glam::Vec3A {}
+unsafe impl Vector<f32, 3> for glam::Vec3A {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<f32, 4> for glam::Vec4 {}
+unsafe impl Vector<f32, 4> for glam::Vec4 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<f32, 2> for GlamVectorTypeLib {
+    type Vector = glam::Vec2;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<f32, 3> for GlamVectorTypeLib {
+    type Vector = glam::Vec3;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<f32, 4> for GlamVectorTypeLib {
+    type Vector = glam::Vec4;
+}
 
 #[cfg(feature = "glam")]
-unsafe impl Vector<f64, 2> for glam::DVec2 {}
+unsafe impl Vector<f64, 2> for glam::DVec2 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<f64, 3> for glam::DVec3 {}
+unsafe impl Vector<f64, 3> for glam::DVec3 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<f64, 4> for glam::DVec4 {}
+unsafe impl Vector<f64, 4> for glam::DVec4 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<f64, 2> for GlamVectorTypeLib {
+    type Vector = glam::DVec2;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<f64, 3> for GlamVectorTypeLib {
+    type Vector = glam::DVec3;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<f64, 4> for GlamVectorTypeLib {
+    type Vector = glam::DVec4;
+}
 
 #[cfg(feature = "glam")]
-unsafe impl Vector<u32, 2> for glam::UVec2 {}
+unsafe impl Vector<u32, 2> for glam::UVec2 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<u32, 3> for glam::UVec3 {}
+unsafe impl Vector<u32, 3> for glam::UVec3 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<u32, 4> for glam::UVec4 {}
+unsafe impl Vector<u32, 4> for glam::UVec4 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<u32, 2> for GlamVectorTypeLib {
+    type Vector = glam::UVec2;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<u32, 3> for GlamVectorTypeLib {
+    type Vector = glam::UVec3;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<u32, 4> for GlamVectorTypeLib {
+    type Vector = glam::UVec4;
+}
 
 #[cfg(feature = "glam")]
-unsafe impl Vector<i32, 2> for glam::IVec2 {}
+unsafe impl Vector<i32, 2> for glam::IVec2 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<i32, 3> for glam::IVec3 {}
+unsafe impl Vector<i32, 3> for glam::IVec3 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
 #[cfg(feature = "glam")]
-unsafe impl Vector<i32, 4> for glam::IVec4 {}
+unsafe impl Vector<i32, 4> for glam::IVec4 {
+    type VectorTypeLib = GlamVectorTypeLib;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<i32, 2> for GlamVectorTypeLib {
+    type Vector = glam::IVec2;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<i32, 3> for GlamVectorTypeLib {
+    type Vector = glam::IVec3;
+}
+#[cfg(feature = "glam")]
+impl VectorTypeRef<i32, 4> for GlamVectorTypeLib {
+    type Vector = glam::IVec4;
+}

--- a/tests/ui/arch/all.rs
+++ b/tests/ui/arch/all.rs
@@ -2,8 +2,9 @@
 
 #![feature(repr_simd)]
 
+use spirv_std::scalar::Scalar;
 use spirv_std::spirv;
-use spirv_std::{scalar::Scalar, vector::Vector};
+use spirv_std::vector::{Vector, VectorTypeRef};
 
 /// HACK(shesp). Rust doesn't allow us to declare regular (tuple-)structs containing `bool` members
 /// as `#[repl(simd)]`. But we need this for `spirv_std::arch::any()` and `spirv_std::arch::all()`
@@ -12,7 +13,13 @@ use spirv_std::{scalar::Scalar, vector::Vector};
 /// it (for now at least)
 #[repr(simd)]
 struct Vec2<T>(T, T);
-unsafe impl<T: Scalar> Vector<T, 2> for Vec2<T> {}
+struct MyVecLib;
+unsafe impl<T: Scalar> Vector<T, 2> for Vec2<T> {
+    type VectorTypeLib = MyVecLib;
+}
+impl<T: Scalar> VectorTypeRef<T, 2> for MyVecLib {
+    type Vector = Vec2<T>;
+}
 
 impl<T: Scalar> Default for Vec2<T> {
     fn default() -> Vec2<T> {

--- a/tests/ui/arch/any.rs
+++ b/tests/ui/arch/any.rs
@@ -2,8 +2,9 @@
 
 #![feature(repr_simd)]
 
+use spirv_std::scalar::Scalar;
 use spirv_std::spirv;
-use spirv_std::{scalar::Scalar, vector::Vector};
+use spirv_std::vector::{Vector, VectorTypeRef};
 
 /// HACK(shesp). Rust doesn't allow us to declare regular (tuple-)structs containing `bool` members
 /// as `#[repl(simd)]`. But we need this for `spirv_std::arch::any()` and `spirv_std::arch::all()`
@@ -12,7 +13,13 @@ use spirv_std::{scalar::Scalar, vector::Vector};
 /// it (for now at least)
 #[repr(simd)]
 struct Vec2<T>(T, T);
-unsafe impl<T: Scalar> Vector<T, 2> for Vec2<T> {}
+struct MyVecLib;
+unsafe impl<T: Scalar> Vector<T, 2> for Vec2<T> {
+    type VectorTypeLib = MyVecLib;
+}
+impl<T: Scalar> VectorTypeRef<T, 2> for MyVecLib {
+    type Vector = Vec2<T>;
+}
 
 impl<T: Scalar> Default for Vec2<T> {
     fn default() -> Vec2<T> {

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -9,26 +9,90 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:164:15
+   --> $SPIRV_STD_SRC/image.rs:173:15
     |
-164 |         Self: HasGather,
+173 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
 
-error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not satisfied
-   --> $DIR/gather_err.rs:16:34
-    |
-16  |     let r2: glam::Vec4 = image3d.gather(*sampler, v3, 0);
-    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 2, 2, 0, 0, 1, 0>`
-    |
-    = help: the following other types implement trait `HasGather`:
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:164:15
-    |
-164 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
+error: internal compiler error: /rustc/0468a00ae3fd6ef1a6a0f9eaf637d7aa9e604acc/compiler/rustc_middle/src/ty/relate.rs:638:13: var types encountered in super_relate_consts: Const { ty: usize, kind: Param(N/#8) } Const { ty: usize, kind: Infer(Var(_#5c)) }
+
+thread 'rustc' panicked at 'Box<dyn Any>', /rustc/0468a00ae3fd6ef1a6a0f9eaf637d7aa9e604acc/compiler/rustc_errors/src/lib.rs:1576:9
+stack backtrace:
+   0:     0x7ffd34a29de2 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hea3121a92230cef2
+   1:     0x7ffd34a65d0b - core::fmt::write::h0bc3f53e8dca163a
+   2:     0x7ffd34a1c8fa - <std::io::IoSlice as core::fmt::Debug>::fmt::h7890ee78f4472cf6
+   3:     0x7ffd34a29b2b - std::sys::common::alloc::realloc_fallback::h2905b67a6dea1c71
+   4:     0x7ffd34a2d459 - std::panicking::default_hook::h111ce7f1b363c3ab
+   5:     0x7ffd34a2d0db - std::panicking::default_hook::h111ce7f1b363c3ab
+   6:     0x7ffd137949f6 - _rustc_codegen_backend
+   7:     0x7ffd34a2ddc0 - std::panicking::rust_panic_with_hook::hfc6ef76eb93085aa
+   8:     0x7ffd175fff83 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+   9:     0x7ffd175ff939 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  10:     0x7ffd17641fc9 - <rustc_middle[2d97b4190bb00205]::ty::subst::UserSubsts as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  11:     0x7ffd175fe849 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  12:     0x7ffd175fd590 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  13:     0x7ffd175fd0a2 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  14:     0x7ffd176c7da8 - <rustc_middle[2d97b4190bb00205]::ty::consts::valtree::ValTree>::try_to_raw_bytes
+  15:     0x7ffd176c80b8 - rustc_middle[2d97b4190bb00205]::util::bug::bug_fmt
+  16:     0x7ffd176c8035 - rustc_middle[2d97b4190bb00205]::util::bug::bug_fmt
+  17:     0x7ffd17d5cb9e - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::method_chain::CollectAllMismatches as rustc_middle[2d97b4190bb00205]::ty::relate::TypeRelation>::consts
+  18:     0x7ffd17e2b3eb - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::maybe_suggest_unsized_generics
+  19:     0x7ffd17da21fc - <rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::implied_outlives_bounds::ImpliedOutlivesBounds as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  20:     0x7ffd17dd11c2 - <rustc_middle[2d97b4190bb00205]::ty::sty::Binder<rustc_middle[2d97b4190bb00205]::ty::sty::FnSig> as rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::normalize::Normalizable>::type_op_method
+  21:     0x7ffd17df7e87 - <rustc_trait_selection[49c09980fcea1f95]::traits::select::ProvisionalEvaluation as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  22:     0x7ffd17dcbb4c - <rustc_middle[2d97b4190bb00205]::ty::sty::Binder<rustc_middle[2d97b4190bb00205]::ty::sty::FnSig> as rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::normalize::Normalizable>::type_op_method
+  23:     0x7ffd17d6a6c8 - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::GeneratorData as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  24:     0x7ffd17dc4c9f - <rustc_trait_selection[49c09980fcea1f95]::traits::util::TraitAliasExpansionInfo as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  25:     0x7ffd17dd935c - <rustc_trait_selection[49c09980fcea1f95]::traits::TraitQueryMode as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  26:     0x7ffd17d5ce23 - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::method_chain::CollectAllMismatches as rustc_middle[2d97b4190bb00205]::ty::relate::TypeRelation>::consts
+  27:     0x7ffd17dc678b - <rustc_trait_selection[49c09980fcea1f95]::traits::util::TraitAliasExpansionInfo as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  28:     0x7ffd17e1167b - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::TypeErrCtxtExt>::function_argument_obligation
+  29:     0x7ffd17e0cba8 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::TypeErrCtxtExt>::suggest_fully_qualified_path
+  30:     0x7ffd17e1fbe0 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::note_obligation_cause
+  31:     0x7ffd17e15e2f - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::TypeErrCtxtExt>::report_selection_error
+  32:     0x7ffd17e23377 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::report_fulfillment_error
+  33:     0x7ffd17e140b6 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::TypeErrCtxtExt>::report_fulfillment_errors
+  34:     0x7ffd1566abf3 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::probe_instantiate_query_response
+  35:     0x7ffd1564ed19 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::probe_instantiate_query_response
+  36:     0x7ffd15626e43 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
+  37:     0x7ffd1567dfc6 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::check_struct_path
+  38:     0x7ffd1567f5d1 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::check_struct_path
+  39:     0x7ffd15626871 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
+  40:     0x7ffd156391ff - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
+  41:     0x7ffd157394d8 - <rustc_hir_typeck[f0addf0c856a1637]::upvar::InferBorrowKindVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_expr
+  42:     0x7ffd156ee929 - <rustc_hir_typeck[f0addf0c856a1637]::inherited::Inherited>::build
+  43:     0x7ffd1570b64e - <rustc_hir_typeck[f0addf0c856a1637]::gather_locals::GatherLocalsVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_pat
+  44:     0x7ffd15e32234 - <rustc_middle[2d97b4190bb00205]::ty::Visibility as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  45:     0x7ffd1573f812 - <rustc_hir_typeck[f0addf0c856a1637]::upvar::InferBorrowKindVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_expr
+  46:     0x7ffd1445c171 - <rustc_hir_typeck[f0addf0c856a1637]::gather_locals::GatherLocalsVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_param
+  47:     0x7ffd147dcdc9 - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  48:     0x7ffd1485a99b - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  49:     0x7ffd143c1e0a - <rustc_hir_analysis[abf2fb892a9f178e]::check::intrinsicck::InlineAsmCtxt>::check_asm
+  50:     0x7ffd143dcc4f - rustc_hir_analysis[abf2fb892a9f178e]::check_crate
+  51:     0x7ffd144d23fd - rustc_interface[e09bab31b5025fb2]::passes::analysis
+  52:     0x7ffd147c50c9 - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  53:     0x7ffd148626ef - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  54:     0x7ffd142d3573 - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
+  55:     0x7ffd142e4317 - rustc_driver[5e4fd5aa1121bb7c]::args::arg_expand_all
+  56:     0x7ffd142d4983 - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
+  57:     0x7ffd142ca24d - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
+  58:     0x7ffd34a3fe9c - std::sys::windows::thread::Thread::new::h4025a5964e95cbad
+  59:     0x7ffdb0ae55a0 - BaseThreadInitThunk
+  60:     0x7ffdb17e485b - RtlUserThreadStart
+note: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/EmbarkStudios/rust-gpu/issues/new
+
+note: rustc 1.68.0-nightly (0468a00ae 2022-12-17) running on x86_64-pc-windows-msvc
+
+note: compiler flags: -C prefer-dynamic -Z codegen-backend=D:/embark/rust-gpu/target/release/deps/rustc_codegen_spirv.dll -Z binary-dep-depinfo -C overflow-checks=off -C debug-assertions=off -C debuginfo=2 -C embed-bitcode=no -C target-feature=+Int8,+Int16,+Int64,+Float64,+ShaderClockKHR,+ext:SPV_KHR_shader_clock -C symbol-mangling-version=v0 -Z crate-attr=feature(register_tool) -Z crate-attr=register_tool(rust_gpu) --crate-type dylib -Z unstable-options -Z crate-attr=no_std -Z crate-attr=feature(asm_const,asm_experimental_arch) -C llvm-args=--spirt -C target-feature=+Sampled1D
+
+query stack during panic:
+#0 [typeck] type-checking `main`
+#1 [typeck_item_bodies] type-checking all item bodies
+#2 [analysis] running analysis passes on this crate
+end of query stack
+note: `rust-gpu` version 0.4.0
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -9,76 +9,76 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:173:15
+   --> $SPIRV_STD_SRC/image.rs:171:15
     |
-173 |         Self: HasGather,
+171 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
 
 error: internal compiler error: /rustc/0468a00ae3fd6ef1a6a0f9eaf637d7aa9e604acc/compiler/rustc_middle/src/ty/relate.rs:638:13: var types encountered in super_relate_consts: Const { ty: usize, kind: Param(N/#8) } Const { ty: usize, kind: Infer(Var(_#5c)) }
 
 thread 'rustc' panicked at 'Box<dyn Any>', /rustc/0468a00ae3fd6ef1a6a0f9eaf637d7aa9e604acc/compiler/rustc_errors/src/lib.rs:1576:9
 stack backtrace:
-   0:     0x7ffd34a29de2 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hea3121a92230cef2
-   1:     0x7ffd34a65d0b - core::fmt::write::h0bc3f53e8dca163a
-   2:     0x7ffd34a1c8fa - <std::io::IoSlice as core::fmt::Debug>::fmt::h7890ee78f4472cf6
-   3:     0x7ffd34a29b2b - std::sys::common::alloc::realloc_fallback::h2905b67a6dea1c71
-   4:     0x7ffd34a2d459 - std::panicking::default_hook::h111ce7f1b363c3ab
-   5:     0x7ffd34a2d0db - std::panicking::default_hook::h111ce7f1b363c3ab
-   6:     0x7ffd137949f6 - _rustc_codegen_backend
-   7:     0x7ffd34a2ddc0 - std::panicking::rust_panic_with_hook::hfc6ef76eb93085aa
-   8:     0x7ffd175fff83 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
-   9:     0x7ffd175ff939 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
-  10:     0x7ffd17641fc9 - <rustc_middle[2d97b4190bb00205]::ty::subst::UserSubsts as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
-  11:     0x7ffd175fe849 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
-  12:     0x7ffd175fd590 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
-  13:     0x7ffd175fd0a2 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
-  14:     0x7ffd176c7da8 - <rustc_middle[2d97b4190bb00205]::ty::consts::valtree::ValTree>::try_to_raw_bytes
-  15:     0x7ffd176c80b8 - rustc_middle[2d97b4190bb00205]::util::bug::bug_fmt
-  16:     0x7ffd176c8035 - rustc_middle[2d97b4190bb00205]::util::bug::bug_fmt
-  17:     0x7ffd17d5cb9e - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::method_chain::CollectAllMismatches as rustc_middle[2d97b4190bb00205]::ty::relate::TypeRelation>::consts
-  18:     0x7ffd17e2b3eb - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::maybe_suggest_unsized_generics
-  19:     0x7ffd17da21fc - <rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::implied_outlives_bounds::ImpliedOutlivesBounds as core[c581a5698e0001c6]::fmt::Debug>::fmt
-  20:     0x7ffd17dd11c2 - <rustc_middle[2d97b4190bb00205]::ty::sty::Binder<rustc_middle[2d97b4190bb00205]::ty::sty::FnSig> as rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::normalize::Normalizable>::type_op_method
-  21:     0x7ffd17df7e87 - <rustc_trait_selection[49c09980fcea1f95]::traits::select::ProvisionalEvaluation as core[c581a5698e0001c6]::fmt::Debug>::fmt
-  22:     0x7ffd17dcbb4c - <rustc_middle[2d97b4190bb00205]::ty::sty::Binder<rustc_middle[2d97b4190bb00205]::ty::sty::FnSig> as rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::normalize::Normalizable>::type_op_method
-  23:     0x7ffd17d6a6c8 - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::GeneratorData as core[c581a5698e0001c6]::fmt::Debug>::fmt
-  24:     0x7ffd17dc4c9f - <rustc_trait_selection[49c09980fcea1f95]::traits::util::TraitAliasExpansionInfo as core[c581a5698e0001c6]::fmt::Debug>::fmt
-  25:     0x7ffd17dd935c - <rustc_trait_selection[49c09980fcea1f95]::traits::TraitQueryMode as core[c581a5698e0001c6]::fmt::Debug>::fmt
-  26:     0x7ffd17d5ce23 - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::method_chain::CollectAllMismatches as rustc_middle[2d97b4190bb00205]::ty::relate::TypeRelation>::consts
-  27:     0x7ffd17dc678b - <rustc_trait_selection[49c09980fcea1f95]::traits::util::TraitAliasExpansionInfo as core[c581a5698e0001c6]::fmt::Debug>::fmt
-  28:     0x7ffd17e1167b - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::TypeErrCtxtExt>::function_argument_obligation
-  29:     0x7ffd17e0cba8 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::TypeErrCtxtExt>::suggest_fully_qualified_path
-  30:     0x7ffd17e1fbe0 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::note_obligation_cause
-  31:     0x7ffd17e15e2f - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::TypeErrCtxtExt>::report_selection_error
-  32:     0x7ffd17e23377 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::report_fulfillment_error
-  33:     0x7ffd17e140b6 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::TypeErrCtxtExt>::report_fulfillment_errors
-  34:     0x7ffd1566abf3 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::probe_instantiate_query_response
-  35:     0x7ffd1564ed19 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::probe_instantiate_query_response
-  36:     0x7ffd15626e43 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
-  37:     0x7ffd1567dfc6 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::check_struct_path
-  38:     0x7ffd1567f5d1 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::check_struct_path
-  39:     0x7ffd15626871 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
-  40:     0x7ffd156391ff - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
-  41:     0x7ffd157394d8 - <rustc_hir_typeck[f0addf0c856a1637]::upvar::InferBorrowKindVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_expr
-  42:     0x7ffd156ee929 - <rustc_hir_typeck[f0addf0c856a1637]::inherited::Inherited>::build
-  43:     0x7ffd1570b64e - <rustc_hir_typeck[f0addf0c856a1637]::gather_locals::GatherLocalsVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_pat
-  44:     0x7ffd15e32234 - <rustc_middle[2d97b4190bb00205]::ty::Visibility as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
-  45:     0x7ffd1573f812 - <rustc_hir_typeck[f0addf0c856a1637]::upvar::InferBorrowKindVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_expr
-  46:     0x7ffd1445c171 - <rustc_hir_typeck[f0addf0c856a1637]::gather_locals::GatherLocalsVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_param
-  47:     0x7ffd147dcdc9 - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
-  48:     0x7ffd1485a99b - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
-  49:     0x7ffd143c1e0a - <rustc_hir_analysis[abf2fb892a9f178e]::check::intrinsicck::InlineAsmCtxt>::check_asm
-  50:     0x7ffd143dcc4f - rustc_hir_analysis[abf2fb892a9f178e]::check_crate
-  51:     0x7ffd144d23fd - rustc_interface[e09bab31b5025fb2]::passes::analysis
-  52:     0x7ffd147c50c9 - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
-  53:     0x7ffd148626ef - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
-  54:     0x7ffd142d3573 - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
-  55:     0x7ffd142e4317 - rustc_driver[5e4fd5aa1121bb7c]::args::arg_expand_all
-  56:     0x7ffd142d4983 - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
-  57:     0x7ffd142ca24d - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
-  58:     0x7ffd34a3fe9c - std::sys::windows::thread::Thread::new::h4025a5964e95cbad
-  59:     0x7ffdb0ae55a0 - BaseThreadInitThunk
-  60:     0x7ffdb17e485b - RtlUserThreadStart
+   0:     0x7ffda9b69de2 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hea3121a92230cef2
+   1:     0x7ffda9ba5d0b - core::fmt::write::h0bc3f53e8dca163a
+   2:     0x7ffda9b5c8fa - <std::io::IoSlice as core::fmt::Debug>::fmt::h7890ee78f4472cf6
+   3:     0x7ffda9b69b2b - std::sys::common::alloc::realloc_fallback::h2905b67a6dea1c71
+   4:     0x7ffda9b6d459 - std::panicking::default_hook::h111ce7f1b363c3ab
+   5:     0x7ffda9b6d0db - std::panicking::default_hook::h111ce7f1b363c3ab
+   6:     0x7ffd998e49f6 - _rustc_codegen_backend
+   7:     0x7ffda9b6ddc0 - std::panicking::rust_panic_with_hook::hfc6ef76eb93085aa
+   8:     0x7ffd4722ff83 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+   9:     0x7ffd4722f939 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  10:     0x7ffd47271fc9 - <rustc_middle[2d97b4190bb00205]::ty::subst::UserSubsts as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  11:     0x7ffd4722e849 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  12:     0x7ffd4722d590 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  13:     0x7ffd4722d0a2 - <rustc_middle[2d97b4190bb00205]::mir::coverage::ExpressionOperandId as rustc_middle[2d97b4190bb00205]::ty::context::Lift>::lift_to_tcx
+  14:     0x7ffd472f7da8 - <rustc_middle[2d97b4190bb00205]::ty::consts::valtree::ValTree>::try_to_raw_bytes
+  15:     0x7ffd472f80b8 - rustc_middle[2d97b4190bb00205]::util::bug::bug_fmt
+  16:     0x7ffd472f8035 - rustc_middle[2d97b4190bb00205]::util::bug::bug_fmt
+  17:     0x7ffd4798cb9e - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::method_chain::CollectAllMismatches as rustc_middle[2d97b4190bb00205]::ty::relate::TypeRelation>::consts
+  18:     0x7ffd47a5b3eb - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::maybe_suggest_unsized_generics
+  19:     0x7ffd479d21fc - <rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::implied_outlives_bounds::ImpliedOutlivesBounds as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  20:     0x7ffd47a011c2 - <rustc_middle[2d97b4190bb00205]::ty::sty::Binder<rustc_middle[2d97b4190bb00205]::ty::sty::FnSig> as rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::normalize::Normalizable>::type_op_method
+  21:     0x7ffd47a27e87 - <rustc_trait_selection[49c09980fcea1f95]::traits::select::ProvisionalEvaluation as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  22:     0x7ffd479fbb4c - <rustc_middle[2d97b4190bb00205]::ty::sty::Binder<rustc_middle[2d97b4190bb00205]::ty::sty::FnSig> as rustc_trait_selection[49c09980fcea1f95]::traits::query::type_op::normalize::Normalizable>::type_op_method
+  23:     0x7ffd4799a6c8 - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::GeneratorData as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  24:     0x7ffd479f4c9f - <rustc_trait_selection[49c09980fcea1f95]::traits::util::TraitAliasExpansionInfo as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  25:     0x7ffd47a0935c - <rustc_trait_selection[49c09980fcea1f95]::traits::TraitQueryMode as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  26:     0x7ffd4798ce23 - <rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::method_chain::CollectAllMismatches as rustc_middle[2d97b4190bb00205]::ty::relate::TypeRelation>::consts
+  27:     0x7ffd479f678b - <rustc_trait_selection[49c09980fcea1f95]::traits::util::TraitAliasExpansionInfo as core[c581a5698e0001c6]::fmt::Debug>::fmt
+  28:     0x7ffd47a4167b - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::TypeErrCtxtExt>::function_argument_obligation
+  29:     0x7ffd47a3cba8 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::suggestions::TypeErrCtxtExt>::suggest_fully_qualified_path
+  30:     0x7ffd47a4fbe0 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::note_obligation_cause
+  31:     0x7ffd47a45e2f - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::TypeErrCtxtExt>::report_selection_error
+  32:     0x7ffd47a53377 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::InferCtxtPrivExt>::report_fulfillment_error
+  33:     0x7ffd47a440b6 - <rustc_infer[b622840728d78c35]::infer::error_reporting::TypeErrCtxt as rustc_trait_selection[49c09980fcea1f95]::traits::error_reporting::TypeErrCtxtExt>::report_fulfillment_errors
+  34:     0x7ffd4529abf3 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::probe_instantiate_query_response
+  35:     0x7ffd4527ed19 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::probe_instantiate_query_response
+  36:     0x7ffd45256e43 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
+  37:     0x7ffd452adfc6 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::check_struct_path
+  38:     0x7ffd452af5d1 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::check_struct_path
+  39:     0x7ffd45256871 - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
+  40:     0x7ffd452691ff - <rustc_hir_typeck[f0addf0c856a1637]::fn_ctxt::FnCtxt>::demand_coerce
+  41:     0x7ffd453694d8 - <rustc_hir_typeck[f0addf0c856a1637]::upvar::InferBorrowKindVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_expr
+  42:     0x7ffd4531e929 - <rustc_hir_typeck[f0addf0c856a1637]::inherited::Inherited>::build
+  43:     0x7ffd4533b64e - <rustc_hir_typeck[f0addf0c856a1637]::gather_locals::GatherLocalsVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_pat
+  44:     0x7ffd45a62234 - <rustc_middle[2d97b4190bb00205]::ty::Visibility as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  45:     0x7ffd4536f812 - <rustc_hir_typeck[f0addf0c856a1637]::upvar::InferBorrowKindVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_expr
+  46:     0x7ffd4408c171 - <rustc_hir_typeck[f0addf0c856a1637]::gather_locals::GatherLocalsVisitor as rustc_hir[ec2a4f92b6f487f7]::intravisit::Visitor>::visit_param
+  47:     0x7ffd4440cdc9 - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  48:     0x7ffd4448a99b - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  49:     0x7ffd43ff1e0a - <rustc_hir_analysis[abf2fb892a9f178e]::check::intrinsicck::InlineAsmCtxt>::check_asm
+  50:     0x7ffd4400cc4f - rustc_hir_analysis[abf2fb892a9f178e]::check_crate
+  51:     0x7ffd441023fd - rustc_interface[e09bab31b5025fb2]::passes::analysis
+  52:     0x7ffd443f50c9 - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  53:     0x7ffd444926ef - <core[c581a5698e0001c6]::option::Option<rustc_middle[2d97b4190bb00205]::middle::privacy::Level> as rustc_privacy[6422734b6ac716cf]::VisibilityLike>::new_min
+  54:     0x7ffd43f03573 - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
+  55:     0x7ffd43f14317 - rustc_driver[5e4fd5aa1121bb7c]::args::arg_expand_all
+  56:     0x7ffd43f04983 - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
+  57:     0x7ffd43efa24d - <rustc_span[25fa311e2ce9dc22]::DebuggerVisualizerFile>::new
+  58:     0x7ffda9b7fe9c - std::sys::windows::thread::Thread::new::h4025a5964e95cbad
+  59:     0x7ffdcd9f26bd - BaseThreadInitThunk
+  60:     0x7ffdce7cdfb8 - RtlUserThreadStart
 note: the compiler unexpectedly panicked. this is a bug.
 
 note: we would appreciate a bug report: https://github.com/EmbarkStudios/rust-gpu/issues/new

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -1,7 +1,7 @@
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::scalar::vec4::Vec4, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::vec2::Vec2, 2>
           implicit_not_in_fragment::deeper_stack
           implicit_not_in_fragment::deep_stack
           implicit_not_in_fragment::main
@@ -10,7 +10,7 @@ error: ImageSampleImplicitLod cannot be used outside a fragment shader
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::scalar::vec4::Vec4, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::vec2::Vec2, 2>
           implicit_not_in_fragment::main
           main
 

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:851:15
+   --> $SPIRV_STD_SRC/image.rs:843:15
     |
-851 |         Self: HasQueryLevels,
+843 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:821:15
+   --> $SPIRV_STD_SRC/image.rs:851:15
     |
-821 |         Self: HasQueryLevels,
+851 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:847:15
+   --> $SPIRV_STD_SRC/image.rs:877:15
     |
-847 |         Self: HasQueryLevels,
+877 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:877:15
+   --> $SPIRV_STD_SRC/image.rs:869:15
     |
-877 |         Self: HasQueryLevels,
+869 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -15,9 +15,9 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0>: HasQuerySize` is no
               Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT>
             and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:878:15
+   --> $SPIRV_STD_SRC/image.rs:910:15
     |
-878 |         Self: HasQuerySize,
+910 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -15,9 +15,9 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0>: HasQuerySize` is no
               Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT>
             and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:910:15
+   --> $SPIRV_STD_SRC/image.rs:902:15
     |
-910 |         Self: HasQuerySize,
+902 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQuerySizeLod` is
               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:911:15
+   --> $SPIRV_STD_SRC/image.rs:943:15
     |
-911 |         Self: HasQuerySizeLod,
+943 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQuerySizeLod` is
               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:943:15
+   --> $SPIRV_STD_SRC/image.rs:935:15
     |
-943 |         Self: HasQuerySizeLod,
+935 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
 
 error: aborting due to previous error


### PR DESCRIPTION
By referring to concrete 'sibling' vector types from same vector library based on input.

@eddyb this currently causes an ICE in `tests/ui/image/gather_err.rs`