### PR TITLE
entry: apply `NonWritable` to read-only `StorageBuffer`s.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed 🛠
+- [PR#1011](https://github.com/EmbarkStudios/rust-gpu/pull/1011) made `NonWritable` all read-only storage buffers (i.e. those typed `&T`, where `T` doesn't have interior mutability)
+
 ### Fixed 🩹
 - [PR#1009](https://github.com/EmbarkStudios/rust-gpu/pull/1009) fixed [#1008](https://github.com/EmbarkStudios/rust-gpu/issues/1008) by reinstating mutability checks for entry-point parameters pointing into read-only storage classes (e.g. `#[spirv(uniform)] x: &mut u32` is now again an error)
 - [PR#995](https://github.com/EmbarkStudios/rust-gpu/pull/995) fixed [#994](https://github.com/EmbarkStudios/rust-gpu/issues/994) by using `OpAtomicFAddEXT` instead of `OpAtomicFMaxEXT` in `atomic_f_add`.

--- a/tests/ui/dis/non-writable-storage_buffer.not_spirt.rs
+++ b/tests/ui/dis/non-writable-storage_buffer.not_spirt.rs
@@ -1,0 +1,33 @@
+// HACK(eddyb) duplicate of non-writable-storage_buffer.spirt.rs because only-/ignore- do not work with revisions.
+// only-not_spirt
+#![crate_name = "non_writable_storage_buffer"]
+
+// Tests that only `&T` (where `T: Freeze`) storage buffers get `NonWritable`.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+// FIXME(eddyb) this should use revisions to track both the `vulkan1.2` output
+// and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
+// are not supported in `compiletest-rs`.
+// ignore-vulkan1.2
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] buf_imm: &u32,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] buf_mut: &mut u32,
+    // FIXME(eddyb) use `AtomicU32` when methods on that work.
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    buf_interior_mut: &core::cell::UnsafeCell<u32>,
+) {
+    let x = *buf_imm;
+    *buf_mut = x;
+    unsafe {
+        *buf_interior_mut.get() = x;
+    }
+}

--- a/tests/ui/dis/non-writable-storage_buffer.not_spirt.stderr
+++ b/tests/ui/dis/non-writable-storage_buffer.not_spirt.stderr
@@ -1,0 +1,34 @@
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpCapability Shader
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/non-writable-storage_buffer.not_spirt.rs"
+%3 = OpString "$OPSTRING_FILENAME/cell.rs"
+OpName %4 "buf_imm"
+OpName %5 "buf_mut"
+OpName %6 "buf_interior_mut"
+OpDecorate %4 NonWritable
+OpDecorate %7 Block
+OpMemberDecorate %7 0 Offset 0
+OpDecorate %4 DescriptorSet 0
+OpDecorate %4 Binding 0
+OpDecorate %5 DescriptorSet 0
+OpDecorate %5 Binding 1
+OpDecorate %6 DescriptorSet 0
+OpDecorate %6 Binding 2
+%8 = OpTypeInt 32 0
+%9 = OpTypePointer StorageBuffer %8
+%10 = OpTypeVoid
+%11 = OpTypeFunction %10
+%7 = OpTypeStruct %8
+%12 = OpTypePointer StorageBuffer %7
+%13 = OpConstant  %8  0
+%4 = OpVariable  %12  StorageBuffer
+%5 = OpVariable  %12  StorageBuffer
+%6 = OpVariable  %12  StorageBuffer

--- a/tests/ui/dis/non-writable-storage_buffer.spirt.rs
+++ b/tests/ui/dis/non-writable-storage_buffer.spirt.rs
@@ -1,0 +1,33 @@
+// HACK(eddyb) duplicate of non-writable-storage_buffer.not_spirt.rs because only-/ignore- do not work with revisions.
+// only-spirt
+#![crate_name = "non_writable_storage_buffer"]
+
+// Tests that only `&T` (where `T: Freeze`) storage buffers get `NonWritable`.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+// FIXME(eddyb) this should use revisions to track both the `vulkan1.2` output
+// and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
+// are not supported in `compiletest-rs`.
+// ignore-vulkan1.2
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] buf_imm: &u32,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] buf_mut: &mut u32,
+    // FIXME(eddyb) use `AtomicU32` when methods on that work.
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    buf_interior_mut: &core::cell::UnsafeCell<u32>,
+) {
+    let x = *buf_imm;
+    *buf_mut = x;
+    unsafe {
+        *buf_interior_mut.get() = x;
+    }
+}

--- a/tests/ui/dis/non-writable-storage_buffer.spirt.stderr
+++ b/tests/ui/dis/non-writable-storage_buffer.spirt.stderr
@@ -1,0 +1,33 @@
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/non-writable-storage_buffer.spirt.rs"
+OpName %3 "buf_imm"
+OpName %4 "buf_mut"
+OpName %5 "buf_interior_mut"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpDecorate %3 NonWritable
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Binding 1
+OpDecorate %4 DescriptorSet 0
+OpDecorate %5 Binding 2
+OpDecorate %5 DescriptorSet 0
+%7 = OpTypeVoid
+%8 = OpTypeFunction %7
+%9 = OpTypeInt 32 0
+%10 = OpTypePointer StorageBuffer %9
+%6 = OpTypeStruct %9
+%11 = OpTypePointer StorageBuffer %6
+%3 = OpVariable  %11  StorageBuffer
+%12 = OpConstant  %9  0
+%4 = OpVariable  %11  StorageBuffer
+%5 = OpVariable  %11  StorageBuffer

--- a/tests/ui/spirv-attr/bad-deduce-storage-class.rs
+++ b/tests/ui/spirv-attr/bad-deduce-storage-class.rs
@@ -1,4 +1,4 @@
-// Tests that storage class inference fails correctly
+// Tests that storage class deduction (from entry-point signature) fails correctly
 // build-fail
 
 use spirv_std::{spirv, Image};

--- a/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
+++ b/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
@@ -1,26 +1,26 @@
 error: storage class mismatch
- --> $DIR/bad-infer-storage-class.rs:8:5
+ --> $DIR/bad-deduce-storage-class.rs:8:5
   |
 8 |     #[spirv(uniform)] error: &Image!(2D, type=f32),
   |     ^^^^^^^^-------^^^^^^^^^^---------------------
   |             |                |
-  |             |                UniformConstant inferred from type
-  |             Uniform specified in attribute
+  |             |                `UniformConstant` deduced from type
+  |             `Uniform` specified in attribute
   |
-help: remove storage class attribute to use UniformConstant as storage class
- --> $DIR/bad-infer-storage-class.rs:8:13
+help: remove storage class attribute to use `UniformConstant` as storage class
+ --> $DIR/bad-deduce-storage-class.rs:8:13
   |
 8 |     #[spirv(uniform)] error: &Image!(2D, type=f32),
   |             ^^^^^^^
 
-warning: redundant storage class specifier, storage class is inferred from type
- --> $DIR/bad-infer-storage-class.rs:9:13
+warning: redundant storage class attribute, storage class is deduced from type
+ --> $DIR/bad-deduce-storage-class.rs:9:13
   |
 9 |     #[spirv(uniform_constant)] warning: &Image!(2D, type=f32),
   |             ^^^^^^^^^^^^^^^^
 
 error: entry parameter type must be by-reference: `&spirv_std::image::Image<f32, 1, 2, 0, 0, 0, 0>`
-  --> $DIR/bad-infer-storage-class.rs:15:27
+  --> $DIR/bad-deduce-storage-class.rs:15:27
    |
 15 | pub fn issue_585(invalid: Image!(2D, type=f32)) {}
    |                           ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/storage_class/mutability-errors.stderr
+++ b/tests/ui/storage_class/mutability-errors.stderr
@@ -8,9 +8,9 @@ note: ...but storage class `UniformConstant` is read-only
   --> $DIR/mutability-errors.rs:10:78
    |
 10 |     #[spirv(descriptor_set = 0, binding = 0)] implicit_uniform_constant_mut: &mut Image2d,
-   |                                                                              ^^^^^^^^^^^^ `UniformConstant` implied by type
+   |                                                                              ^^^^^^^^^^^^ `UniformConstant` deduced from type
 
-warning: redundant storage class specifier, storage class is inferred from type
+warning: redundant storage class attribute, storage class is deduced from type
   --> $DIR/mutability-errors.rs:11:13
    |
 11 |     #[spirv(uniform_constant, descriptor_set = 0, binding = 0)] uniform_constant_mut: &mut Image2d,


### PR DESCRIPTION
This PR applies `NonWritable` to `#[spirv(storage_buffer)] x: &T` (if `T` doesn't have interior mutability).
* fixes #689
  * (assuming we want to postpone `NonReadable`)
    <sup>(also we should maybe do something different for storage images?)</sup>
  * limited to `StorageBuffer` as, according to `spirv-val`, only it and `Uniform` allow `NonWritable`, and `Uniform` buffers are always read-only anyway
* motivated by: https://github.com/Bevy-Rust-GPU/bevy-rust-gpu/issues/13
  * (more specifically, `wgpu` `read-only-storage` buffers are stricter than their Vulkan counterparts)