### PR TITLE
Made `glam` a default feature in `spirv-std`

### DIFF
--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -15,4 +15,4 @@ num-traits = { version = "0.2.14", default-features = false, features = ["libm"]
 glam = { version = "0.22", default-features = false, features = ["libm"], optional = true }
 
 [features]
-default = []
+default = ["glam"]

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -12,7 +12,7 @@ spirv-std-types.workspace = true
 spirv-std-macros.workspace = true
 bitflags = "1.2.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
-glam = { version = "0.22", default-features = false, features = ["libm"], optional = true }
+glam = { version = "0.22", default-features = false, features = ["libm"] }
 
 [features]
-default = ["glam"]
+default = []

--- a/crates/spirv-std/src/float.rs
+++ b/crates/spirv-std/src/float.rs
@@ -82,7 +82,6 @@ pub fn f32_to_f16(float: f32) -> u32 {
 
 /// Converts an f16 (half) into an f32 (float). The parameter is a u32, due to GPU support for u16
 /// not being universal - the upper 16 bits are ignored.
-#[cfg(feature = "glam")]
 #[spirv_std_macros::gpu_only]
 pub fn f16_to_f32(packed: u32) -> f32 {
     f16x2_to_vec2::<F32x2>(packed).x

--- a/crates/spirv-std/src/image/params.rs
+++ b/crates/spirv-std/src/image/params.rs
@@ -27,7 +27,6 @@ macro_rules! sample_type_impls {
     }
 }
 
-#[cfg(feature = "glam")]
 sample_type_impls! {
     Unknown: i8 => (glam::IVec2, glam::IVec3, glam::IVec4),
     Unknown: i16 => (glam::IVec2, glam::IVec3, glam::IVec4),

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -113,17 +113,7 @@ pub use byte_addressable_buffer::ByteAddressableBuffer;
 pub use num_traits;
 pub use runtime_array::*;
 
-#[cfg(feature = "glam")]
 pub use glam;
-
-// HACK(shesp) As we removed support for generic user-configurable vector types in the Image API,
-// glam is now required. In the future we might want to add other popular vector math libraries,
-// so we keep the "glam" feature toggle intact for now. As the code won't currently compile
-// without it, present the user with a somewhat friendly error message.
-#[cfg(not(feature = "glam"))]
-compile_error!(
-    r#"`spriv-std` now requires the use of `glam`. Make sure the "glam" feature is specified for `spirv-std` in `Cargo.toml`"#
-);
 
 #[cfg(all(not(test), target_arch = "spirv"))]
 #[panic_handler]

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -7,32 +7,19 @@
 /// should not be done.
 pub unsafe trait Vector<T: crate::scalar::Scalar, const N: usize>: Default {}
 
-#[cfg(feature = "glam")]
 unsafe impl Vector<f32, 2> for glam::Vec2 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<f32, 3> for glam::Vec3 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<f32, 3> for glam::Vec3A {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<f32, 4> for glam::Vec4 {}
 
-#[cfg(feature = "glam")]
 unsafe impl Vector<f64, 2> for glam::DVec2 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<f64, 3> for glam::DVec3 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<f64, 4> for glam::DVec4 {}
 
-#[cfg(feature = "glam")]
 unsafe impl Vector<u32, 2> for glam::UVec2 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<u32, 3> for glam::UVec3 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<u32, 4> for glam::UVec4 {}
 
-#[cfg(feature = "glam")]
 unsafe impl Vector<i32, 2> for glam::IVec2 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<i32, 3> for glam::IVec3 {}
-#[cfg(feature = "glam")]
 unsafe impl Vector<i32, 4> for glam::IVec4 {}

--- a/docs/src/writing-shader-crates.md
+++ b/docs/src/writing-shader-crates.md
@@ -150,7 +150,7 @@ Configure your shader crate as a `"dylib"` type crate, and add `spirv-std` to it
 
 ```toml
 [dependencies]
-spirv-std = { version = "0.4", features = ["glam"] }
+spirv-std = { version = "0.6" }
 ```
 
 Make sure your shader code uses the `no_std` attribute and makes the `spirv` attribute visibile in the global scope. Then, you're ready to write your first shader. Here's a very simple fragment shader called `main_fs` as an example that outputs the color red:

--- a/examples/shaders/compute-shader/Cargo.toml
+++ b/examples/shaders/compute-shader/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 crate-type = ["dylib", "lib"]
 
 [dependencies]
-spirv-std = { workspace = true, features = ["glam"] }
+spirv-std = { workspace = true }
 
 [target.'cfg(not(target_arch = "spirv"))'.dependencies]
 rayon = "1.5"

--- a/examples/shaders/mouse-shader/Cargo.toml
+++ b/examples/shaders/mouse-shader/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["dylib"]
 
 [dependencies]
 shared = { path = "../../shaders/shared" }
-spirv-std = { workspace = true, features = ["glam"] }
+spirv-std = { workspace = true }

--- a/examples/shaders/reduce/Cargo.toml
+++ b/examples/shaders/reduce/Cargo.toml
@@ -11,4 +11,4 @@ repository.workspace = true
 crate-type = ["dylib", "lib"]
 
 [dependencies]
-spirv-std = { workspace = true, features = ["glam"] }
+spirv-std = { workspace = true }

--- a/examples/shaders/shared/Cargo.toml
+++ b/examples/shaders/shared/Cargo.toml
@@ -8,5 +8,5 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-spirv-std = { workspace = true, features = ["glam"] }
+spirv-std = { workspace = true }
 bytemuck = { version = "1.6.3", features = ["derive"] }

--- a/examples/shaders/simplest-shader/Cargo.toml
+++ b/examples/shaders/simplest-shader/Cargo.toml
@@ -11,5 +11,5 @@ repository.workspace = true
 crate-type = ["dylib"]
 
 [dependencies]
-spirv-std = { workspace = true, features = ["glam"] }
+spirv-std = { workspace = true }
 shared = { path = "../shared" }

--- a/examples/shaders/sky-shader/Cargo.toml
+++ b/examples/shaders/sky-shader/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["lib", "dylib"]
 
 [dependencies]
 shared = { path = "../../shaders/shared" }
-spirv-std = { workspace = true, features = ["glam"] }
+spirv-std = { workspace = true }

--- a/tests/deps-helper/Cargo.toml
+++ b/tests/deps-helper/Cargo.toml
@@ -9,4 +9,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-spirv-std = { workspace = true, features = ["glam"] }
+spirv-std = { workspace = true }

--- a/tests/ui/arch/debug_printf_type_checking.stderr
+++ b/tests/ui/arch/debug_printf_type_checking.stderr
@@ -75,9 +75,9 @@ help: the return type of this call is `u32` due to the type of the argument pass
     |                             |
     |                             this argument influences the return type of `spirv_std`
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:144:8
+   --> $SPIRV_STD_SRC/lib.rs:134:8
     |
-144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+134 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: change the type of the numeric literal from `u32` to `f32`
@@ -102,9 +102,9 @@ help: the return type of this call is `f32` due to the type of the argument pass
     |                             |
     |                             this argument influences the return type of `spirv_std`
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:144:8
+   --> $SPIRV_STD_SRC/lib.rs:134:8
     |
-144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+134 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: change the type of the numeric literal from `f32` to `u32`
@@ -132,9 +132,9 @@ error[E0277]: the trait bound `{float}: Vector<f32, 2>` is not satisfied
               <UVec3 as Vector<u32, 3>>
             and 5 others
 note: required by a bound in `debug_printf_assert_is_vector`
-   --> $SPIRV_STD_SRC/lib.rs:151:8
+   --> $SPIRV_STD_SRC/lib.rs:141:8
     |
-151 |     V: crate::vector::Vector<TY, SIZE>,
+141 |     V: crate::vector::Vector<TY, SIZE>,
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `debug_printf_assert_is_vector`
 
 error[E0308]: mismatched types
@@ -154,9 +154,9 @@ help: the return type of this call is `Vec2` due to the type of the argument pas
     |                             |
     |                             this argument influences the return type of `spirv_std`
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:144:8
+   --> $SPIRV_STD_SRC/lib.rs:134:8
     |
-144 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+134 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
We need this to be able to publish `spirv-std`, otherwise it will compile without glam and it will fail

The rationale behind doing it this way was because glam was optional in the past while it is mandatory currently. In the future, we might want to support other vector libraries as well, in which case we need to put glam behind a feature toggle again.

Also, people currently would expect glam not to be included when not specifying it or depending on it with `no-default-features`, so I wanted it to be an in-your-face error when you did that. Unfortunately, this also means that `cargo publish` fails as it compiles without features, so as a quick fix I made it default for the 0.6 release for now. We might want to readdress this.