### PR TITLE
fixed SampledImage::sample() fns being unnecessarily marked as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 🛠
 - [PR#1011](https://github.com/EmbarkStudios/rust-gpu/pull/1011) made `NonWritable` all read-only storage buffers (i.e. those typed `&T`, where `T` doesn't have interior mutability)
+- [PR#1029](https://github.com/EmbarkStudios/rust-gpu/pull/1029) fixed SampledImage::sample() fns being unnecessarily marked as unsafe
 
 ### Fixed 🩹
 - [PR#1025](https://github.com/EmbarkStudios/rust-gpu/pull/1025) fixed [#1024](https://github.com/EmbarkStudios/rust-gpu/issues/1024) by keeping checked arithmetic "zombie" `bool`s disjoint from normal `bool` (`false`) consts

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -979,38 +979,29 @@ impl<
     >
 {
     /// Sample texels at `coord` from the sampled image with an implicit lod.
-    ///
-    /// # Safety
-    /// Sampling with a type (`S`) that doesn't match the image's image format
-    /// will result in undefined behaviour.
     #[crate::macros::gpu_only]
-    pub unsafe fn sample<F>(
-        &self,
-        coord: impl ImageCoordinate<F, DIM, ARRAYED>,
-    ) -> SampledType::Vec4
+    pub fn sample<F>(&self, coord: impl ImageCoordinate<F, DIM, ARRAYED>) -> SampledType::Vec4
     where
         F: Float,
     {
         let mut result = Default::default();
-        asm!(
-            "%sampledImage = OpLoad typeof*{1} {1}",
-            "%coord = OpLoad typeof*{2} {2}",
-            "%result = OpImageSampleImplicitLod typeof*{0} %sampledImage %coord",
-            "OpStore {0} %result",
-            in(reg) &mut result,
-            in(reg) self,
-            in(reg) &coord
-        );
+        unsafe {
+            asm!(
+                "%sampledImage = OpLoad typeof*{1} {1}",
+                "%coord = OpLoad typeof*{2} {2}",
+                "%result = OpImageSampleImplicitLod typeof*{0} %sampledImage %coord",
+                "OpStore {0} %result",
+                in(reg) &mut result,
+                in(reg) self,
+                in(reg) &coord
+            );
+        }
         result
     }
 
     /// Sample texels at `coord` from the sampled image with an explicit lod.
-    ///
-    /// # Safety
-    /// Sampling with a type (`S`) that doesn't match the image's image format
-    /// will result in undefined behaviour.
     #[crate::macros::gpu_only]
-    pub unsafe fn sample_by_lod<F>(
+    pub fn sample_by_lod<F>(
         &self,
         coord: impl ImageCoordinate<F, DIM, ARRAYED>,
         lod: f32,
@@ -1019,17 +1010,19 @@ impl<
         F: Float,
     {
         let mut result = Default::default();
-        asm!(
-            "%sampledImage = OpLoad typeof*{1} {1}",
-            "%coord = OpLoad typeof*{2} {2}",
-            "%lod = OpLoad typeof*{3} {3}",
-            "%result = OpImageSampleExplicitLod typeof*{0} %sampledImage %coord Lod %lod",
-            "OpStore {0} %result",
-            in(reg) &mut result,
-            in(reg) self,
-            in(reg) &coord,
-            in(reg) &lod,
-        );
+        unsafe {
+            asm!(
+                "%sampledImage = OpLoad typeof*{1} {1}",
+                "%coord = OpLoad typeof*{2} {2}",
+                "%lod = OpLoad typeof*{3} {3}",
+                "%result = OpImageSampleExplicitLod typeof*{0} %sampledImage %coord Lod %lod",
+                "OpStore {0} %result",
+                in(reg) &mut result,
+                in(reg) self,
+                in(reg) &coord,
+                in(reg) &lod,
+            );
+        }
         result
     }
 }


### PR DESCRIPTION
Seems to be a forgotten leftover from a refactor in https://github.com/EmbarkStudios/rust-gpu/pull/359

---

**EDIT**(@eddyb): removed quoted Discord messages (referring to https://github.com/EmbarkStudios/rust-gpu/commit/bc2a121cca0da4a4020e6630c2e429d85cb4fdf9) in favor of PR comments (see below)