### PR TITLE
WIP: VK_EXT_mesh_shader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
  "num-traits",
  "petgraph",
  "rustc-hash",
- "spirv",
+ "spirv 0.2.0+1.5.4",
  "termcolor",
  "thiserror",
  "unicode-xid",
@@ -1950,7 +1950,16 @@ checksum = "1503993b59ca9ae4127365c3293517576d7ce56be9f3d8abb1625c85ddc583ba"
 dependencies = [
  "fxhash",
  "num-traits",
- "spirv",
+ "spirv 0.2.0+1.5.4",
+]
+
+[[package]]
+name = "rspirv"
+version = "0.11.0+sdk-1.2.198"
+source = "git+https://github.com/beastle9end/rspirv#43850fe299c30559f5de4a6fd0588a8e53509837"
+dependencies = [
+ "rustc-hash",
+ "spirv 0.2.0+sdk-1.2.198",
 ]
 
 [[package]]
@@ -1980,7 +1989,7 @@ dependencies = [
  "pipe",
  "pretty_assertions",
  "regex",
- "rspirv",
+ "rspirv 0.11.0+sdk-1.2.198",
  "rustc-demangle",
  "rustc_codegen_spirv-types",
  "sanitize-filename",
@@ -1997,7 +2006,7 @@ dependencies = [
 name = "rustc_codegen_spirv-types"
 version = "0.6.1"
 dependencies = [
- "rspirv",
+ "rspirv 0.11.0+1.5.4",
  "serde",
 ]
 
@@ -2215,8 +2224,6 @@ dependencies = [
 [[package]]
 name = "spirt"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06834ebbbbc6f86448fd5dc7ccbac80e36f52f8d66838683752e19d3cae9a459"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -2238,6 +2245,14 @@ checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
  "bitflags",
  "num-traits",
+]
+
+[[package]]
+name = "spirv"
+version = "0.2.0+sdk-1.2.198"
+source = "git+https://github.com/beastle9end/rspirv#43850fe299c30559f5de4a6fd0588a8e53509837"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/crates/rustc_codegen_spirv-types/Cargo.toml
+++ b/crates/rustc_codegen_spirv-types/Cargo.toml
@@ -8,5 +8,5 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rspirv = "0.11"
+rspirv = { git = "https://github.com/beastle9end/rspirv" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -50,7 +50,7 @@ regex = { version = "1", features = ["perf"] }
 ar = "0.9.0"
 either = "1.8.0"
 indexmap = "1.6.0"
-rspirv = "0.11"
+rspirv = { git = "https://github.com/beastle9end/rspirv" }
 rustc-demangle = "0.1.21"
 sanitize-filename = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -58,7 +58,7 @@ serde_json = "1.0"
 smallvec = { version = "1.6.1", features = ["union"] }
 spirv-tools = { version = "0.9", default-features = false }
 rustc_codegen_spirv-types.workspace = true
-spirt = "0.1.0"
+spirt = { git = "https://github.com/projectkml/spirt" }
 lazy_static = "1.4.0"
 
 [dev-dependencies]

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -4,7 +4,7 @@
 use crate::attr::{AggregatedSpirvAttributes, IntrinsicType};
 use crate::codegen_cx::CodegenCx;
 use crate::spirv_type::SpirvType;
-use rspirv::spirv::{StorageClass, Word};
+use rspirv::spirv::{Dim, ImageFormat, StorageClass, Word};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_index::vec::Idx;
@@ -27,8 +27,6 @@ use rustc_target::spec::abi::Abi as SpecAbi;
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::fmt;
-
-use num_traits::cast::FromPrimitive;
 
 pub(crate) fn provide(providers: &mut Providers) {
     // This is a lil weird: so, we obviously don't support C ABIs at all. However, libcore does declare some extern
@@ -856,7 +854,31 @@ fn trans_intrinsic_type<'tcx>(
             // let image_format: spirv::ImageFormat =
             //     type_from_variant_discriminant(cx, substs.const_at(6));
 
-            fn const_int_value<'tcx, P: FromPrimitive>(
+            trait FromU128 {
+                fn from_u128(value: u128) -> Option<Self>
+                where
+                    Self: Sized;
+            }
+
+            impl FromU128 for Dim {
+                fn from_u128(value: u128) -> Option<Self> {
+                    Self::from_u32(value.try_into().ok()?)
+                }
+            }
+
+            impl FromU128 for u32 {
+                fn from_u128(value: u128) -> Option<Self> {
+                    value.try_into().ok()
+                }
+            }
+
+            impl FromU128 for ImageFormat {
+                fn from_u128(value: u128) -> Option<Self> {
+                    Self::from_u32(value.try_into().ok()?)
+                }
+            }
+
+            fn const_int_value<'tcx, P: FromU128>(
                 cx: &CodegenCx<'tcx>,
                 const_: Const<'tcx>,
             ) -> Result<P, ErrorGuaranteed> {

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -725,9 +725,9 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 ))
             } else if signed {
                 // this cast chain can probably be collapsed, but, whatever, be safe
-                Operand::LiteralInt32(v as u8 as i8 as i32 as u32)
+                Operand::LiteralBit32(v as u8 as i8 as i32 as u32)
             } else {
-                Operand::LiteralInt32(v as u8 as u32)
+                Operand::LiteralBit32(v as u8 as u32)
             }
         }
         fn construct_16(self_: &Builder<'_, '_>, signed: bool, v: u128) -> Operand {
@@ -736,9 +736,9 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                     "Switches to values above u16::MAX not supported: {v:?}"
                 ))
             } else if signed {
-                Operand::LiteralInt32(v as u16 as i16 as i32 as u32)
+                Operand::LiteralBit32(v as u16 as i16 as i32 as u32)
             } else {
-                Operand::LiteralInt32(v as u16 as u32)
+                Operand::LiteralBit32(v as u16 as u32)
             }
         }
         fn construct_32(self_: &Builder<'_, '_>, _signed: bool, v: u128) -> Operand {
@@ -747,7 +747,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                     "Switches to values above u32::MAX not supported: {v:?}"
                 ))
             } else {
-                Operand::LiteralInt32(v as u32)
+                Operand::LiteralBit32(v as u32)
             }
         }
         fn construct_64(self_: &Builder<'_, '_>, _signed: bool, v: u128) -> Operand {
@@ -756,7 +756,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                     "Switches to values above u64::MAX not supported: {v:?}"
                 ))
             } else {
-                Operand::LiteralInt64(v as u64)
+                Operand::LiteralBit64(v as u64)
             }
         }
         // pass in signed into the closure to be able to unify closure types

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -273,12 +273,12 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             Op::TypeVoid => SpirvType::Void.def(self.span(), self),
             Op::TypeBool => SpirvType::Bool.def(self.span(), self),
             Op::TypeInt => SpirvType::Integer(
-                inst.operands[0].unwrap_literal_int32(),
-                inst.operands[1].unwrap_literal_int32() != 0,
+                inst.operands[0].unwrap_literal_bit32(),
+                inst.operands[1].unwrap_literal_bit32() != 0,
             )
             .def(self.span(), self),
             Op::TypeFloat => {
-                SpirvType::Float(inst.operands[0].unwrap_literal_int32()).def(self.span(), self)
+                SpirvType::Float(inst.operands[0].unwrap_literal_bit32()).def(self.span(), self)
             }
             Op::TypeStruct => {
                 self.err("OpTypeStruct in asm! is not supported yet");
@@ -286,12 +286,12 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             }
             Op::TypeVector => SpirvType::Vector {
                 element: inst.operands[0].unwrap_id_ref(),
-                count: inst.operands[1].unwrap_literal_int32(),
+                count: inst.operands[1].unwrap_literal_bit32(),
             }
             .def(self.span(), self),
             Op::TypeMatrix => SpirvType::Matrix {
                 element: inst.operands[0].unwrap_id_ref(),
-                count: inst.operands[1].unwrap_literal_int32(),
+                count: inst.operands[1].unwrap_literal_bit32(),
             }
             .def(self.span(), self),
             Op::TypeArray => {
@@ -322,10 +322,10 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             Op::TypeImage => SpirvType::Image {
                 sampled_type: inst.operands[0].unwrap_id_ref(),
                 dim: inst.operands[1].unwrap_dim(),
-                depth: inst.operands[2].unwrap_literal_int32(),
-                arrayed: inst.operands[3].unwrap_literal_int32(),
-                multisampled: inst.operands[4].unwrap_literal_int32(),
-                sampled: inst.operands[5].unwrap_literal_int32(),
+                depth: inst.operands[2].unwrap_literal_bit32(),
+                arrayed: inst.operands[3].unwrap_literal_bit32(),
+                multisampled: inst.operands[4].unwrap_literal_bit32(),
+                sampled: inst.operands[5].unwrap_literal_bit32(),
                 image_format: inst.operands[6].unwrap_image_format(),
             }
             .def(self.span(), self),
@@ -694,7 +694,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                         let index_to_usize = || match *index {
                             // FIXME(eddyb) support more than just literals,
                             // by looking up `IdRef`s as constant integers.
-                            dr::Operand::LiteralInt32(i) => usize::try_from(i).ok(),
+                            dr::Operand::LiteralBit32(i) => usize::try_from(i).ok(),
 
                             _ => None,
                         };
@@ -1075,7 +1075,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             }
 
             (OperandKind::LiteralInteger, Some(word)) => match word.parse() {
-                Ok(v) => inst.operands.push(dr::Operand::LiteralInt32(v)),
+                Ok(v) => inst.operands.push(dr::Operand::LiteralBit32(v)),
                 Err(e) => self.err(&format!("invalid integer: {e}")),
             },
             (OperandKind::LiteralString, _) => {
@@ -1092,34 +1092,34 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                     }
                     Ok(match ty {
                         SpirvType::Integer(8, false) => {
-                            dr::Operand::LiteralInt32(w.parse::<u8>().map_err(fmt)? as u32)
+                            dr::Operand::LiteralBit32(w.parse::<u8>().map_err(fmt)? as u32)
                         }
                         SpirvType::Integer(16, false) => {
-                            dr::Operand::LiteralInt32(w.parse::<u16>().map_err(fmt)? as u32)
+                            dr::Operand::LiteralBit32(w.parse::<u16>().map_err(fmt)? as u32)
                         }
                         SpirvType::Integer(32, false) => {
-                            dr::Operand::LiteralInt32(w.parse::<u32>().map_err(fmt)?)
+                            dr::Operand::LiteralBit32(w.parse::<u32>().map_err(fmt)?)
                         }
                         SpirvType::Integer(64, false) => {
-                            dr::Operand::LiteralInt64(w.parse::<u64>().map_err(fmt)?)
+                            dr::Operand::LiteralBit64(w.parse::<u64>().map_err(fmt)?)
                         }
                         SpirvType::Integer(8, true) => {
-                            dr::Operand::LiteralInt32(w.parse::<i8>().map_err(fmt)? as i32 as u32)
+                            dr::Operand::LiteralBit32(w.parse::<i8>().map_err(fmt)? as i32 as u32)
                         }
                         SpirvType::Integer(16, true) => {
-                            dr::Operand::LiteralInt32(w.parse::<i16>().map_err(fmt)? as i32 as u32)
+                            dr::Operand::LiteralBit32(w.parse::<i16>().map_err(fmt)? as i32 as u32)
                         }
                         SpirvType::Integer(32, true) => {
-                            dr::Operand::LiteralInt32(w.parse::<i32>().map_err(fmt)? as u32)
+                            dr::Operand::LiteralBit32(w.parse::<i32>().map_err(fmt)? as u32)
                         }
                         SpirvType::Integer(64, true) => {
-                            dr::Operand::LiteralInt64(w.parse::<i64>().map_err(fmt)? as u64)
+                            dr::Operand::LiteralBit64(w.parse::<i64>().map_err(fmt)? as u64)
                         }
                         SpirvType::Float(32) => {
-                            dr::Operand::LiteralFloat32(w.parse::<f32>().map_err(fmt)?)
+                            dr::Operand::LiteralBit32(w.parse::<f32>().map_err(fmt)?.to_bits())
                         }
                         SpirvType::Float(64) => {
-                            dr::Operand::LiteralFloat64(w.parse::<f64>().map_err(fmt)?)
+                            dr::Operand::LiteralBit64(w.parse::<f64>().map_err(fmt)?.to_bits())
                         }
                         _ => return Err("expected number literal in OpConstant".to_string()),
                     })
@@ -1150,7 +1150,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                     inst.operands.push(dr::Operand::IdRef(id));
                     match tokens.next() {
                         Some(Token::Word(word)) => match word.parse() {
-                            Ok(v) => inst.operands.push(dr::Operand::LiteralInt32(v)),
+                            Ok(v) => inst.operands.push(dr::Operand::LiteralBit32(v)),
                             Err(e) => {
                                 self.err(&format!("invalid integer: {e}"));
                             }
@@ -1354,6 +1354,26 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                     .operands
                     .push(dr::Operand::RayQueryCandidateIntersectionType(x)),
                 Err(()) => self.err(&format!("unknown RayQueryCandidateIntersectionType {word}")),
+            },
+            (OperandKind::FPDenormMode, Some(word)) => match word.parse() {
+                Ok(x) => inst.operands.push(dr::Operand::FPDenormMode(x)),
+                Err(()) => self.err(&format!("unknown FPDenormMode {word}")),
+            },
+            (OperandKind::QuantizationModes, Some(word)) => match word.parse() {
+                Ok(x) => inst.operands.push(dr::Operand::QuantizationModes(x)),
+                Err(()) => self.err(&format!("unknown QuantizationModes {word}")),
+            },
+            (OperandKind::FPOperationMode, Some(word)) => match word.parse() {
+                Ok(x) => inst.operands.push(dr::Operand::FPOperationMode(x)),
+                Err(()) => self.err(&format!("unknown FPOperationMode {word}")),
+            },
+            (OperandKind::OverflowModes, Some(word)) => match word.parse() {
+                Ok(x) => inst.operands.push(dr::Operand::OverflowModes(x)),
+                Err(()) => self.err(&format!("unknown OverflowModes {word}")),
+            },
+            (OperandKind::PackedVectorFormat, Some(word)) => match word.parse() {
+                Ok(x) => inst.operands.push(dr::Operand::PackedVectorFormat(x)),
+                Err(()) => self.err(&format!("unknown PackedVectorFormat {word}")),
             },
             (kind, None) => match token {
                 Token::Word(_) => bug!(),

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -509,10 +509,10 @@ impl<'tcx> BuilderSpirv<'tcx> {
         }
         let val = val_with_type.val;
         let id = match val {
-            SpirvConst::U32(v) => builder.constant_u32(ty, v),
-            SpirvConst::U64(v) => builder.constant_u64(ty, v),
-            SpirvConst::F32(v) => builder.constant_f32(ty, f32::from_bits(v)),
-            SpirvConst::F64(v) => builder.constant_f64(ty, f64::from_bits(v)),
+            SpirvConst::U32(v) => builder.constant_bit32(ty, v),
+            SpirvConst::U64(v) => builder.constant_bit64(ty, v),
+            SpirvConst::F32(v) => builder.constant_bit32(ty, v),
+            SpirvConst::F64(v) => builder.constant_bit64(ty, v),
             SpirvConst::Bool(v) => {
                 if v {
                     builder.constant_true(ty)

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -461,7 +461,7 @@ impl<'tcx> CodegenCx<'tcx> {
             self.emit_global().decorate(
                 var,
                 Decoration::DescriptorSet,
-                std::iter::once(Operand::LiteralInt32(index)),
+                std::iter::once(Operand::LiteralBit32(index)),
             );
             decoration_supersedes_location = true;
         }
@@ -469,7 +469,7 @@ impl<'tcx> CodegenCx<'tcx> {
             self.emit_global().decorate(
                 var,
                 Decoration::Binding,
-                std::iter::once(Operand::LiteralInt32(index)),
+                std::iter::once(Operand::LiteralBit32(index)),
             );
             decoration_supersedes_location = true;
         }
@@ -508,7 +508,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 self.emit_global().decorate(
                     var,
                     Decoration::InputAttachmentIndex,
-                    std::iter::once(Operand::LiteralInt32(attachment_index.value)),
+                    std::iter::once(Operand::LiteralBit32(attachment_index.value)),
                 );
             } else if is_subpass_input {
                 self.tcx
@@ -553,7 +553,7 @@ impl<'tcx> CodegenCx<'tcx> {
             self.emit_global().decorate(
                 var,
                 Decoration::Location,
-                std::iter::once(Operand::LiteralInt32(*location)),
+                std::iter::once(Operand::LiteralBit32(*location)),
             );
             *location += 1;
         }

--- a/crates/rustc_codegen_spirv/src/linker/destructure_composites.rs
+++ b/crates/rustc_codegen_spirv/src/linker/destructure_composites.rs
@@ -23,13 +23,13 @@ pub fn destructure_composites(function: &mut Function) {
     for inst in function.all_inst_iter_mut() {
         if inst.class.opcode == Op::CompositeExtract && inst.operands.len() == 2 {
             let mut composite = inst.operands[0].unwrap_id_ref();
-            let index = inst.operands[1].unwrap_literal_int32();
+            let index = inst.operands[1].unwrap_literal_bit32();
 
             let origin = loop {
                 if let Some(inst) = reference.get(&composite) {
                     match inst.class.opcode {
                         Op::CompositeInsert => {
-                            let insert_index = inst.operands[2].unwrap_literal_int32();
+                            let insert_index = inst.operands[2].unwrap_literal_bit32();
                             if insert_index == index {
                                 break Some(inst.operands[0].unwrap_id_ref());
                             }

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -261,7 +261,7 @@ pub fn remove_duplicate_types(module: &mut Module) {
             && (inst.class.opcode != Op::MemberName
                 || member_name_ids.insert((
                     inst.operands[0].unwrap_id_ref(),
-                    inst.operands[1].unwrap_literal_int32(),
+                    inst.operands[1].unwrap_literal_bit32(),
                 )))
     });
 }

--- a/crates/rustc_codegen_spirv/src/linker/mem2reg.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mem2reg.rs
@@ -516,7 +516,7 @@ impl Renamer<'_> {
                         );
                         let mut operands = vec![Operand::IdRef(val), Operand::IdRef(prev_comp)];
                         operands
-                            .extend(var_info.indices.iter().copied().map(Operand::LiteralInt32));
+                            .extend(var_info.indices.iter().copied().map(Operand::LiteralBit32));
                         *inst = Instruction::new(
                             Op::CompositeInsert,
                             Some(self.base_var_type),
@@ -544,7 +544,7 @@ impl Renamer<'_> {
                         let new_id = id(self.header);
                         let mut operands = vec![Operand::IdRef(current_obj)];
                         operands
-                            .extend(var_info.indices.iter().copied().map(Operand::LiteralInt32));
+                            .extend(var_info.indices.iter().copied().map(Operand::LiteralBit32));
                         *inst = Instruction::new(
                             Op::CompositeExtract,
                             Some(var_info.ty),

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -275,14 +275,14 @@ pub fn link(
                         .insert(inst.result_id.unwrap(), inst.operands[1].unwrap_id_ref());
                 }
                 Op::TypeInt
-                    if inst.operands[0].unwrap_literal_int32() == 32
-                        && inst.operands[1].unwrap_literal_int32() == 0 =>
+                    if inst.operands[0].unwrap_literal_bit32() == 32
+                        && inst.operands[1].unwrap_literal_bit32() == 0 =>
                 {
                     assert!(u32.is_none());
                     u32 = Some(inst.result_id.unwrap());
                 }
                 Op::Constant if u32.is_some() && inst.result_type == u32 => {
-                    let value = inst.operands[0].unwrap_literal_int32();
+                    let value = inst.operands[0].unwrap_literal_bit32();
                     constants.insert(inst.result_id.unwrap(), value);
                 }
                 _ => {}
@@ -331,14 +331,14 @@ pub fn link(
                         .insert(inst.result_id.unwrap(), inst.operands[1].unwrap_id_ref());
                 }
                 Op::TypeInt
-                    if inst.operands[0].unwrap_literal_int32() == 32
-                        && inst.operands[1].unwrap_literal_int32() == 0 =>
+                    if inst.operands[0].unwrap_literal_bit32() == 32
+                        && inst.operands[1].unwrap_literal_bit32() == 0 =>
                 {
                     assert!(u32.is_none());
                     u32 = Some(inst.result_id.unwrap());
                 }
                 Op::Constant if u32.is_some() && inst.result_type == u32 => {
-                    let value = inst.operands[0].unwrap_literal_int32();
+                    let value = inst.operands[0].unwrap_literal_bit32();
                     constants.insert(inst.result_id.unwrap(), value);
                 }
                 _ => {}

--- a/crates/rustc_codegen_spirv/src/linker/specializer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/specializer.rs
@@ -542,7 +542,7 @@ struct Specializer<S: Specialization> {
     // FIXME(eddyb) compact SPIR-V IDs to allow flatter maps.
     generics: IndexMap<Word, Generic>,
 
-    /// Integer `OpConstant`s (i.e. containing a `LiteralInt32`), to be used
+    /// Integer `OpConstant`s (i.e. containing a `LiteralBit32`), to be used
     /// for interpreting `TyPat::IndexComposite` (such as for `OpAccessChain`).
     int_consts: FxHashMap<Word, u32>,
 }
@@ -597,7 +597,7 @@ impl<S: Specialization> Specializer<S> {
 
             // Record all integer `OpConstant`s (used for `IndexComposite`).
             if inst.class.opcode == Op::Constant {
-                if let Operand::LiteralInt32(x) = inst.operands[0] {
+                if let Operand::LiteralBit32(x) = inst.operands[0] {
                     self.int_consts.insert(result_id, x);
                 }
             }
@@ -1188,7 +1188,7 @@ impl<'a> Match<'a> {
                                 // known `OpConstant`s (e.g. struct field indices).
                                 let maybe_idx = match operand {
                                     Operand::IdRef(id) => cx.specializer.int_consts.get(id),
-                                    Operand::LiteralInt32(idx) => Some(idx),
+                                    Operand::LiteralBit32(idx) => Some(idx),
                                     _ => None,
                                 };
                                 match maybe_idx {
@@ -1313,7 +1313,7 @@ impl<'a, S: Specialization> InferCx<'a, S> {
                     TyPat::Array(pat) => simple(Op::TypeArray, pat),
                     TyPat::Vector(pat) => simple(Op::TypeVector, pat),
                     TyPat::Vector4(pat) => match ty_operands.operands {
-                        [_, Operand::LiteralInt32(4)] => simple(Op::TypeVector, pat),
+                        [_, Operand::LiteralBit32(4)] => simple(Op::TypeVector, pat),
                         _ => Err(Unapplicable),
                     },
                     TyPat::Matrix(pat) => simple(Op::TypeMatrix, pat),
@@ -1714,7 +1714,7 @@ impl<'a, S: Specialization> InferCx<'a, S> {
                             unreachable!("non-constant `OpTypeStruct` field index {}", id);
                         })
                     }
-                    &Operand::LiteralInt32(i) => i,
+                    &Operand::LiteralBit32(i) => i,
                     _ => {
                         unreachable!("invalid `OpTypeStruct` field index operand {:?}", idx);
                     }

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -271,7 +271,7 @@ fn standard() {
         OpMemoryModel Logical OpenCL
         OpDecorate %1 LinkageAttributes "foo" Export
         %2 = OpTypeFloat 32
-        %3 = OpConstant %2 42.0
+        %3 = OpConstant %2 42
         %1 = OpVariable %2 Uniform %3"#;
 
     without_header_eq(result, expect);

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -162,7 +162,7 @@ impl SpirvType<'_> {
                         result,
                         index as u32,
                         Decoration::Offset,
-                        [Operand::LiteralInt32(offset.bytes() as u32)]
+                        [Operand::LiteralBit32(offset.bytes() as u32)]
                             .iter()
                             .cloned(),
                     );
@@ -188,7 +188,7 @@ impl SpirvType<'_> {
                 emit.decorate(
                     result,
                     Decoration::ArrayStride,
-                    iter::once(Operand::LiteralInt32(element_size as u32)),
+                    iter::once(Operand::LiteralBit32(element_size as u32)),
                 );
                 result
             }
@@ -204,7 +204,7 @@ impl SpirvType<'_> {
                 emit.decorate(
                     result,
                     Decoration::ArrayStride,
-                    iter::once(Operand::LiteralInt32(element_size as u32)),
+                    iter::once(Operand::LiteralBit32(element_size as u32)),
                 );
                 result
             }
@@ -267,7 +267,7 @@ impl SpirvType<'_> {
                     result,
                     0,
                     Decoration::Offset,
-                    [Operand::LiteralInt32(0)].iter().cloned(),
+                    [Operand::LiteralBit32(0)].iter().cloned(),
                 );
                 result
             }

--- a/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
@@ -494,6 +494,12 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         Op::IAddCarry | Op::ISubBorrow | Op::UMulExtended | Op::SMulExtended => sig! {
             (T, T) -> Struct([T, T])
         },
+        Op::SDot | Op::UDot | Op::SUDot | Op::SDotAccSat | Op::UDotAccSat | Op::SUDotAccSat => {
+            sig! {
+                // FIXME(eddyb) missing equality constraint between two vectors
+                (Vector(T), T) -> Vector(T)
+            }
+        }
 
         // 3.37.14. Bit Instructions
         Op::ShiftRightLogical
@@ -593,6 +599,8 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         },
         // Capability: Kernel
         Op::AtomicFlagTestAndSet | Op::AtomicFlagClear => {}
+        // SPV_EXT_shader_atomic_float_min_max
+        Op::AtomicFMinEXT | Op::AtomicFMaxEXT => sig! { (Pointer(_, T), _, _, T) -> T },
         // SPV_EXT_shader_atomic_float_add
         Op::AtomicFAddEXT => sig! { (Pointer(_, T), _, _, T) -> T },
 
@@ -821,7 +829,7 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
 
         // Instructions not present in current SPIR-V specification
         // SPV_INTEL_function_pointers
-        Op::FunctionPointerINTEL | Op::FunctionPointerCallINTEL => {
+        Op::ConstantFunctionPointerINTEL | Op::FunctionPointerCallINTEL => {
             reserved!(SPV_INTEL_function_pointers);
         }
         // SPV_INTEL_device_side_avc_motion_estimation
@@ -945,6 +953,139 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         | Op::SubgroupAvcSicGetInterRawSadsINTEL => {
             reserved!(SPV_INTEL_device_side_avc_motion_estimation);
         }
+
+        // SPV_EXT_mesh_shader
+        Op::EmitMeshTasksEXT | Op::SetMeshOutputsEXT => {
+            // NOTE(eddyb) we actually use these despite not being in the standard yet.
+            // reserved!(SPV_EXT_mesh_shader)
+        }
+        // SPV_NV_ray_tracing_motion_blur
+        Op::TraceMotionNV | Op::TraceRayMotionNV => reserved!(SPV_NV_ray_tracing_motion_blur),
+        // SPV_NV_bindless_texture
+        Op::ConvertUToImageNV
+        | Op::ConvertUToSamplerNV
+        | Op::ConvertImageToUNV
+        | Op::ConvertSamplerToUNV
+        | Op::ConvertUToSampledImageNV
+        | Op::ConvertSampledImageToUNV
+        | Op::SamplerImageAddressingModeNV => reserved!(SPV_NV_bindless_texture),
+        // SPV_INTEL_inline_assembly
+        Op::AsmTargetINTEL | Op::AsmINTEL | Op::AsmCallINTEL => reserved!(SPV_NV_bindless_texture),
+        // SPV_INTEL_variable_length_array
+        Op::VariableLengthArrayINTEL => reserved!(SPV_INTEL_variable_length_array),
+        // SPV_KHR_uniform_group_instructions
+        Op::GroupIMulKHR
+        | Op::GroupFMulKHR
+        | Op::GroupBitwiseAndKHR
+        | Op::GroupBitwiseOrKHR
+        | Op::GroupBitwiseXorKHR
+        | Op::GroupLogicalAndKHR
+        | Op::GroupLogicalOrKHR
+        | Op::GroupLogicalXorKHR => reserved!(SPV_KHR_uniform_group_instructions),
+        // SPV_KHR_expect_assume
+        Op::AssumeTrueKHR | Op::ExpectKHR => reserved!(SPV_KHR_expect_assume),
+        // SPV_KHR_subgroup_rotate
+        Op::GroupNonUniformRotateKHR => reserved!(SPV_KHR_subgroup_rotate),
+        // SPV_NV_shader_invocation_reorder
+        Op::HitObjectRecordHitMotionNV
+        | Op::HitObjectRecordHitWithIndexMotionNV
+        | Op::HitObjectRecordMissMotionNV
+        | Op::HitObjectGetWorldToObjectNV
+        | Op::HitObjectGetObjectToWorldNV
+        | Op::HitObjectGetObjectRayDirectionNV
+        | Op::HitObjectGetObjectRayOriginNV
+        | Op::HitObjectTraceRayMotionNV
+        | Op::HitObjectGetShaderRecordBufferHandleNV
+        | Op::HitObjectGetShaderBindingTableRecordIndexNV
+        | Op::HitObjectRecordEmptyNV
+        | Op::HitObjectTraceRayNV
+        | Op::HitObjectRecordHitNV
+        | Op::HitObjectRecordHitWithIndexNV
+        | Op::HitObjectRecordMissNV
+        | Op::HitObjectExecuteShaderNV
+        | Op::HitObjectGetCurrentTimeNV
+        | Op::HitObjectGetAttributesNV
+        | Op::HitObjectGetHitKindNV
+        | Op::HitObjectGetPrimitiveIndexNV
+        | Op::HitObjectGetGeometryIndexNV
+        | Op::HitObjectGetInstanceIdNV
+        | Op::HitObjectGetInstanceCustomIndexNV
+        | Op::HitObjectGetWorldRayDirectionNV
+        | Op::HitObjectGetWorldRayOriginNV
+        | Op::HitObjectGetRayTMaxNV
+        | Op::HitObjectGetRayTMinNV
+        | Op::HitObjectIsEmptyNV
+        | Op::HitObjectIsHitNV
+        | Op::HitObjectIsMissNV
+        | Op::ReorderThreadWithHitObjectNV
+        | Op::ReorderThreadWithHintNV
+        | Op::TypeHitObjectNV => reserved!(SPV_NV_shader_invocation_reorder),
+        //TODO: extension name??
+        Op::SaveMemoryINTEL
+        | Op::RestoreMemoryINTEL
+        | Op::ArbitraryFloatSinCosPiINTEL
+        | Op::ArbitraryFloatCastINTEL
+        | Op::ArbitraryFloatCastFromIntINTEL
+        | Op::ArbitraryFloatCastToIntINTEL
+        | Op::ArbitraryFloatAddINTEL
+        | Op::ArbitraryFloatSubINTEL
+        | Op::ArbitraryFloatMulINTEL
+        | Op::ArbitraryFloatDivINTEL
+        | Op::ArbitraryFloatGTINTEL
+        | Op::ArbitraryFloatGEINTEL
+        | Op::ArbitraryFloatLTINTEL
+        | Op::ArbitraryFloatLEINTEL
+        | Op::ArbitraryFloatEQINTEL
+        | Op::ArbitraryFloatRecipINTEL
+        | Op::ArbitraryFloatRSqrtINTEL
+        | Op::ArbitraryFloatCbrtINTEL
+        | Op::ArbitraryFloatHypotINTEL
+        | Op::ArbitraryFloatSqrtINTEL
+        | Op::ArbitraryFloatLogINTEL
+        | Op::ArbitraryFloatLog2INTEL
+        | Op::ArbitraryFloatLog10INTEL
+        | Op::ArbitraryFloatLog1pINTEL
+        | Op::ArbitraryFloatExpINTEL
+        | Op::ArbitraryFloatExp2INTEL
+        | Op::ArbitraryFloatExp10INTEL
+        | Op::ArbitraryFloatExpm1INTEL
+        | Op::ArbitraryFloatSinINTEL
+        | Op::ArbitraryFloatCosINTEL
+        | Op::ArbitraryFloatSinCosINTEL
+        | Op::ArbitraryFloatSinPiINTEL
+        | Op::ArbitraryFloatCosPiINTEL
+        | Op::ArbitraryFloatASinINTEL
+        | Op::ArbitraryFloatASinPiINTEL
+        | Op::ArbitraryFloatACosINTEL
+        | Op::ArbitraryFloatACosPiINTEL
+        | Op::ArbitraryFloatATanINTEL
+        | Op::ArbitraryFloatATanPiINTEL
+        | Op::ArbitraryFloatATan2INTEL
+        | Op::ArbitraryFloatPowINTEL
+        | Op::ArbitraryFloatPowRINTEL
+        | Op::ArbitraryFloatPowNINTEL
+        | Op::AliasDomainDeclINTEL
+        | Op::AliasScopeDeclINTEL
+        | Op::AliasScopeListDeclINTEL
+        | Op::FixedSqrtINTEL
+        | Op::FixedRecipINTEL
+        | Op::FixedRsqrtINTEL
+        | Op::FixedSinINTEL
+        | Op::FixedCosINTEL
+        | Op::FixedSinCosINTEL
+        | Op::FixedSinPiINTEL
+        | Op::FixedCosPiINTEL
+        | Op::FixedSinCosPiINTEL
+        | Op::FixedLogINTEL
+        | Op::FixedExpINTEL
+        | Op::PtrCastToCrossWorkgroupINTEL
+        | Op::CrossWorkgroupCastToPtrINTEL
+        | Op::TypeBufferSurfaceINTEL
+        | Op::TypeStructContinuedINTEL
+        | Op::ConstantCompositeContinuedINTEL
+        | Op::SpecConstantCompositeContinuedINTEL
+        | Op::ControlBarrierArriveINTEL
+        | Op::ControlBarrierWaitINTEL => todo!(),
     }
 
     None

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -114,8 +114,17 @@ const BUILTINS: &[(&str, BuiltIn)] = {
         ("layer_per_view_nv", LayerPerViewNV),
         ("mesh_view_count_nv", MeshViewCountNV),
         ("mesh_view_indices_nv", MeshViewIndicesNV),
-        ("bary_coord_nv", BaryCoordNV),
-        ("bary_coord_no_persp_nv", BaryCoordNoPerspNV),
+        ("primitive_point_indices_ext", PrimitivePointIndicesEXT),
+        ("primitive_line_indices_ext", PrimitiveLineIndicesEXT),
+        (
+            "primitive_triangle_indices_ext",
+            PrimitiveTriangleIndicesEXT,
+        ),
+        ("cull_primitive_ext", CullPrimitiveEXT),
+        ("bary_coord_nv", BaryCoordKHR),
+        ("bary_coord_khr", BaryCoordKHR),
+        ("bary_coord_no_persp_nv", BaryCoordNoPerspKHR),
+        ("bary_coord_no_persp_khr", BaryCoordNoPerspKHR),
         ("frag_size_ext", FragSizeEXT),
         ("frag_invocation_count_ext", FragInvocationCountEXT),
         ("launch_id", BuiltIn::LaunchIdKHR),
@@ -179,6 +188,8 @@ const EXECUTION_MODELS: &[(&str, ExecutionModel)] = {
         ("compute", GLCompute),
         ("task_nv", TaskNV),
         ("mesh_nv", MeshNV),
+        ("task_ext", TaskEXT),
+        ("mesh_ext", MeshEXT),
         ("ray_generation", ExecutionModel::RayGenerationKHR),
         ("intersection", ExecutionModel::IntersectionKHR),
         ("any_hit", ExecutionModel::AnyHitKHR),
@@ -259,6 +270,17 @@ const EXECUTION_MODES: &[(&str, ExecutionMode, ExecutionModeExtraDim)] = {
         ("output_primitives_nv", OutputPrimitivesNV, Value),
         ("derivative_group_quads_nv", DerivativeGroupQuadsNV, None),
         ("output_triangles_nv", OutputTrianglesNV, None),
+        ("output_lines_ext", ExecutionMode::OutputLinesEXT, None),
+        (
+            "output_triangles_ext",
+            ExecutionMode::OutputTrianglesEXT,
+            None,
+        ),
+        (
+            "output_primitives_ext",
+            ExecutionMode::OutputPrimitivesEXT,
+            Value,
+        ),
         (
             "pixel_interlock_ordered_ext",
             PixelInterlockOrderedEXT,
@@ -673,7 +695,7 @@ fn parse_entry_attrs(
                 .execution_modes
                 .push((origin_mode, ExecutionModeExtra::new([])));
         }
-        GLCompute | MeshNV | TaskNV => {
+        GLCompute | MeshNV | TaskNV | TaskEXT | MeshEXT => {
             if let Some(local_size) = local_size {
                 entry
                     .execution_modes
@@ -682,7 +704,7 @@ fn parse_entry_attrs(
                 return Err((
                     arg.span(),
                     String::from(
-                        "The `threads` argument must be specified when using `#[spirv(compute)]`, `#[spirv(mesh_nv)]` or `#[spirv(task_nv)]`",
+                        "The `threads` argument must be specified when using `#[spirv(compute)]`, `#[spirv(mesh_nv)]`, `#[spirv(task_nv)]`, `#[spirv(task_ext)]` or `#[spirv(mesh_ext)]`",
                     ),
                 ));
             }

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -17,6 +17,7 @@ mod atomics;
 mod barrier;
 mod demote_to_helper_invocation_ext;
 mod derivative;
+mod mesh_shading;
 mod primitive;
 mod ray_tracing;
 
@@ -24,6 +25,7 @@ pub use atomics::*;
 pub use barrier::*;
 pub use demote_to_helper_invocation_ext::*;
 pub use derivative::*;
+pub use mesh_shading::*;
 pub use primitive::*;
 pub use ray_tracing::*;
 

--- a/crates/spirv-std/src/arch/mesh_shading.rs
+++ b/crates/spirv-std/src/arch/mesh_shading.rs
@@ -1,0 +1,26 @@
+#[cfg(target_arch = "spirv")]
+use core::arch::asm;
+
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpSetMeshOutputsEXT")]
+#[inline]
+pub unsafe fn set_mesh_outputs_ext(vertex_count: u32, primitive_count: u32) {
+    asm! {
+        "OpSetMeshOutputsEXT {vertex_count} {primitive_count}",
+        vertex_count = in(reg) vertex_count,
+        primitive_count = in(reg) primitive_count,
+    }
+}
+
+#[spirv_std_macros::gpu_only]
+#[doc(alias = "OpEmitMeshTasksEXT")]
+#[inline]
+pub unsafe fn emit_mesh_tasks_ext(group_count_x: u32, group_count_y: u32, group_count_z: u32) -> ! {
+    asm! {
+        "OpEmitMeshTasksEXT {group_count_x} {group_count_y} {group_count_z}",
+        group_count_x = in(reg) group_count_x,
+        group_count_y = in(reg) group_count_y,
+        group_count_z = in(reg) group_count_z,
+        options(noreturn),
+    }
+}


### PR DESCRIPTION
This PR adds support for VK_EXT_mesh_shader. At the moment, it depends on my unofficial updated rspirv version. 

An example mesh shader looks like this:
```Rust
#[spirv(mesh_ext(
    threads(1),
    output_vertices = 3,
    output_primitives_ext = 1,
    output_triangles_ext
))]
pub fn my_mesh_shader(
    #[spirv(position)] positions: &mut [Vec4; 3],
    #[spirv(primitive_triangle_indices_ext)] indices: &mut [UVec3; 1],
) {
    unsafe {
        set_mesh_outputs_ext(3, 1);
    }

    positions[0] = Vec4::new(-0.5, 0.5, 0.0, 1.0);
    positions[1] = Vec4::new(0.5, 0.5, 0.0, 1.0);
    positions[2] = Vec4::new(0.0, -0.5, 0.0, 1.0);

    indices[0] = UVec3::new(0, 1, 2);
}
```