### PR TITLE
builder: use undef `bool` instead of `false`, for `checked_binop`'s zombie.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#1011](https://github.com/EmbarkStudios/rust-gpu/pull/1011) made `NonWritable` all read-only storage buffers (i.e. those typed `&T`, where `T` doesn't have interior mutability)
 
 ### Fixed 🩹
+- [PR#1025](https://github.com/EmbarkStudios/rust-gpu/pull/1025) fixed [#1024](https://github.com/EmbarkStudios/rust-gpu/issues/1024) by keeping checked arithmetic "zombie" `bool`s disjoint from normal `bool` (`false`) consts
 - [PR#1023](https://github.com/EmbarkStudios/rust-gpu/pull/1023) fixed [#1021](https://github.com/EmbarkStudios/rust-gpu/issues/1021) by always inlining calls with "not obviously legal" pointer args (instead of only inlining calls with "obviously illegal" pointer args)
 - [PR#1009](https://github.com/EmbarkStudios/rust-gpu/pull/1009) fixed [#1008](https://github.com/EmbarkStudios/rust-gpu/issues/1008) by reinstating mutability checks for entry-point parameters pointing into read-only storage classes (e.g. `#[spirv(uniform)] x: &mut u32` is now again an error)
-- [PR#995](https://github.com/EmbarkStudios/rust-gpu/pull/995) fixed [#994](https://github.com/EmbarkStudios/rust-gpu/issues/994) by using `OpAtomicFAddEXT` instead of `OpAtomicFMaxEXT` in `atomic_f_add`.
+- [PR#995](https://github.com/EmbarkStudios/rust-gpu/pull/995) fixed [#994](https://github.com/EmbarkStudios/rust-gpu/issues/994) by using `OpAtomicFAddEXT` instead of `OpAtomicFMaxEXT` in `atomic_f_add`
 
 ## [0.6.1]
 
@@ -45,13 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0]
 
 ### Added ⭐
-- [PR#998](https://github.com/EmbarkStudios/rust-gpu/pull/998) added `extra_arg()` SpirvBuilder API to be able to set codegen args otherwise not supported by the API (for example, to set `--spirv-passes`).
+- [PR#998](https://github.com/EmbarkStudios/rust-gpu/pull/998) added `extra_arg()` SpirvBuilder API to be able to set codegen args otherwise not supported by the API (for example, to set `--spirv-passes`)
 
 ### Changed 🛠
-- [PR#999](https://github.com/EmbarkStudios/rust-gpu/pull/999) Made the [`SPIR-🇹` shader IR framework](https://github.com/EmbarkStudios/spirt) the default. You can opt-out using `--no-spirt` codegen arg.
-- [PR#992](https://github.com/EmbarkStudios/rust-gpu/pull/992) renamed `rust-toolchain` to `rust-toolchain.toml`.
-- [PR#991](https://github.com/EmbarkStudios/rust-gpu/pull/991) updated toolchain to `nightly-2023-01-21`.
-- [PR#990](https://github.com/EmbarkStudios/rust-gpu/pull/990) removed return type inference from `Image` API and made `glam` usage mandatory.
+- [PR#999](https://github.com/EmbarkStudios/rust-gpu/pull/999) made the [`SPIR-🇹` shader IR framework](https://github.com/EmbarkStudios/spirt) the default (you can opt out via `RUSTGPU_CODEGEN_ARGS=--no-spirt`)
+- [PR#992](https://github.com/EmbarkStudios/rust-gpu/pull/992) renamed `rust-toolchain` to `rust-toolchain.toml`
+- [PR#991](https://github.com/EmbarkStudios/rust-gpu/pull/991) updated toolchain to `nightly-2023-01-21`
+- [PR#990](https://github.com/EmbarkStudios/rust-gpu/pull/990) removed return type inference from `Image` API and made `glam` usage mandatory
 
 ## [0.5.0]
 

--- a/tests/ui/lang/consts/issue-1024.rs
+++ b/tests/ui/lang/consts/issue-1024.rs
@@ -1,0 +1,31 @@
+// Tests that the zombie `bool` from `overflowing_*` (the "has overflowed" value)
+// isn't kept alive by the user's own (unrelated) `bool` constants.
+//
+// NOTE(eddyb) quick explanation for the compile-flags below:
+// * `-Coverflow-checks=off`: the default, but explicit here because of how
+//   its behavior is relied upon by `u32_overflowing_add_only_result`
+// * `-Ccodegen-units=1`: avoids `bool` consts and `<u32 as Add>::add` being
+//   in separate CGUs (which then bypasses const deduplication, during linking)
+
+// build-pass
+// compile-flags: -Coverflow-checks=off -Ccodegen-units=1
+
+use spirv_std::spirv;
+
+const PRIVATE_GLOBAL_BOOLS: &[bool; 2] = &[false, true];
+
+/// `a.overflowing_add(b).0` equivalent, but with the Rust `(u32, bool`) never
+/// existing, and the `.0` happening in the compiler, via `CheckedBinaryOp(Add)`
+/// in `<u32 as Add>::add`, and `-Coverflow-checks=off` ignoring the `.1` `bool`.
+fn u32_overflowing_add_only_result(a: u32, b: u32) -> u32 {
+    <u32 as core::ops::Add>::add(a, b)
+}
+
+#[spirv(fragment)]
+pub fn main(x: &mut u32) {
+    *x = 0;
+    for i in 0..PRIVATE_GLOBAL_BOOLS.len() {
+        let y = (PRIVATE_GLOBAL_BOOLS[i] as u32) << i;
+        *x = u32_overflowing_add_only_result(*x, y);
+    }
+}


### PR DESCRIPTION
* fixes #1024

The actual fix was tiny, but testing required going through some hoops, as the original issue only seemed to reproduce with `--release` (ironically, given the checked overflow connection).

In the end I went with `-Ccodegen-units=1` (to try and force the user's `bool` constants to overlap the zombie), but I'm not 100% sure that's future-proof. But it did reproduce, i.e. w/o the fix, the test errors with:
```
error: checked add is not supported yet
   --> /home/eddy/.rustup/toolchains/nightly-2023-03-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/arith.rs:104:45
    |
104 |             fn add(self, other: $t) -> $t { self + other }
    |                                             ^^^^^^^^^^^^
    |
    = note: Stack:
            issue_1024::main
            main
```