### PR TITLE
Integrate the SPIR-T `qptr` experiment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added ⭐
-- [PR#1039](https://github.com/EmbarkStudios/rust-gpu/pull/1039) added new experimental `sample_with` to `Image` API to set additional image operands.
+- [PR#1020](https://github.com/EmbarkStudios/rust-gpu/pull/1020) added SPIR-T `qptr`
+  support in the form of `--spirt-passes=qptr`, a way to turn off "Storage Class inference",
+  and reporting for SPIR-T diagnostics - to test `qptr` fully, you can use:  
+  `RUSTGPU_CODEGEN_ARGS="--no-infer-storage-classes --spirt-passes=qptr"`  
+  (see also [the SPIR-T `qptr` PR](https://github.com/EmbarkStudios/spirt/pull/24) for more details about the `qptr` experiment)
+- [PR#1039](https://github.com/EmbarkStudios/rust-gpu/pull/1039) added new experimental `sample_with` to `Image` API to set additional image operands
 - [PR#1031](https://github.com/EmbarkStudios/rust-gpu/pull/1031) added `Components` generic parameter to `Image` type, allowing images to return lower dimensional vectors and even scalars from the sampling API
 
 ### Changed 🛠

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "internal-iterator"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668ef46056a63366da9d74f48062da9ece1a27958f2f3704aa6f7421c4433f5"
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1270,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "longest-increasing-subsequence"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 
 [[package]]
 name = "malloc_buf"
@@ -2215,16 +2227,18 @@ dependencies = [
 
 [[package]]
 name = "spirt"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06834ebbbbc6f86448fd5dc7ccbac80e36f52f8d66838683752e19d3cae9a459"
+checksum = "e24fa996f12f3c667efbceaa99c222b8910a295a14d2c43c3880dfab2752def7"
 dependencies = [
  "arrayvec",
  "bytemuck",
  "elsa",
  "indexmap",
+ "internal-iterator",
  "itertools",
  "lazy_static",
+ "longest-increasing-subsequence",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -58,7 +58,7 @@ serde_json = "1.0"
 smallvec = { version = "1.6.1", features = ["union"] }
 spirv-tools = { version = "0.9", default-features = false }
 rustc_codegen_spirv-types.workspace = true
-spirt = "0.1.0"
+spirt = "0.2.0"
 lazy_static = "1.4.0"
 itertools = "0.10.5"
 

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -1267,7 +1267,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         if let SpirvValueKind::LogicalPtrCast {
             original_ptr,
             original_pointee_ty,
-            zombie_target_undef: _,
+            bitcast_result_id: _,
         } = ptr.kind
         {
             let offset = match pointee_kind {
@@ -1533,7 +1533,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             SpirvValueKind::LogicalPtrCast {
                 original_ptr,
                 original_pointee_ty,
-                zombie_target_undef: _,
+                bitcast_result_id: _,
             } => (
                 original_ptr.with_type(
                     SpirvType::Pointer {
@@ -1572,11 +1572,12 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 .with_type(dest_ty)
         } else {
             // Defer the cast so that it has a chance to be avoided.
+            let original_ptr = val.def(self);
             SpirvValue {
                 kind: SpirvValueKind::LogicalPtrCast {
-                    original_ptr: val.def(self),
+                    original_ptr,
                     original_pointee_ty: val_pointee,
-                    zombie_target_undef: self.undef(dest_ty).def(self),
+                    bitcast_result_id: self.emit().bitcast(dest_ty, None, original_ptr).unwrap(),
                 },
                 ty: dest_ty,
             }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -335,6 +335,11 @@ impl CodegenArgs {
                 "no-early-report-zombies",
                 "delays reporting zombies (to allow more legalization)",
             );
+            opts.optflag(
+                "",
+                "no-infer-storage-classes",
+                "disables SPIR-V Storage Class inference",
+            );
             opts.optflag("", "no-structurize", "disables CFG structurization");
 
             opts.optflag(
@@ -515,6 +520,7 @@ impl CodegenArgs {
             dce: !matches.opt_present("no-dce"),
             compact_ids: !matches.opt_present("no-compact-ids"),
             early_report_zombies: !matches.opt_present("no-early-report-zombies"),
+            infer_storage_classes: !matches.opt_present("no-infer-storage-classes"),
             structurize: !matches.opt_present("no-structurize"),
             spirt: !matches.opt_present("no-spirt"),
             spirt_passes: matches

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -102,8 +102,9 @@ impl Zombies {
         // No need to zombie defs within a function: If any def within a function is zombied, then the
         // whole function is zombied. But, we don't have to mark the defs within a function as zombie,
         // because the defs can't escape the function.
-        // HACK(eddyb) one exception to this is function-local variables, which may
-        // be unused and as such cannot be allowed to always zombie the function.
+        // HACK(eddyb) one exception to this is function-local variables, or the
+        // `OpBitcast`s of pointer casts, either of which which may actually be
+        // unused and as such cannot be allowed to always zombie the function.
         for func in &module.functions {
             let func_id = func.def_id().unwrap();
             if self.id_to_zombie_kind.contains_key(&func_id) {
@@ -126,7 +127,7 @@ impl Zombies {
                     _ => {}
                 }
 
-                if inst.class.opcode == Op::Variable {
+                if [Op::Variable, Op::Bitcast].contains(&inst.class.opcode) {
                     let result_id = inst.result_id.unwrap();
                     if self.id_to_zombie_kind.contains_key(&result_id) {
                         continue;

--- a/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
+++ b/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
@@ -18,11 +18,11 @@ note: called by `main_scalar_scalar_pair_nested`
    | ^
 
 error: cannot cast between pointer types
-       from `*struct (usize, usize) { u32, u32 }`
+       from `*u32`
          to `*struct B {  }`
-  --> $DIR/zst_member_ref_arg-broken.rs:33:5
+  --> $DIR/zst_member_ref_arg-broken.rs:23:5
    |
-33 |     f(&s.y);
+23 |     f(&s.y);
    |     ^
    |
 note: used from within `zst_member_ref_arg_broken::main_scalar`
@@ -37,11 +37,11 @@ note: called by `main_scalar`
    | ^
 
 error: cannot cast between pointer types
-       from `*struct (usize, usize) { u32, u32 }`
+       from `*struct S<usize, usize> { u32, u32 }`
          to `*struct B {  }`
-  --> $DIR/zst_member_ref_arg-broken.rs:33:5
+  --> $DIR/zst_member_ref_arg-broken.rs:28:5
    |
-33 |     f(&s.y);
+28 |     f(&s.y);
    |     ^
    |
 note: used from within `zst_member_ref_arg_broken::main_scalar_pair`


### PR DESCRIPTION
For more information, check out the SPIR-T PR, which has a much longer explanation:
* https://github.com/EmbarkStudios/spirt/pull/24

The short version is goes something like this:
> doing more (`union`/`enum` support, more flexible storage classes, `PhysicalStorageBuffer`, etc.)
> with less (extremely untyped pointers, removing Rust-GPU's existing "storage class inference" pass)

Currently this PR allows testing replacing the old storage class inference with `qptr` passes, via:
```sh
RUSTGPU_CODEGEN_ARGS="--no-infer-storage-classes --spirt-passes=qptr"
```