### PR TITLE
Set SPIR-T as the default IR linker framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#998](https://github.com/EmbarkStudios/rust-gpu/pull/998) added `extra_arg()` SpirvBuilder API to be able to set codegen args otherwise not supported by the API (for example, to set `--spirv-passes`).
 
 ### Changed 🛠
+- [PR#999](https://github.com/EmbarkStudios/rust-gpu/pull/999) Made the [`SPIR-🇹` shader IR framework](https://github.com/EmbarkStudios/spirt) the default. You can opt-out using `--no-spirt` codegen arg.
 - [PR#992](https://github.com/EmbarkStudios/rust-gpu/pull/992) renamed `rust-toolchain` to `rust-toolchain.toml`.
 - [PR#991](https://github.com/EmbarkStudios/rust-gpu/pull/991) updated toolchain to `nightly-2023-01-21`.
 - [PR#990](https://github.com/EmbarkStudios/rust-gpu/pull/990) removed return type inference from `Image` API and made `glam` usage mandatory.

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -362,7 +362,7 @@ impl CodegenArgs {
             opts.optflag(
                 "",
                 "no-spirt",
-                "disable SPIR-T for legalization (see also `docs/src/codegen-args.md`)",
+                "disable using SPIR-T for legalization (see also `docs/src/codegen-args.md`)",
             );
             opts.optmulti(
                 "",

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -361,8 +361,8 @@ impl CodegenArgs {
 
             opts.optflag(
                 "",
-                "spirt",
-                "use SPIR-T for legalization (see also `docs/src/codegen-args.md`)",
+                "no-spirt",
+                "disable SPIR-T for legalization (see also `docs/src/codegen-args.md`)",
             );
             opts.optmulti(
                 "",
@@ -537,7 +537,7 @@ impl CodegenArgs {
             dce: !matches.opt_present("no-dce"),
             compact_ids: !matches.opt_present("no-compact-ids"),
             structurize: !matches.opt_present("no-structurize"),
-            spirt: matches.opt_present("spirt"),
+            spirt: !matches.opt_present("no-spirt"),
             spirt_passes: matches
                 .opt_strs("spirt-passes")
                 .iter()

--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -139,7 +139,9 @@ anyway, be careful).
 
 Disables CFG structurization. Probably results in invalid modules.
 
-### `--spirt`
+### `--spirt` <sub>_(until 0.6.0)_</sub>
+
+Note: as of `rust-gpu 0.6.0`, `SPIR-🇹` is enabled by default. Use `--no-spirt` to disable.
 
 Enables using the experimental [`SPIR-🇹` shader IR framework](https://github.com/EmbarkStudios/spirt) in the linker - more specifically, this:
 - adds a `SPIR-V -> SPIR-🇹 -> SPIR-V` roundtrip  
@@ -148,6 +150,9 @@ Enables using the experimental [`SPIR-🇹` shader IR framework](https://github.
 - runs some existing `SPIR-V` legalization/optimization passes (`mem2reg`) *before* inlining, instead of *only after* (as the `OpPhi`s they would produce are no longer an issue for structurization)
 
 For more information, also see [the `SPIR-🇹` repository](https://github.com/EmbarkStudios/spirt).
+
+### `--no-spirt` <sub>_(0.6.0)_</sup>
+Disables the [`SPIR-🇹` shader IR framework](https://github.com/EmbarkStudios/spirt) in the linker.
 
 ### `--spirt-passes PASSES`
 

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -150,8 +150,8 @@ impl Runner {
                         .join(DepKind::ProcMacro.target_dir_suffix(&target)),
                 ],
             );
-            if spirt {
-                flags += " -Cllvm-args=--spirt";
+            if !spirt {
+                flags += " -Cllvm-args=--no-spirt";
             }
 
             let config = compiletest::Config {


### PR DESCRIPTION
Rather than opting in using `--spirt`, you can now opt-out using `--no-spirt`