### PR TITLE
Removed return type inference from `Image` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
+## [Unreleased]
+
+### Changed 🛠
+- [PR#990](https://github.com/EmbarkStudios/rust-gpu/pull/990) Removed return type inference from `Image` API and made `glam` usage mandatory.
+
 ## [0.5.0]
 
 ### Added ⭐

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -119,12 +119,11 @@ impl<
     /// Fetch a single texel with a sampler set at compile time
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageFetch")]
-    pub fn fetch<V, I>(&self, coordinate: impl ImageCoordinate<I, DIM, ARRAYED>) -> V
+    pub fn fetch<I>(&self, coordinate: impl ImageCoordinate<I, DIM, ARRAYED>) -> SampledType::Vec4
     where
-        V: Vector<SampledType, 4>,
         I: Integer,
     {
-        let mut result = V::default();
+        let mut result = Default::default();
         unsafe {
             asm! {
                 "%image = OpLoad _ {this}",
@@ -154,18 +153,17 @@ impl<
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageGather")]
     #[inline]
-    pub fn gather<F, V>(
+    pub fn gather<F>(
         &self,
         sampler: Sampler,
         coordinate: impl ImageCoordinate<F, DIM, ARRAYED>,
         component: u32,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         Self: HasGather,
         F: Float,
-        V: Vector<SampledType, 4>,
     {
-        let mut result = V::default();
+        let mut result = Default::default();
         unsafe {
             asm! {
                 "%typeSampledImage = OpTypeSampledImage typeof*{this}",
@@ -187,10 +185,13 @@ impl<
 
     /// Sample texels at `coord` from the image using `sampler`.
     #[crate::macros::gpu_only]
-    pub fn sample<F, V>(&self, sampler: Sampler, coord: impl ImageCoordinate<F, DIM, ARRAYED>) -> V
+    pub fn sample<F>(
+        &self,
+        sampler: Sampler,
+        coord: impl ImageCoordinate<F, DIM, ARRAYED>,
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         unsafe {
             let mut result = Default::default();
@@ -214,15 +215,14 @@ impl<
     /// Sample texels at `coord` from the image using `sampler`, after adding the input bias to the
     /// implicit level of detail.
     #[crate::macros::gpu_only]
-    pub fn sample_bias<F, V>(
+    pub fn sample_bias<F>(
         &self,
         sampler: Sampler,
         coord: impl ImageCoordinate<F, DIM, ARRAYED>,
         bias: f32,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         unsafe {
             let mut result = Default::default();
@@ -248,15 +248,14 @@ impl<
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageSampleExplicitLod")]
     /// Sample the image at a coordinate by a lod
-    pub fn sample_by_lod<F, V>(
+    pub fn sample_by_lod<F>(
         &self,
         sampler: Sampler,
         coordinate: impl ImageCoordinate<F, DIM, ARRAYED>,
         lod: f32,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         let mut result = Default::default();
         unsafe {
@@ -281,16 +280,15 @@ impl<
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageSampleExplicitLod")]
     /// Sample the image based on a gradient formed by (dx, dy). Specifically, ([du/dx, dv/dx], [du/dy, dv/dy])
-    pub fn sample_by_gradient<F, V>(
+    pub fn sample_by_gradient<F>(
         &self,
         sampler: Sampler,
         coordinate: impl ImageCoordinate<F, DIM, ARRAYED>,
         gradient_dx: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
         gradient_dy: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         let mut result = Default::default();
         unsafe {
@@ -441,14 +439,13 @@ impl<
     /// Sample the image with a project coordinate
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageSampleProjImplicitLod")]
-    pub fn sample_with_project_coordinate<F, V>(
+    pub fn sample_with_project_coordinate<F>(
         &self,
         sampler: Sampler,
         project_coordinate: impl ImageCoordinate<F, DIM, { Arrayed::True as u32 }>,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         unsafe {
             let mut result = Default::default();
@@ -471,15 +468,14 @@ impl<
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageSampleProjExplicitLod")]
     /// Sample the image with a project coordinate by a lod
-    pub fn sample_with_project_coordinate_by_lod<F, V>(
+    pub fn sample_with_project_coordinate_by_lod<F>(
         &self,
         sampler: Sampler,
         project_coordinate: impl ImageCoordinate<F, DIM, { Arrayed::True as u32 }>,
         lod: f32,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         let mut result = Default::default();
         unsafe {
@@ -504,16 +500,15 @@ impl<
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageSampleProjExplicitLod")]
     /// Sample the image with a project coordinate based on a gradient formed by (dx, dy). Specifically, ([du/dx, dv/dx], [du/dy, dv/dy])
-    pub fn sample_with_project_coordinate_by_gradient<F, V>(
+    pub fn sample_with_project_coordinate_by_gradient<F>(
         &self,
         sampler: Sampler,
         project_coordinate: impl ImageCoordinate<F, DIM, { Arrayed::True as u32 }>,
         gradient_dx: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
         gradient_dy: impl ImageCoordinate<F, DIM, { Arrayed::False as u32 }>,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         let mut result = Default::default();
         unsafe {
@@ -656,12 +651,11 @@ impl<
     /// Read a texel from an image without a sampler.
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageRead")]
-    pub fn read<I, V, const N: usize>(&self, coordinate: impl ImageCoordinate<I, DIM, ARRAYED>) -> V
+    pub fn read<I>(&self, coordinate: impl ImageCoordinate<I, DIM, ARRAYED>) -> SampledType::Vec4
     where
         I: Integer,
-        V: Vector<SampledType, N>,
     {
-        let mut result = V::default();
+        let mut result = Default::default();
 
         unsafe {
             asm! {
@@ -712,12 +706,11 @@ impl<
     /// Read a texel from an image without a sampler.
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageRead")]
-    pub fn read<I, V, const N: usize>(&self, coordinate: impl ImageCoordinate<I, DIM, ARRAYED>) -> V
+    pub fn read<I>(&self, coordinate: impl ImageCoordinate<I, DIM, ARRAYED>) -> SampledType::Vec4
     where
         I: Integer,
-        V: Vector<SampledType, N>,
     {
-        let mut result = V::default();
+        let mut result = Default::default();
 
         unsafe {
             asm! {
@@ -777,15 +770,14 @@ impl<
     /// Note: Vulkan only allows the read if the first two components of the coordinate are zero.
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageRead")]
-    pub fn read_subpass<I, V, const N: usize>(
+    pub fn read_subpass<I>(
         &self,
         coordinate: impl ImageCoordinateSubpassData<I, ARRAYED>,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         I: Integer,
-        V: Vector<SampledType, N>,
     {
-        let mut result = V::default();
+        let mut result = Default::default();
 
         unsafe {
             asm! {
@@ -838,11 +830,11 @@ impl<
     /// detail relative to the base level.
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageQueryLod")]
-    pub fn query_lod<V: Vector<f32, 2>>(
+    pub fn query_lod(
         &self,
         sampler: Sampler,
         coord: impl ImageCoordinate<f32, DIM, { Arrayed::False as u32 }>,
-    ) -> V
+    ) -> SampledType::Vec2
     where
         Self: HasQueryLevels,
     {
@@ -988,10 +980,12 @@ impl<
     /// Sampling with a type (`S`) that doesn't match the image's image format
     /// will result in undefined behaviour.
     #[crate::macros::gpu_only]
-    pub unsafe fn sample<F, V>(&self, coord: impl ImageCoordinate<F, DIM, ARRAYED>) -> V
+    pub unsafe fn sample<F>(
+        &self,
+        coord: impl ImageCoordinate<F, DIM, ARRAYED>,
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         let mut result = Default::default();
         asm!(
@@ -1012,14 +1006,13 @@ impl<
     /// Sampling with a type (`S`) that doesn't match the image's image format
     /// will result in undefined behaviour.
     #[crate::macros::gpu_only]
-    pub unsafe fn sample_by_lod<F, V>(
+    pub unsafe fn sample_by_lod<F>(
         &self,
         coord: impl ImageCoordinate<F, DIM, ARRAYED>,
         lod: f32,
-    ) -> V
+    ) -> SampledType::Vec4
     where
         F: Float,
-        V: Vector<SampledType, 4>,
     {
         let mut result = Default::default();
         asm!(

--- a/crates/spirv-std/src/image/params.rs
+++ b/crates/spirv-std/src/image/params.rs
@@ -2,60 +2,85 @@ use super::{Arrayed, Dimensionality, ImageFormat};
 use crate::{integer::Integer, scalar::Scalar, vector::Vector};
 
 /// Marker trait for arguments that accept single scalar values or vectors
-/// of scalars.
-pub trait SampleType<const FORMAT: u32>: Scalar {}
+/// of scalars. Defines 2-, 3- and 4-component vector types based on the sample type.
+pub trait SampleType<const FORMAT: u32>: Scalar {
+    /// A 2-component vector of this sample type
+    type Vec2: Default;
 
-impl SampleType<{ ImageFormat::Unknown as u32 }> for i8 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for i16 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for i64 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for u8 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for u16 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for u64 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Unknown as u32 }> for f64 {}
-impl SampleType<{ ImageFormat::Rgba32f as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rgba16f as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::R32f as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rgba8 as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rgba8Snorm as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rg32f as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rg16f as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::R11fG11fB10f as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::R16f as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rgba16 as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rgb10A2 as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rg16 as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rg8 as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::R16 as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::R8 as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rgba16Snorm as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rg16Snorm as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rg8Snorm as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::R16Snorm as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::R8Snorm as u32 }> for f32 {}
-impl SampleType<{ ImageFormat::Rgba32i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::Rgba16i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::Rgba8i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::R32i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::Rg32i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::Rg16i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::Rg8i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::R16i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::R8i as u32 }> for i32 {}
-impl SampleType<{ ImageFormat::Rgba32ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::Rgba16ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::Rgba8ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::R32ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::Rgb10A2ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::Rg32ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::Rg16ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::Rg8ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::R16ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::R8ui as u32 }> for u32 {}
-impl SampleType<{ ImageFormat::R64ui as u32 }> for u64 {}
-impl SampleType<{ ImageFormat::R64i as u32 }> for i64 {}
+    /// A 3-component vector of this sample type
+    type Vec3: Default;
+
+    /// A 4-component vector of this sample type
+    type Vec4: Default;
+}
+
+/// Helper macro to implement `SampleType` of various formats for various scalar types.
+macro_rules! sampletype_impls {
+    ($($fmt:ident : $s:ty => ($v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
+        $(
+            impl SampleType<{ ImageFormat::$fmt as u32 }> for $s {
+                type Vec2 = $v2;
+                type Vec3 = $v3;
+                type Vec4 = $v4;
+            }
+        )+
+    }
+}
+
+#[cfg(feature = "glam")]
+sampletype_impls! {
+    Unknown: i8 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: i16 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: i64 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: u8 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: u16 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: u64 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Unknown: f64 => (glam::DVec2, glam::DVec3, glam::DVec4),
+    Rgba32f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba16f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    R32f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba8: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba8Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg32f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg16f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    R11fG11fB10f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    R16f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba16: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgb10A2: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg16: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg8: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    R16: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    R8: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba16Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg16Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg8Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    R16Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    R8Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba32i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Rgba16i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Rgba8i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    R32i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Rg32i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Rg16i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Rg8i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    R16i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    R8i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Rgba32ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Rgba16ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Rgba8ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    R32ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Rgb10A2ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Rg32ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Rg16ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    Rg8ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    R16ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    R8ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    R64ui: u64 => (glam::UVec2, glam::UVec3, glam::UVec4),
+    R64i: i64 => (glam::IVec2, glam::IVec3, glam::IVec4),
+}
 
 /// Marker trait for arguments that accept a coordinate for an [`crate::Image`].
 pub trait ImageCoordinate<T, const DIM: u32, const ARRAYED: u32> {}

--- a/crates/spirv-std/src/image/params.rs
+++ b/crates/spirv-std/src/image/params.rs
@@ -15,7 +15,7 @@ pub trait SampleType<const FORMAT: u32>: Scalar {
 }
 
 /// Helper macro to implement `SampleType` of various formats for various scalar types.
-macro_rules! sampletype_impls {
+macro_rules! sample_type_impls {
     ($($fmt:ident : $s:ty => ($v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
         $(
             impl SampleType<{ ImageFormat::$fmt as u32 }> for $s {
@@ -28,7 +28,7 @@ macro_rules! sampletype_impls {
 }
 
 #[cfg(feature = "glam")]
-sampletype_impls! {
+sample_type_impls! {
     Unknown: i8 => (glam::IVec2, glam::IVec3, glam::IVec4),
     Unknown: i16 => (glam::IVec2, glam::IVec3, glam::IVec4),
     Unknown: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -121,7 +121,9 @@ pub use glam;
 // so we keep the "glam" feature toggle intact for now. As the code won't currently compile
 // without it, present the user with a somewhat friendly error message.
 #[cfg(not(feature = "glam"))]
-compile_error!("`spriv-std` now requires the use of `glam`. Make sure the "glam" feature is specified for `spirv-std` in `Cargo.toml`");
+compile_error!(
+    r#"`spriv-std` now requires the use of `glam`. Make sure the "glam" feature is specified for `spirv-std` in `Cargo.toml`"#
+);
 
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -116,6 +116,13 @@ pub use runtime_array::*;
 #[cfg(feature = "glam")]
 pub use glam;
 
+// HACK(shesp) As we removed support for generic user-configurable vector types in the Image API,
+// glam is now required. In the future we might want to add other popular vector math libraries,
+// so we keep the "glam" feature toggle intact for now. As the code won't currently compile
+// without it, present the user with a somewhat friendly error message.
+#[cfg(not(feature = "glam"))]
+compile_error!("`spriv-std` now requires the use of `glam`. Make sure the "glam" feature is specified for `spirv-std` in `Cargo.toml`");
+
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo<'_>) -> ! {

--- a/tests/ui/arch/debug_printf_type_checking.stderr
+++ b/tests/ui/arch/debug_printf_type_checking.stderr
@@ -68,9 +68,9 @@ error[E0308]: mismatched types
     |         arguments to this function are incorrect
     |
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:142:8
+   --> $SPIRV_STD_SRC/lib.rs:144:8
     |
-142 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: change the type of the numeric literal from `u32` to `f32`
     |
@@ -87,9 +87,9 @@ error[E0308]: mismatched types
     |         arguments to this function are incorrect
     |
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:142:8
+   --> $SPIRV_STD_SRC/lib.rs:144:8
     |
-142 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: change the type of the numeric literal from `f32` to `u32`
     |
@@ -116,9 +116,9 @@ error[E0277]: the trait bound `{float}: Vector<f32, 2>` is not satisfied
               <UVec3 as Vector<u32, 3>>
             and 5 others
 note: required by a bound in `debug_printf_assert_is_vector`
-   --> $SPIRV_STD_SRC/lib.rs:149:8
+   --> $SPIRV_STD_SRC/lib.rs:151:8
     |
-149 |     V: crate::vector::Vector<TY, SIZE>,
+151 |     V: crate::vector::Vector<TY, SIZE>,
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `debug_printf_assert_is_vector`
 
 error[E0308]: mismatched types
@@ -131,9 +131,9 @@ error[E0308]: mismatched types
     |         arguments to this function are incorrect
     |
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:142:8
+   --> $SPIRV_STD_SRC/lib.rs:144:8
     |
-142 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 14 previous errors

--- a/tests/ui/arch/debug_printf_type_checking.stderr
+++ b/tests/ui/arch/debug_printf_type_checking.stderr
@@ -68,9 +68,9 @@ error[E0308]: mismatched types
     |         arguments to this function are incorrect
     |
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:135:8
+   --> $SPIRV_STD_SRC/lib.rs:142:8
     |
-135 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+142 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: change the type of the numeric literal from `u32` to `f32`
     |
@@ -87,9 +87,9 @@ error[E0308]: mismatched types
     |         arguments to this function are incorrect
     |
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:135:8
+   --> $SPIRV_STD_SRC/lib.rs:142:8
     |
-135 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+142 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: change the type of the numeric literal from `f32` to `u32`
     |
@@ -116,9 +116,9 @@ error[E0277]: the trait bound `{float}: Vector<f32, 2>` is not satisfied
               <UVec3 as Vector<u32, 3>>
             and 5 others
 note: required by a bound in `debug_printf_assert_is_vector`
-   --> $SPIRV_STD_SRC/lib.rs:142:8
+   --> $SPIRV_STD_SRC/lib.rs:149:8
     |
-142 |     V: crate::vector::Vector<TY, SIZE>,
+149 |     V: crate::vector::Vector<TY, SIZE>,
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `debug_printf_assert_is_vector`
 
 error[E0308]: mismatched types
@@ -131,9 +131,9 @@ error[E0308]: mismatched types
     |         arguments to this function are incorrect
     |
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:135:8
+   --> $SPIRV_STD_SRC/lib.rs:142:8
     |
-135 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+142 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 14 previous errors

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:164:15
+   --> $SPIRV_STD_SRC/image.rs:163:15
     |
-164 |         Self: HasGather,
+163 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
 
 error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not satisfied
@@ -25,9 +25,9 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:164:15
+   --> $SPIRV_STD_SRC/image.rs:163:15
     |
-164 |         Self: HasGather,
+163 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -1,7 +1,7 @@
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::scalar::vec4::Vec4, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::deeper_stack
           implicit_not_in_fragment::deep_stack
           implicit_not_in_fragment::main
@@ -10,7 +10,7 @@ error: ImageSampleImplicitLod cannot be used outside a fragment shader
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::scalar::vec4::Vec4, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::main
           main
 

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:821:15
+   --> $SPIRV_STD_SRC/image.rs:813:15
     |
-821 |         Self: HasQueryLevels,
+813 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:847:15
+   --> $SPIRV_STD_SRC/image.rs:839:15
     |
-847 |         Self: HasQueryLevels,
+839 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -15,9 +15,9 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0>: HasQuerySize` is no
               Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT>
             and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:878:15
+   --> $SPIRV_STD_SRC/image.rs:870:15
     |
-878 |         Self: HasQuerySize,
+870 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQuerySizeLod` is
               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:911:15
+   --> $SPIRV_STD_SRC/image.rs:903:15
     |
-911 |         Self: HasQuerySizeLod,
+903 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
 
 error: aborting due to previous error


### PR DESCRIPTION
Return types are now always `glam` vectors. This also means that `glam` is required; the "glam" feature toggle is made mandatory rather thn removed as we may want to support other specific vector libraries in the future, and this way people get a clear error when they use something else.

I considered removing the `Vector` trait, but that ripples down to some of the API functions like `any()` so I left it in place.