### PR TITLE
tests/ui: fix "invalid character in crate name" w/ explicit `#![crate_name]`.

### DIFF
--- a/tests/ui/dis/asm_op_decorate.not_spirt.rs
+++ b/tests/ui/dis/asm_op_decorate.not_spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of asm_op_decorate.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
+#![crate_name = "asm_op_decorate"]
 
 // build-pass
 // compile-flags: -C target-feature=+RuntimeDescriptorArray,+ext:SPV_EXT_descriptor_indexing

--- a/tests/ui/dis/asm_op_decorate.not_spirt.stderr
+++ b/tests/ui/dis/asm_op_decorate.not_spirt.stderr
@@ -1,4 +1,29 @@
-error: invalid character `'.'` in crate name: `asm_op_decorate.not_spirt`
-
-error: aborting due to previous error
-
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability RuntimeDescriptorArray
+OpCapability ShaderClockKHR
+OpCapability Shader
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/asm_op_decorate.not_spirt.rs"
+OpName %3 "asm_op_decorate::add_decorate"
+OpName %4 "asm_op_decorate::main"
+OpDecorate %5 ArrayStride 4
+OpDecorate %6 DescriptorSet 0
+OpDecorate %6 Binding 0
+%7 = OpTypeVoid
+%8 = OpTypeFunction %7
+%9 = OpTypeInt 32 0
+%10 = OpConstant  %9  1
+%11 = OpTypeFloat 32
+%12 = OpTypeImage %11 2D 0 0 0 1 Unknown
+%13 = OpTypeSampledImage %12
+%5 = OpTypeRuntimeArray %13
+%14 = OpTypePointer UniformConstant %5
+%6 = OpVariable  %14  UniformConstant
+%15 = OpTypePointer UniformConstant %13

--- a/tests/ui/dis/asm_op_decorate.spirt.rs
+++ b/tests/ui/dis/asm_op_decorate.spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of asm_op_decorate.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
+#![crate_name = "asm_op_decorate"]
 
 // build-pass
 // compile-flags: -C target-feature=+RuntimeDescriptorArray,+ext:SPV_EXT_descriptor_indexing

--- a/tests/ui/dis/asm_op_decorate.spirt.stderr
+++ b/tests/ui/dis/asm_op_decorate.spirt.stderr
@@ -1,4 +1,29 @@
-error: invalid character `'.'` in crate name: `asm_op_decorate.spirt`
-
-error: aborting due to previous error
-
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpCapability RuntimeDescriptorArray
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/asm_op_decorate.spirt.rs"
+OpName %3 "asm_op_decorate::main"
+OpName %4 "asm_op_decorate::add_decorate"
+OpDecorate %5 ArrayStride 4
+OpDecorate %6 Binding 0
+OpDecorate %6 DescriptorSet 0
+%7 = OpTypeVoid
+%8 = OpTypeFunction %7
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeSampledImage %10
+%12 = OpTypePointer UniformConstant %11
+%5 = OpTypeRuntimeArray %11
+%13 = OpTypePointer UniformConstant %5
+%6 = OpVariable  %13  UniformConstant
+%14 = OpTypeInt 32 0
+%15 = OpConstant  %14  1

--- a/tests/ui/dis/custom_entry_point.not_spirt.rs
+++ b/tests/ui/dis/custom_entry_point.not_spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of custom_entry_point.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
+#![crate_name = "custom_entry_point"]
 
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals

--- a/tests/ui/dis/custom_entry_point.not_spirt.stderr
+++ b/tests/ui/dis/custom_entry_point.not_spirt.stderr
@@ -1,4 +1,14 @@
-error: invalid character `'.'` in crate name: `custom_entry_point.not_spirt`
-
-error: aborting due to previous error
-
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpCapability Shader
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "hello_world"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/custom_entry_point.not_spirt.rs"
+OpName %3 "custom_entry_point::main"
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4

--- a/tests/ui/dis/custom_entry_point.spirt.rs
+++ b/tests/ui/dis/custom_entry_point.spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of custom_entry_point.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
+#![crate_name = "custom_entry_point"]
 
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals

--- a/tests/ui/dis/custom_entry_point.spirt.stderr
+++ b/tests/ui/dis/custom_entry_point.spirt.stderr
@@ -1,4 +1,14 @@
-error: invalid character `'.'` in crate name: `custom_entry_point.spirt`
-
-error: aborting due to previous error
-
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "hello_world"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/custom_entry_point.spirt.rs"
+OpName %3 "custom_entry_point::main"
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4

--- a/tests/ui/dis/generic-fn-op-name.not_spirt.rs
+++ b/tests/ui/dis/generic-fn-op-name.not_spirt.rs
@@ -1,6 +1,7 @@
 // HACK(eddyb) duplicate of generic-fn-op-name.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
-
+#![crate_name = "generic_fn_op_name"]
+//
 // Test that generic functions' `OpName` correctly include generic arguments.
 
 // build-pass
@@ -8,7 +9,6 @@
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
-
 #![feature(adt_const_params)]
 #![allow(incomplete_features)]
 

--- a/tests/ui/dis/generic-fn-op-name.not_spirt.stderr
+++ b/tests/ui/dis/generic-fn-op-name.not_spirt.stderr
@@ -1,4 +1,15 @@
-error: invalid character `'.'` in crate name: `generic_fn_op_name.not_spirt`
-
-error: aborting due to previous error
-
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpCapability Shader
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/generic-fn-op-name.not_spirt.rs"
+OpName %3 "generic_fn_op_name::generic::<f32, {spirv_std_types::image_params::Dimensionality::TwoD}>"
+OpName %4 "generic_fn_op_name::main"
+%5 = OpTypeVoid
+%6 = OpTypeFunction %5

--- a/tests/ui/dis/generic-fn-op-name.spirt.rs
+++ b/tests/ui/dis/generic-fn-op-name.spirt.rs
@@ -1,6 +1,7 @@
 // HACK(eddyb) duplicate of generic-fn-op-name.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
-
+#![crate_name = "generic_fn_op_name"]
+//
 // Test that generic functions' `OpName` correctly include generic arguments.
 
 // build-pass
@@ -8,7 +9,6 @@
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
-
 #![feature(adt_const_params)]
 #![allow(incomplete_features)]
 

--- a/tests/ui/dis/generic-fn-op-name.spirt.stderr
+++ b/tests/ui/dis/generic-fn-op-name.spirt.stderr
@@ -1,4 +1,15 @@
-error: invalid character `'.'` in crate name: `generic_fn_op_name.spirt`
-
-error: aborting due to previous error
-
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%2 = OpString "$OPSTRING_FILENAME/generic-fn-op-name.spirt.rs"
+OpName %3 "generic_fn_op_name::main"
+OpName %4 "generic_fn_op_name::generic::<f32, {spirv_std_types::image_params::Dimensionality::TwoD}>"
+%5 = OpTypeVoid
+%6 = OpTypeFunction %5

--- a/tests/ui/dis/index_user_dst.not_spirt.rs
+++ b/tests/ui/dis/index_user_dst.not_spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of index_user_dst.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
+#![crate_name = "index_user_dst"]
 
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-entry=main

--- a/tests/ui/dis/index_user_dst.not_spirt.stderr
+++ b/tests/ui/dis/index_user_dst.not_spirt.stderr
@@ -1,4 +1,34 @@
-error: invalid character `'.'` in crate name: `index_user_dst.not_spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 11 12
+%6 = OpAccessChain  %7  %8 %9
+%10 = OpArrayLength  %11  %8 0
+OpLine %5 12 21
+%12 = OpULessThan  %13  %9 %10
+OpLine %5 12 21
+OpSelectionMerge %14 None
+OpBranchConditional %12 %15 %16
+%15 = OpLabel
+OpLine %5 12 21
+%17 = OpInBoundsAccessChain  %18  %6 %9
+%19 = OpLoad  %20  %17
+OpLine %5 14 1
+OpReturn
+%16 = OpLabel
+OpLine %5 12 21
+OpBranch %21
+%21 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%23 = OpPhi  %13  %24 %21 %24 %25
+OpLoopMerge %26 %25 None
+OpBranchConditional %23 %27 %26
+%27 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %22
+%26 = OpLabel
+OpUnreachable
+%14 = OpLabel
+OpUnreachable
+OpFunctionEnd

--- a/tests/ui/dis/index_user_dst.spirt.rs
+++ b/tests/ui/dis/index_user_dst.spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of index_user_dst.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
+#![crate_name = "index_user_dst"]
 
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-entry=main

--- a/tests/ui/dis/index_user_dst.spirt.stderr
+++ b/tests/ui/dis/index_user_dst.spirt.stderr
@@ -18,6 +18,8 @@ OpBranch %14
 OpBranch %21
 %21 = OpLabel
 OpLoopMerge %22 %23 None
+OpBranch %24
+%24 = OpLabel
 OpBranch %23
 %23 = OpLabel
 OpBranch %21

--- a/tests/ui/dis/index_user_dst.spirt.stderr
+++ b/tests/ui/dis/index_user_dst.spirt.stderr
@@ -1,4 +1,28 @@
-error: invalid character `'.'` in crate name: `index_user_dst.spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 11 12
+%6 = OpAccessChain  %7  %8 %9
+%10 = OpArrayLength  %11  %8 0
+OpLine %5 12 21
+%12 = OpULessThan  %13  %9 %10
+OpNoLine
+OpSelectionMerge %14 None
+OpBranchConditional %12 %15 %16
+%15 = OpLabel
+OpLine %5 12 21
+%17 = OpInBoundsAccessChain  %18  %6 %9
+%19 = OpLoad  %20  %17
+OpNoLine
+OpBranch %14
+%16 = OpLabel
+OpBranch %21
+%21 = OpLabel
+OpLoopMerge %22 %23 None
+OpBranch %23
+%23 = OpLabel
+OpBranch %21
+%22 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpReturn
+OpFunctionEnd

--- a/tests/ui/dis/issue-373.not_spirt.rs
+++ b/tests/ui/dis/issue-373.not_spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of issue-373.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
+#![crate_name = "issue_373"]
 
 // Test that returning a single-scalar-field `#[repr(C)] struct` doesn't generate
 // unsupported pointer casts (the problem was the use of `PassMode::Cast`, through

--- a/tests/ui/dis/issue-373.not_spirt.stderr
+++ b/tests/ui/dis/issue-373.not_spirt.stderr
@@ -1,4 +1,11 @@
-error: invalid character `'.'` in crate name: `issue_373.not_spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 26 11
+%6 = OpFunctionCall  %7  %8
+OpLine %5 26 11
+%9 = OpCompositeExtract  %10  %6 0
+OpLine %5 26 4
+OpStore %11 %9
+OpLine %5 27 1
+OpReturn
+OpFunctionEnd

--- a/tests/ui/dis/issue-373.spirt.rs
+++ b/tests/ui/dis/issue-373.spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of issue-373.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
+#![crate_name = "issue_373"]
 
 // Test that returning a single-scalar-field `#[repr(C)] struct` doesn't generate
 // unsupported pointer casts (the problem was the use of `PassMode::Cast`, through

--- a/tests/ui/dis/issue-373.spirt.stderr
+++ b/tests/ui/dis/issue-373.spirt.stderr
@@ -1,4 +1,10 @@
-error: invalid character `'.'` in crate name: `issue_373.spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 26 11
+%6 = OpFunctionCall  %7  %8
+%9 = OpCompositeExtract  %10  %6 0
+OpLine %5 26 4
+OpStore %11 %9
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/ui/dis/issue-723-output.not_spirt.rs
+++ b/tests/ui/dis/issue-723-output.not_spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of issue-723-output.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
+#![crate_name = "issue_723_output"]
 
 // Test that interface (global) `OpVariable`s mentioned by `OpEntryPoint` don't
 // have to be used by the shader, for storage class inference to succeed.

--- a/tests/ui/dis/issue-723-output.not_spirt.stderr
+++ b/tests/ui/dis/issue-723-output.not_spirt.stderr
@@ -1,4 +1,19 @@
-error: invalid character `'.'` in crate name: `issue_723_output.not_spirt`
-
-error: aborting due to previous error
-
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpCapability Shader
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/issue-723-output.not_spirt.rs"
+OpName %4 "issue_723_output::main"
+OpDecorate %2 Location 0
+%5 = OpTypeVoid
+%6 = OpTypeFloat 32
+%7 = OpTypeVector %6 4
+%8 = OpTypePointer Output %7
+%9 = OpTypeFunction %5
+%2 = OpVariable  %8  Output

--- a/tests/ui/dis/issue-723-output.spirt.rs
+++ b/tests/ui/dis/issue-723-output.spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of issue-723-output.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
+#![crate_name = "issue_723_output"]
 
 // Test that interface (global) `OpVariable`s mentioned by `OpEntryPoint` don't
 // have to be used by the shader, for storage class inference to succeed.

--- a/tests/ui/dis/issue-723-output.spirt.stderr
+++ b/tests/ui/dis/issue-723-output.spirt.stderr
@@ -1,4 +1,19 @@
-error: invalid character `'.'` in crate name: `issue_723_output.spirt`
-
-error: aborting due to previous error
-
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/issue-723-output.spirt.rs"
+OpName %4 "issue_723_output::main"
+OpDecorate %2 Location 0
+%5 = OpTypeFloat 32
+%6 = OpTypeVector %5 4
+%7 = OpTypePointer Output %6
+%8 = OpTypeVoid
+%9 = OpTypeFunction %8
+%2 = OpVariable  %7  Output

--- a/tests/ui/dis/pass-mode-cast-struct.not_spirt.rs
+++ b/tests/ui/dis/pass-mode-cast-struct.not_spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of pass-mode-cast-struct.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
+#![crate_name = "pass_mode_cast_struct"]
 
 // Test that a small enough `struct` doesn't generate unsupported pointer casts.
 // (Just like `issue-373`, the problem was the use of `PassMode::Cast`, through

--- a/tests/ui/dis/pass-mode-cast-struct.not_spirt.stderr
+++ b/tests/ui/dis/pass-mode-cast-struct.not_spirt.stderr
@@ -1,4 +1,22 @@
-error: invalid character `'.'` in crate name: `pass_mode_cast_struct.not_spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 31 12
+%6 = OpLoad  %7  %8
+OpLine %5 32 14
+%9 = OpFunctionCall  %10  %11 %6
+OpLine %5 33 15
+%12 = OpCompositeExtract  %13  %9 0
+OpLine %5 33 24
+%14 = OpCompositeExtract  %15  %9 1
+OpLine %5 33 32
+%16 = OpCompositeExtract  %15  %9 2
+OpLine %5 33 23
+%17 = OpIAdd  %15  %14 %16
+OpLine %5 33 23
+%18 = OpUConvert  %13  %17
+OpLine %5 33 4
+%19 = OpIAdd  %13  %12 %18
+OpStore %20 %19
+OpLine %5 34 1
+OpReturn
+OpFunctionEnd

--- a/tests/ui/dis/pass-mode-cast-struct.spirt.rs
+++ b/tests/ui/dis/pass-mode-cast-struct.spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of pass-mode-cast-struct.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
+#![crate_name = "pass_mode_cast_struct"]
 
 // Test that a small enough `struct` doesn't generate unsupported pointer casts.
 // (Just like `issue-373`, the problem was the use of `PassMode::Cast`, through

--- a/tests/ui/dis/pass-mode-cast-struct.spirt.stderr
+++ b/tests/ui/dis/pass-mode-cast-struct.spirt.stderr
@@ -1,4 +1,21 @@
-error: invalid character `'.'` in crate name: `pass_mode_cast_struct.spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 31 12
+%6 = OpLoad  %7  %8
+OpLine %5 32 14
+%9 = OpFunctionCall  %10  %11 %6
+OpLine %5 33 15
+%12 = OpCompositeExtract  %13  %9 0
+OpLine %5 33 24
+%14 = OpCompositeExtract  %15  %9 1
+OpLine %5 33 32
+%16 = OpCompositeExtract  %15  %9 2
+OpLine %5 33 23
+%17 = OpIAdd  %15  %14 %16
+%18 = OpUConvert  %13  %17
+OpLine %5 33 4
+%19 = OpIAdd  %13  %12 %18
+OpStore %20 %19
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/ui/lang/core/unwrap_or.not_spirt.rs
+++ b/tests/ui/lang/core/unwrap_or.not_spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of unwrap_or.spirt.rs because only-/ignore- do not work with revisions.
 // only-not_spirt
+#![crate_name = "unwrap_or"]
 
 // unwrap_or generates some memory-bools (as u8). Test to make sure they're fused away.
 // OpINotEqual, as well as %bool, should not appear in the output.

--- a/tests/ui/lang/core/unwrap_or.not_spirt.stderr
+++ b/tests/ui/lang/core/unwrap_or.not_spirt.stderr
@@ -1,4 +1,39 @@
-error: invalid character `'.'` in crate name: `unwrap_or.not_spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 15 11
+%6 = OpCompositeInsert  %7  %8 %9 0
+OpLine %5 15 11
+%10 = OpCompositeExtract  %11  %6 1
+OpLine %12 803 14
+%13 = OpBitcast  %14  %8
+OpLine %12 803 8
+OpSelectionMerge %15 None
+OpSwitch %13 %16 0 %17 1 %18
+%16 = OpLabel
+OpLine %12 803 14
+OpUnreachable
+%17 = OpLabel
+OpLine %12 805 20
+OpBranch %15
+%18 = OpLabel
+OpLine %12 804 23
+OpBranch %15
+%15 = OpLabel
+%19 = OpPhi  %20  %21 %17 %22 %18
+%23 = OpPhi  %11  %24 %17 %10 %18
+OpBranch %25
+%25 = OpLabel
+OpLine %12 807 4
+OpSelectionMerge %26 None
+OpBranchConditional %19 %27 %28
+%27 = OpLabel
+OpLine %12 807 4
+OpBranch %26
+%28 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpLine %5 15 4
+OpStore %29 %23
+OpLine %5 16 1
+OpReturn
+OpFunctionEnd

--- a/tests/ui/lang/core/unwrap_or.not_spirt.stderr
+++ b/tests/ui/lang/core/unwrap_or.not_spirt.stderr
@@ -4,36 +4,32 @@ OpLine %5 15 11
 %6 = OpCompositeInsert  %7  %8 %9 0
 OpLine %5 15 11
 %10 = OpCompositeExtract  %11  %6 1
-OpLine %12 803 14
+OpLine %12 967 14
 %13 = OpBitcast  %14  %8
-OpLine %12 803 8
-OpSelectionMerge %15 None
-OpSwitch %13 %16 0 %17 1 %18
-%16 = OpLabel
-OpLine %12 803 14
-OpUnreachable
-%17 = OpLabel
-OpLine %12 805 20
-OpBranch %15
+OpLine %12 967 8
+%15 = OpIEqual  %16  %13 %17
+OpSelectionMerge %18 None
+OpBranchConditional %15 %19 %20
+%19 = OpLabel
+OpLine %12 969 20
+OpBranch %18
+%20 = OpLabel
+OpLine %12 968 23
+OpBranch %18
 %18 = OpLabel
-OpLine %12 804 23
-OpBranch %15
-%15 = OpLabel
-%19 = OpPhi  %20  %21 %17 %22 %18
-%23 = OpPhi  %11  %24 %17 %10 %18
-OpBranch %25
-%25 = OpLabel
-OpLine %12 807 4
+%21 = OpPhi  %16  %22 %19 %23 %20
+%24 = OpPhi  %11  %25 %19 %10 %20
+OpLine %12 971 4
 OpSelectionMerge %26 None
-OpBranchConditional %19 %27 %28
+OpBranchConditional %21 %27 %28
 %27 = OpLabel
-OpLine %12 807 4
+OpLine %12 971 4
 OpBranch %26
 %28 = OpLabel
 OpBranch %26
 %26 = OpLabel
 OpLine %5 15 4
-OpStore %29 %23
+OpStore %29 %24
 OpLine %5 16 1
 OpReturn
 OpFunctionEnd

--- a/tests/ui/lang/core/unwrap_or.spirt.rs
+++ b/tests/ui/lang/core/unwrap_or.spirt.rs
@@ -1,5 +1,6 @@
 // HACK(eddyb) duplicate of unwrap_or.not_spirt.rs because only-/ignore- do not work with revisions.
 // only-spirt
+#![crate_name = "unwrap_or"]
 
 // unwrap_or generates some memory-bools (as u8). Test to make sure they're fused away.
 // OpINotEqual, as well as %bool, should not appear in the output.

--- a/tests/ui/lang/core/unwrap_or.spirt.stderr
+++ b/tests/ui/lang/core/unwrap_or.spirt.stderr
@@ -1,4 +1,31 @@
-error: invalid character `'.'` in crate name: `unwrap_or.spirt`
-
-error: aborting due to previous error
-
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 15 11
+%6 = OpCompositeInsert  %7  %8 %9 0
+%10 = OpCompositeExtract  %11  %6 1
+OpLine %12 803 14
+%13 = OpBitcast  %14  %8
+OpNoLine
+OpSelectionMerge %15 None
+OpSwitch %13 %16 0 %17 1 %18
+%16 = OpLabel
+OpBranch %15
+%17 = OpLabel
+OpBranch %15
+%18 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%19 = OpPhi  %20  %21 %16 %22 %17 %23 %18
+%24 = OpPhi  %11  %25 %16 %26 %17 %10 %18
+OpSelectionMerge %27 None
+OpBranchConditional %19 %28 %29
+%28 = OpLabel
+OpBranch %27
+%29 = OpLabel
+OpBranch %27
+%27 = OpLabel
+OpLine %5 15 4
+OpStore %30 %24
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/ui/lang/core/unwrap_or.spirt.stderr
+++ b/tests/ui/lang/core/unwrap_or.spirt.stderr
@@ -3,29 +3,29 @@
 OpLine %5 15 11
 %6 = OpCompositeInsert  %7  %8 %9 0
 %10 = OpCompositeExtract  %11  %6 1
-OpLine %12 803 14
+OpLine %12 967 14
 %13 = OpBitcast  %14  %8
+OpLine %12 967 8
+%15 = OpIEqual  %16  %13 %17
 OpNoLine
-OpSelectionMerge %15 None
-OpSwitch %13 %16 0 %17 1 %18
-%16 = OpLabel
-OpBranch %15
-%17 = OpLabel
-OpBranch %15
+OpSelectionMerge %18 None
+OpBranchConditional %15 %19 %20
+%19 = OpLabel
+OpBranch %18
+%20 = OpLabel
+OpBranch %18
 %18 = OpLabel
-OpBranch %15
-%15 = OpLabel
-%19 = OpPhi  %20  %21 %16 %22 %17 %23 %18
-%24 = OpPhi  %11  %25 %16 %26 %17 %10 %18
-OpSelectionMerge %27 None
-OpBranchConditional %19 %28 %29
-%28 = OpLabel
-OpBranch %27
-%29 = OpLabel
-OpBranch %27
+%21 = OpPhi  %16  %22 %19 %23 %20
+%24 = OpPhi  %11  %25 %19 %10 %20
+OpSelectionMerge %26 None
+OpBranchConditional %21 %27 %28
 %27 = OpLabel
+OpBranch %26
+%28 = OpLabel
+OpBranch %26
+%26 = OpLabel
 OpLine %5 15 4
-OpStore %30 %24
+OpStore %29 %24
 OpNoLine
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
* fixes #1026

In order to ensure that the blessed contents haven't changed since the tests were rendered useless, they were initially blessed on top of 3fca36ecb2325e7425f9a2583dcd7c56ef095c3f, and only rebased/re-blessed later (in the second commit).

Before rebasing onto `main`, I did [a diff of all `.stderr` files vs before the `spirt`/`not_spirt` split](https://gist.github.com/eddyb/50c055df2e10756a2704277619e36857) (i.e. against the state just before 3fca36ecb2325e7425f9a2583dcd7c56ef095c3f).

:exclamation::exclamation::exclamation: Since the original test contents are gone on `main`, that diff should be used to review this PR.
<sub>(most changes are either in `OpLine`s, because of the extra lines in tests, or in how SPIR-T changes the orders of definitions/control-flow etc.)