### PR TITLE
Always inline calls with "not obviously legal" pointer args (instead of the opposite).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed 🩹
+- [PR#1023](https://github.com/EmbarkStudios/rust-gpu/pull/1023) fixed [#1021](https://github.com/EmbarkStudios/rust-gpu/issues/1021) by always inlining calls with "not obviously legal" pointer args (instead of only inlining calls with "obviously illegal" pointer args)
 - [PR#1009](https://github.com/EmbarkStudios/rust-gpu/pull/1009) fixed [#1008](https://github.com/EmbarkStudios/rust-gpu/issues/1008) by reinstating mutability checks for entry-point parameters pointing into read-only storage classes (e.g. `#[spirv(uniform)] x: &mut u32` is now again an error)
 - [PR#995](https://github.com/EmbarkStudios/rust-gpu/pull/995) fixed [#994](https://github.com/EmbarkStudios/rust-gpu/issues/994) by using `OpAtomicFAddEXT` instead of `OpAtomicFMaxEXT` in `atomic_f_add`.
 

--- a/tests/ui/lang/core/ref/member_ref_arg.rs
+++ b/tests/ui/lang/core/ref/member_ref_arg.rs
@@ -7,10 +7,18 @@ struct S {
     y: u32,
 }
 
+// NOTE(eddyb) `#[inline(never)]` is for blocking inlining at the e.g. MIR level,
+// whereas any Rust-GPU-specific legalization will intentially ignore it.
+
+#[inline(never)]
 fn f(x: &u32) {}
+
+#[inline(never)]
+fn g(xy: (&u32, &u32)) {}
 
 #[spirv(fragment)]
 pub fn main() {
     let s = S { x: 2, y: 2 };
     f(&s.x);
+    g((&s.x, &s.y));
 }


### PR DESCRIPTION
* fixes #1021

Before this PR, the behavior of the inliner wrt pointer types in `fn` signatures (and pointer args) was to special-case a illegal cases and force inlining. This PR flips some of that on its head, treating everything it's not sure about as illegal, forcing inlining in all the cases not explicitly deemed legal.

Specifically for fixing #1021, the necessary change is obeying the SPIR-V spec about pointer call arguments having to be "memory object declarations" (i.e. an `OpVariable`, or one of the caller's own `OpFunctionParameter`s, which transitively must be a whole `OpVariable` etc.).

With this PR, any pointer argument other than an `OpVariable` (either global or in the caller) or an `OpFunctionParameter`, will force inlining (even if some of those edge cases may actually be legal, we'll still be correctly conservative).

(The several commits should be reviewed separately, as the first 3 only refactor `linker::inline`'s existing logic)