### PR TITLE
Update to nightly-2023-01-21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed 🛠
+- [PR#991](https://github.com/EmbarkStudios/rust-gpu/pull/991) Updated toolchain to `nightly-2023-01-21`.
 - [PR#990](https://github.com/EmbarkStudios/rust-gpu/pull/990) Removed return type inference from `Image` API and made `glam` usage mandatory.
 
 ## [0.5.0]

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -10,9 +10,9 @@ use std::process::{Command, ExitCode};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2022-12-18"
+channel = "nightly-2023-01-21"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = 0468a00ae3fd6ef1a6a0f9eaf637d7aa9e604acc"#;
+# commit_hash = 5ce39f42bd2c8bca9c570f0560ebe1fce4eddb14"#;
 
 fn get_rustc_commit_hash() -> Result<String, Box<dyn Error>> {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -302,7 +302,7 @@ impl CheckSpirvAttrVisitor<'_> {
                 | SpirvAttribute::Invariant
                 | SpirvAttribute::InputAttachmentIndex(_) => match target {
                     Target::Param => {
-                        let parent_hir_id = self.tcx.hir().get_parent_node(hir_id);
+                        let parent_hir_id = self.tcx.hir().parent_id(hir_id);
                         let parent_is_entry_point =
                             parse_attrs(self.tcx.hir().attrs(parent_hir_id))
                                 .filter_map(|r| r.ok())

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -142,7 +142,8 @@ fn is_blocklisted_fn<'tcx>(
                 Some(assoc) if assoc.ident(tcx).name == sym::fmt => match assoc.container {
                     ty::ImplContainer => {
                         let impl_def_id = assoc.container_id(tcx);
-                        tcx.impl_trait_ref(impl_def_id).map(|tr| tr.def_id)
+                        tcx.impl_trait_ref(impl_def_id)
+                            .map(|tr| tr.subst_identity().def_id)
                             == Some(debug_trait_def_id)
                     }
                     ty::TraitContainer => false,

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -143,7 +143,7 @@ fn is_blocklisted_fn<'tcx>(
                     ty::ImplContainer => {
                         let impl_def_id = assoc.container_id(tcx);
                         tcx.impl_trait_ref(impl_def_id)
-                            .map(|tr| tr.subst_identity().def_id)
+                            .map(|tr| tr.skip_binder().def_id)
                             == Some(debug_trait_def_id)
                     }
                     ty::TraitContainer => false,

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
@@ -257,7 +257,7 @@ const _: () = {
 // HACK(eddyb) this works around the accidental lack of `spirt::Value: Hash`.
 #[derive(Copy, Clone, PartialEq, Eq)]
 struct HashableValue(Value);
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for HashableValue {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         use spirt::*;

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -2,6 +2,8 @@ use super::{link, LinkResult};
 use pipe::pipe;
 use rspirv::dr::{Loader, Module};
 use rustc_errors::registry::Registry;
+use rustc_session::{config::Input, CompilerIO};
+use rustc_span::FileName;
 use std::io::Read;
 
 // https://github.com/colin-kiegel/rust-pretty-assertions/issues/24
@@ -130,7 +132,15 @@ fn link_with_linker_opts(
         rustc_span::create_session_globals_then(sopts.edition, || {
             let mut sess = rustc_session::build_session(
                 sopts,
-                None,
+                CompilerIO {
+                    input: Input::Str {
+                        name: FileName::Custom(String::new()),
+                        input: String::new(),
+                    },
+                    output_dir: None,
+                    output_file: None,
+                    temps_dir: None,
+                },
                 None,
                 Registry::new(&[]),
                 Default::default(),

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,8 +1,8 @@
-# If you see this, run `rustup self update` to get rustup 1.23 or newer
+# If you see this, run `rustup self update` to get rustup 1.23 or newer.
 
-# NOTE: above comment is for older `rustup` (before TOML support was added)
+# NOTE: above comment is for older `rustup` (before TOML support was added),
 # which will treat the first line as the toolchain name, and therefore show it
-# to the user in the error, instead of "error: invalid channel name '[toolchain]'"
+# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
 channel = "nightly-2023-01-21"
@@ -10,4 +10,4 @@ components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
 # commit_hash = 5ce39f42bd2c8bca9c570f0560ebe1fce4eddb14
 
 # Whenever changing the nightly channel, update the commit hash above, and make
-# sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also
+# sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also.

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,14 +1,13 @@
-# If you see this, run `rustup self update` to get rustup 1.23 or newer.
+# If you see this, run `rustup self update` to get rustup 1.23 or newer
 
-# NOTE: above comment is for older `rustup` (before TOML support was added),
+# NOTE: above comment is for older `rustup` (before TOML support was added)
 # which will treat the first line as the toolchain name, and therefore show it
-# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
+# to the user in the error, instead of "error: invalid channel name '[toolchain]'"
 
 [toolchain]
-channel = "nightly-2022-12-18"
+channel = "nightly-2023-01-21"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = 0468a00ae3fd6ef1a6a0f9eaf637d7aa9e604acc
+# commit_hash = 5ce39f42bd2c8bca9c570f0560ebe1fce4eddb14
 
 # Whenever changing the nightly channel, update the commit hash above, and make
-# sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also.
-
+# sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also

--- a/tests/ui/arch/debug_printf_type_checking.stderr
+++ b/tests/ui/arch/debug_printf_type_checking.stderr
@@ -67,11 +67,19 @@ error[E0308]: mismatched types
     |         |                   expected `f32`, found `u32`
     |         arguments to this function are incorrect
     |
+help: the return type of this call is `u32` due to the type of the argument passed
+   --> $DIR/debug_printf_type_checking.rs:21:9
+    |
+21  |         debug_printf!("%f", 11_u32);
+    |         ^^^^^^^^^^^^^^^^^^^^------^
+    |                             |
+    |                             this argument influences the return type of `spirv_std`
 note: function defined here
    --> $SPIRV_STD_SRC/lib.rs:144:8
     |
 144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: change the type of the numeric literal from `u32` to `f32`
     |
 21  |         debug_printf!("%f", 11_f32);
@@ -86,11 +94,19 @@ error[E0308]: mismatched types
     |         |                   expected `u32`, found `f32`
     |         arguments to this function are incorrect
     |
+help: the return type of this call is `f32` due to the type of the argument passed
+   --> $DIR/debug_printf_type_checking.rs:22:9
+    |
+22  |         debug_printf!("%u", 11.0_f32);
+    |         ^^^^^^^^^^^^^^^^^^^^--------^
+    |                             |
+    |                             this argument influences the return type of `spirv_std`
 note: function defined here
    --> $SPIRV_STD_SRC/lib.rs:144:8
     |
 144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: change the type of the numeric literal from `f32` to `u32`
     |
 22  |         debug_printf!("%u", 11u32);
@@ -130,11 +146,19 @@ error[E0308]: mismatched types
     |         |                   expected `f32`, found struct `Vec2`
     |         arguments to this function are incorrect
     |
+help: the return type of this call is `Vec2` due to the type of the argument passed
+   --> $DIR/debug_printf_type_checking.rs:24:9
+    |
+24  |         debug_printf!("%f", Vec2::splat(33.3));
+    |         ^^^^^^^^^^^^^^^^^^^^-----------------^
+    |                             |
+    |                             this argument influences the return type of `spirv_std`
 note: function defined here
    --> $SPIRV_STD_SRC/lib.rs:144:8
     |
 144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,7 +1,7 @@
 error: Cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2519:9
+    --> $CORE_SRC/intrinsics.rs:2458:9
      |
-2519 |         copy(src, dst, count)
+2458 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
      |
      = note: Stack:

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1135 8
+OpLine %8 1157 8
 %9 = OpLoad  %10  %4
 OpLine %11 9 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1135 8
+OpLine %8 1157 8
 %9 = OpLoad  %10  %4
 OpLine %11 9 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 9 35
 %9 = OpLoad  %10  %4
-OpLine %11 1332 8
+OpLine %11 1354 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 9 37
 %9 = OpLoad  %10  %4
-OpLine %11 1332 8
+OpLine %11 1354 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -8,11 +8,11 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
    --> $SPIRV_STD_SRC/image.rs:163:15
     |
 163 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
 
 error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not satisfied
    --> $DIR/gather_err.rs:16:34
@@ -24,11 +24,11 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
    --> $SPIRV_STD_SRC/image.rs:163:15
     |
 163 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::gather`
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -9,11 +9,11 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQuerySizeLod` is
               Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT>::query_size_lod`
    --> $SPIRV_STD_SRC/image.rs:903:15
     |
 903 |         Self: HasQuerySizeLod,
-    |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, _, SAMPLED, FORMAT>::query_size_lod`
+    |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT>::query_size_lod`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This nightly contains all changes that have been branched off into beta and will become stable as Rust 1.68 on March 9