### PR TITLE
Add vector-or-scalar traits

### DIFF
--- a/crates/spirv-std/src/float.rs
+++ b/crates/spirv-std/src/float.rs
@@ -9,17 +9,50 @@ use core::arch::asm;
 /// # Safety
 /// Implementing this trait on non-primitive-float types breaks assumptions of other unsafe code,
 /// and should not be done.
-pub unsafe trait Float: num_traits::Float + crate::scalar::Scalar + Default {
+pub unsafe trait Float: num_traits::Float + crate::scalar::Scalar {
     /// Width of the float, in bits.
     const WIDTH: usize;
 }
 
-unsafe impl Float for f32 {
-    const WIDTH: usize = 32;
+/// Abstract trait representing a SPIR-V floating point type. It may also be a vector type.
+///
+/// # Safety
+/// Implementing this trait on non-primitive-float types breaks assumptions of other unsafe code,
+/// and should not be done.
+pub unsafe trait FloatVector: crate::scalar::ScalarVector {
+    /// Width of the float, in bits.
+    const WIDTH: usize;
 }
 
-unsafe impl Float for f64 {
-    const WIDTH: usize = 64;
+macro_rules! impl_floats {
+    (unsafe impl Float for $($typ:ty)*;) => {
+        $(
+            unsafe impl Float for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+            }
+
+            unsafe impl FloatVector for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+            }
+        )*
+    };
+
+    (unsafe impl FloatVector for $($typ:ty)*;) => {
+        $(
+            unsafe impl FloatVector for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+            }
+        )*
+    };
+
+    ($(unsafe impl $trait:ident for $($typ:ty)*;)+) => {
+        $(impl_floats!(unsafe impl $trait for $($typ)*;);)+
+    };
+}
+
+impl_floats! {
+    unsafe impl Float for f32 f64;
+    unsafe impl FloatVector for glam::Vec2 glam::Vec3 glam::Vec4 glam::DVec2 glam::DVec3 glam::DVec4;
 }
 
 /// Converts two f32 values (floats) into two f16 values (halfs). The result is a u32, with the low

--- a/crates/spirv-std/src/integer.rs
+++ b/crates/spirv-std/src/integer.rs
@@ -12,41 +12,93 @@ pub unsafe trait Integer: num_traits::PrimInt + crate::scalar::Scalar {
     const SIGNED: bool;
 }
 
+/// Abstract trait representing any SPIR-V integer type. It may also be a vector type.
+///
+/// # Safety
+/// Implementing this trait on non-primitive-integer types breaks assumptions of other unsafe code,
+/// and should not be done.
+pub unsafe trait IntegerVector: crate::scalar::ScalarVector {
+    /// Width of the integer, in bits.
+    const WIDTH: usize;
+    /// If the integer is signed: true means signed, false means unsigned.
+    const SIGNED: bool;
+}
+
 /// A trait for being generic over signed integer types.
 pub trait SignedInteger: Integer {}
+/// A trait for being generic over signed integer types. It may also be a vector type.
+pub trait SignedIntegerVector: IntegerVector {}
+
 /// A trait for being generic over unsigned integer types.
 pub trait UnsignedInteger: Integer {}
+/// A trait for being generic over unsigned integer types. It may also be a vector type.
+pub trait UnsignedIntegerVector: IntegerVector {}
 
 macro_rules! impl_numbers {
-    (impl UnsignedInteger for $typ:ty;) => {
-        unsafe impl Integer for $typ {
-            const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
-            const SIGNED: bool = false;
-        }
+    (impl UnsignedInteger for $($typ:ty)*;) => {
+        $(
+            unsafe impl Integer for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+                const SIGNED: bool = false;
+            }
 
-        impl UnsignedInteger for $typ {}
-    };
-    (impl SignedInteger for $typ:ty;) => {
-        unsafe impl Integer for $typ {
-            const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
-            const SIGNED: bool = true;
-        }
+            unsafe impl IntegerVector for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+                const SIGNED: bool = false;
+            }
 
-        impl SignedInteger for $typ {}
-    };
-    ($(impl $trait:ident for $typ:ty;)+) => {
-        $(impl_numbers!(impl $trait for $typ;);)+
+            impl UnsignedInteger for $typ {}
+            impl UnsignedIntegerVector for $typ {}
+        )*
     };
 
+    (impl UnsignedIntegerVector for $($typ:ty)*;) => {
+        $(
+            unsafe impl IntegerVector for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+                const SIGNED: bool = false;
+            }
+
+            impl UnsignedIntegerVector for $typ {}
+        )*
+    };
+
+    (impl SignedInteger for $($typ:ty)*;) => {
+        $(
+            unsafe impl Integer for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+                const SIGNED: bool = true;
+            }
+
+            unsafe impl IntegerVector for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+                const SIGNED: bool = true;
+            }
+
+            impl SignedInteger for $typ {}
+            impl SignedIntegerVector for $typ {}
+        )*
+    };
+
+    (impl SignedIntegerVector for $($typ:ty)*;) => {
+        $(
+            unsafe impl IntegerVector for $typ {
+                const WIDTH: usize = core::mem::size_of::<$typ>() * 8;
+                const SIGNED: bool = true;
+            }
+
+            impl SignedIntegerVector for $typ {}
+        )*
+    };
+
+    ($(impl $trait:ident for $($typ:ty)*;)+) => {
+        $(impl_numbers!(impl $trait for $($typ)*;);)+
+    };
 }
 
 impl_numbers! {
-    impl UnsignedInteger for u8;
-    impl UnsignedInteger for u16;
-    impl UnsignedInteger for u32;
-    impl UnsignedInteger for u64;
-    impl SignedInteger for i8;
-    impl SignedInteger for i16;
-    impl SignedInteger for i32;
-    impl SignedInteger for i64;
+    impl UnsignedInteger for u8 u16 u32 u64;
+    impl UnsignedIntegerVector for glam::UVec2 glam::UVec3 glam::UVec4;
+    impl SignedInteger for i8 i16 i32 i64;
+    impl SignedIntegerVector for glam::IVec2 glam::IVec3 glam::IVec4;
 }

--- a/crates/spirv-std/src/number.rs
+++ b/crates/spirv-std/src/number.rs
@@ -3,13 +3,31 @@
 /// Abstract trait representing a SPIR-V integer or floating-point type.
 pub trait Number: crate::scalar::Scalar {}
 
-impl Number for u8 {}
-impl Number for u16 {}
-impl Number for u32 {}
-impl Number for u64 {}
-impl Number for i8 {}
-impl Number for i16 {}
-impl Number for i32 {}
-impl Number for i64 {}
-impl Number for f32 {}
-impl Number for f64 {}
+/// Abstract trait representing a SPIR-V integer or floating-point type. It may also be a vector type.
+pub trait NumberVector: crate::scalar::ScalarVector {}
+
+macro_rules! impl_numbers {
+    (unsafe impl Number for $($typ:ty)*;) => {
+        $(
+            impl Number for $typ {}
+            impl NumberVector for $typ {}
+        )*
+    };
+
+    (unsafe impl NumberVector for $($typ:ty)*;) => {
+        $(
+            impl NumberVector for $typ {}
+        )*
+    };
+
+    ($(unsafe impl $trait:ident for $($typ:ty)*;)+) => {
+        $(impl_numbers!(unsafe impl $trait for $($typ)*;);)+
+    };
+}
+
+impl_numbers! {
+    unsafe impl Number for u8 u16 u32 u64 i8 i16 i32 i64 f32 f64;
+    unsafe impl NumberVector for glam::Vec2 glam::DVec2 glam::UVec2 glam::IVec2;
+    unsafe impl NumberVector for glam::Vec3 glam::DVec3 glam::UVec3 glam::IVec3;
+    unsafe impl NumberVector for glam::Vec4 glam::DVec4 glam::UVec4 glam::IVec4;
+}

--- a/crates/spirv-std/src/scalar.rs
+++ b/crates/spirv-std/src/scalar.rs
@@ -7,14 +7,47 @@
 /// not be done.
 pub unsafe trait Scalar: Copy + Default + crate::sealed::Sealed {}
 
-unsafe impl Scalar for bool {}
-unsafe impl Scalar for f32 {}
-unsafe impl Scalar for f64 {}
-unsafe impl Scalar for u8 {}
-unsafe impl Scalar for u16 {}
-unsafe impl Scalar for u32 {}
-unsafe impl Scalar for u64 {}
-unsafe impl Scalar for i8 {}
-unsafe impl Scalar for i16 {}
-unsafe impl Scalar for i32 {}
-unsafe impl Scalar for i64 {}
+/// Abstract trait representing a SPIR-V scalar type. It may also be a vector type.
+///
+/// # Safety
+/// Implementing this trait on non-scalar types breaks assumptions of other unsafe code, and should
+/// not be done.
+pub unsafe trait ScalarVector: Copy + Default {
+    /// Dimension of the vector, 1 if it is a scalar
+    const DIM: usize;
+}
+
+macro_rules! impl_scalars {
+    (unsafe impl Scalar for $($typ:ty)*;) => {
+        $(
+            unsafe impl Scalar for $typ {}
+            unsafe impl ScalarVector for $typ {
+                const DIM: usize = 1;
+            }
+        )*
+    };
+
+    (unsafe impl ScalarVector, $num: literal for $($typ:ty)*;) => {
+        $(
+            unsafe impl ScalarVector for $typ {
+                const DIM: usize = $num;
+            }
+        )*
+    };
+}
+
+impl_scalars! {
+    unsafe impl Scalar for bool f32 f64 u8 u16 u32 u64 i8 i16 i32 i64;
+}
+
+impl_scalars! {
+    unsafe impl ScalarVector, 2 for glam::BVec2 glam::Vec2 glam::DVec2 glam::UVec2 glam::IVec2;
+}
+
+impl_scalars! {
+    unsafe impl ScalarVector, 3 for glam::BVec3 glam::Vec3 glam::DVec3 glam::UVec3 glam::IVec3;
+}
+
+impl_scalars! {
+    unsafe impl ScalarVector, 4 for glam::BVec4 glam::Vec4 glam::DVec4 glam::UVec4 glam::IVec4;
+}


### PR DESCRIPTION
This PR adds the traits `ScalarVector`, `NumberVector`, `IntegerVector`, `UnsignedIntegerVector`, `SignedIntegerVector`, `FloatVector`.
This traits can be either a scalar or a vector type. (Not sure how to name them, I'm open for changes there).

Motivation:
I am currently adding support for subgroup operations, and for example `OpGroupNonUniformIAdd`s result type must be scalar or vector of integer type, so it would be useful to have traits that represent types like this.
