### PR TITLE
inline asm!: ban `OpReturn`/`OpReturnValue` (they're always UB).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
+## [Unreleased]
+
+### Fixed 🩹
+- [PR#1006](https://github.com/EmbarkStudios/rust-gpu/pull/1006) fixed [#1002](https://github.com/EmbarkStudios/rust-gpu/issues/1002) by rewriting away all `spirv-std` uses of `asm!("OpReturnValue %result")` and disallowing `OpReturn`/`OpReturnValue` from inline `asm!` (as it's always UB to leave `asm!` blocks in any way other than falling through their end)
+
 ## [0.6.0]
 
 ### Added ⭐

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -94,6 +94,8 @@ pub type Cubemap = crate::Image!(cube, type=f32, sampled, __crate_root=crate);
 /// See SPIR-V OpTypeImage specification for the meaning of integer parameters.
 #[spirv(generic_image_type)]
 #[derive(Copy, Clone)]
+// HACK(eddyb) avoids "transparent newtype of `_anti_zst_padding`" misinterpretation.
+#[repr(C)]
 pub struct Image<
     SampledType: SampleType<FORMAT>,
     const DIM: u32,          // Dimensionality,
@@ -103,7 +105,9 @@ pub struct Image<
     const SAMPLED: u32,      // Sampled,
     const FORMAT: u32,       // ImageFormat,
 > {
-    _x: u32,
+    // HACK(eddyb) avoids the layout becoming ZST (and being elided in one way
+    // or another, before `#[spirv(generic_image_type)]` can special-case it).
+    _anti_zst_padding: core::mem::MaybeUninit<u32>,
     _marker: core::marker::PhantomData<SampledType>,
 }
 

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -7,8 +7,12 @@ use core::arch::asm;
 /// acceleration structure handle as defined in the client API specification.
 #[spirv(acceleration_structure)]
 #[derive(Copy, Clone)]
+// HACK(eddyb) avoids "transparent newtype of `_anti_zst_padding`" misinterpretation.
+#[repr(C)]
 pub struct AccelerationStructure {
-    pub(crate) _private: u32,
+    // HACK(eddyb) avoids the layout becoming ZST (and being elided in one way
+    // or another, before `#[spirv(acceleration_structure)]` can special-case it).
+    _anti_zst_padding: core::mem::MaybeUninit<u32>,
 }
 
 impl AccelerationStructure {
@@ -186,8 +190,12 @@ pub enum CommittedIntersection {
 
 /// A ray query type which is an opaque object representing a ray traversal.
 #[spirv(ray_query)]
+// HACK(eddyb) avoids "transparent newtype of `_anti_zst_padding`" misinterpretation.
+#[repr(C)]
 pub struct RayQuery {
-    _private: u32,
+    // HACK(eddyb) avoids the layout becoming ZST (and being elided in one way
+    // or another, before `#[spirv(ray_query)]` can special-case it).
+    _anti_zst_padding: core::mem::MaybeUninit<u32>,
 }
 
 /// Constructs an uninitialized ray query variable. Using the syntax

--- a/crates/spirv-std/src/runtime_array.rs
+++ b/crates/spirv-std/src/runtime_array.rs
@@ -7,9 +7,12 @@ use core::marker::PhantomData;
 /// Hence, this type represents something very similar to a slice, but with no way of knowing its
 /// length.
 #[spirv(runtime_array)]
+// HACK(eddyb) avoids "transparent newtype of `_anti_zst_padding`" misinterpretation.
+#[repr(C)]
 pub struct RuntimeArray<T> {
-    // spooky! this field does not exist, so if it's referenced in rust code, things will explode
-    _do_not_touch: u32,
+    // HACK(eddyb) avoids the layout becoming ZST (and being elided in one way
+    // or another, before `#[spirv(runtime_array)]` can special-case it).
+    _anti_zst_padding: core::mem::MaybeUninit<u32>,
     _phantom: PhantomData<T>,
 }
 

--- a/crates/spirv-std/src/sampler.rs
+++ b/crates/spirv-std/src/sampler.rs
@@ -2,6 +2,10 @@
 /// sample an image.
 #[spirv(sampler)]
 #[derive(Copy, Clone)]
+// HACK(eddyb) avoids "transparent newtype of `_anti_zst_padding`" misinterpretation.
+#[repr(C)]
 pub struct Sampler {
-    _x: u32,
+    // HACK(eddyb) avoids the layout becoming ZST (and being elided in one way
+    // or another, before `#[spirv(sampler)]` can special-case it).
+    _anti_zst_padding: core::mem::MaybeUninit<u32>,
 }

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:163:15
+   --> $SPIRV_STD_SRC/image.rs:167:15
     |
-163 |         Self: HasGather,
+167 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
 
 error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not satisfied
@@ -25,9 +25,9 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not s
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:163:15
+   --> $SPIRV_STD_SRC/image.rs:167:15
     |
-163 |         Self: HasGather,
+167 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:813:15
+   --> $SPIRV_STD_SRC/image.rs:817:15
     |
-813 |         Self: HasQueryLevels,
+817 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:839:15
+   --> $SPIRV_STD_SRC/image.rs:843:15
     |
-839 |         Self: HasQueryLevels,
+843 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -15,9 +15,9 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0>: HasQuerySize` is no
               Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT>
             and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:870:15
+   --> $SPIRV_STD_SRC/image.rs:874:15
     |
-870 |         Self: HasQuerySize,
+874 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQuerySizeLod` is
               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:903:15
+   --> $SPIRV_STD_SRC/image.rs:907:15
     |
-903 |         Self: HasQuerySizeLod,
+907 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT>::query_size_lod`
 
 error: aborting due to previous error

--- a/tests/ui/lang/asm/block_tracking_fail.stderr
+++ b/tests/ui/lang/asm/block_tracking_fail.stderr
@@ -4,13 +4,13 @@ error: `noreturn` requires a terminator at the end
 11 |         asm!("", options(noreturn));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: trailing terminator Unreachable requires `options(noreturn)`
+error: trailing terminator `OpUnreachable` requires `options(noreturn)`
   --> $DIR/block_tracking_fail.rs:18:9
    |
 18 |         asm!("OpUnreachable");
    |         ^^^^^^^^^^^^^^^^^^^^^
 
-error: expected OpLabel after terminator Kill
+error: expected `OpLabel` after terminator `OpKill`
   --> $DIR/block_tracking_fail.rs:25:9
    |
 25 | /         asm!(

--- a/tests/ui/lang/asm/block_tracking_pass.rs
+++ b/tests/ui/lang/asm/block_tracking_pass.rs
@@ -8,7 +8,7 @@ use spirv_std::spirv;
 fn asm_label() {
     unsafe {
         asm!(
-            "OpReturn",          // close active block
+            "OpKill",            // close active block
             "%unused = OpLabel", // open new block
         );
     }

--- a/tests/ui/lang/asm/issue-1002.rs
+++ b/tests/ui/lang/asm/issue-1002.rs
@@ -1,0 +1,49 @@
+// Tests that we don't allow returning from `asm!` (which would always be UB).
+// build-fail
+
+use core::arch::asm;
+use spirv_std::spirv;
+
+fn asm_return() {
+    unsafe {
+        asm!("OpReturn", options(noreturn));
+    }
+}
+
+fn asm_return_value(x: u32) -> u32 {
+    unsafe {
+        asm!(
+            "OpReturnValue {x}",
+            x = in(reg) x,
+            options(noreturn),
+        );
+    }
+}
+
+fn asm_return_label() {
+    unsafe {
+        asm!(
+            "OpReturn",          // close active block
+            "%unused = OpLabel", // open new block
+        );
+    }
+}
+
+fn asm_return_value_label(x: u32) -> u32 {
+    unsafe {
+        asm!(
+            "OpReturnValue {x}", // close active block
+            "%unused = OpLabel", // open new block
+            x = in(reg) x
+        );
+    }
+    0
+}
+
+#[spirv(fragment)]
+pub fn main() {
+    asm_return();
+    asm_return_value(123);
+    asm_return_label();
+    asm_return_value_label(123);
+}

--- a/tests/ui/lang/asm/issue-1002.stderr
+++ b/tests/ui/lang/asm/issue-1002.stderr
@@ -1,0 +1,45 @@
+error: using `OpReturn` to return from within `asm!` is disallowed
+ --> $DIR/issue-1002.rs:9:9
+  |
+9 |         asm!("OpReturn", options(noreturn));
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
+
+error: using `OpReturnValue` to return from within `asm!` is disallowed
+  --> $DIR/issue-1002.rs:15:9
+   |
+15 | /         asm!(
+16 | |             "OpReturnValue {x}",
+17 | |             x = in(reg) x,
+18 | |             options(noreturn),
+19 | |         );
+   | |_________^
+   |
+   = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
+
+error: using `OpReturn` to return from within `asm!` is disallowed
+  --> $DIR/issue-1002.rs:25:9
+   |
+25 | /         asm!(
+26 | |             "OpReturn",          // close active block
+27 | |             "%unused = OpLabel", // open new block
+28 | |         );
+   | |_________^
+   |
+   = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
+
+error: using `OpReturnValue` to return from within `asm!` is disallowed
+  --> $DIR/issue-1002.rs:34:9
+   |
+34 | /         asm!(
+35 | |             "OpReturnValue {x}", // close active block
+36 | |             "%unused = OpLabel", // open new block
+37 | |             x = in(reg) x
+38 | |         );
+   | |_________^
+   |
+   = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This PR fixes #1002 by banning the misuse of inline `asm!` (see the issue for more details).

We used to get away with the UB, but now MIR inlining is wreaking havoc (e.g. inlining `asm!("ret")` will return from the caller it was inlined into - one of the many ways in which the UB can manifest).

Most of this PR is actually making progress towards:
* #981

However, I'm not considering #981 as being fixed just yet, because the original usecase involves arrays, which have their own complications, and I focused on only opaque handles (as `AccelerationStructure` constructors need it).

I've also not changed any unaffected use of `asm!`, leaving the migration to `MaybeUninit` for an issue:
* #1007

Each commit should be reviewed separately (or maybe I should've split this into two PRs?).