### PR TITLE
Support optional number of components on an `Image` to improve public facing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed 🛠
+- [PR#1031](https://github.com/EmbarkStudios/rust-gpu/pull/1031) Added `Components` generic parameter to `Image` type, allowing images to return lower dimensional vectors and even scalars from the sampling API.
 - [PR#1011](https://github.com/EmbarkStudios/rust-gpu/pull/1011) made `NonWritable` all read-only storage buffers (i.e. those typed `&T`, where `T` doesn't have interior mutability)
 - [PR#1029](https://github.com/EmbarkStudios/rust-gpu/pull/1029) fixed SampledImage::sample() fns being unnecessarily marked as unsafe
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",

--- a/crates/spirv-std/macros/src/image.rs
+++ b/crates/spirv-std/macros/src/image.rs
@@ -152,7 +152,7 @@ impl Parse for ImageType {
                     let value = value.unwrap();
                     set_unique!(
                         components = match value.base10_parse() {
-                            Ok(n) if n >= 1 && n <= 4 => n,
+                            Ok(n) if (1..=4).contains(&n) => n,
                             _ =>
                                 return Err(syn::Error::new(
                                     value.span(),

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -1,6 +1,8 @@
 //! Image types
 
 #[cfg(target_arch = "spirv")]
+use crate::vector::VectorTruncateInto;
+#[cfg(target_arch = "spirv")]
 use core::arch::asm;
 
 // Rustfmt formats long marker trait impls over multiple lines which makes them
@@ -14,12 +16,7 @@ pub use spirv_std_types::image_params::{
     AccessQualifier, Arrayed, Dimensionality, ImageDepth, ImageFormat, Multisampled, Sampled,
 };
 
-use crate::{
-    float::Float,
-    integer::Integer,
-    vector::{Vector, VectorTruncateInto},
-    Sampler,
-};
+use crate::{float::Float, integer::Integer, vector::Vector, Sampler};
 
 /// Re-export of primitive types to ensure the `Image` proc macro always points
 /// to the right type.

--- a/crates/spirv-std/src/image/params.rs
+++ b/crates/spirv-std/src/image/params.rs
@@ -1,9 +1,12 @@
 use super::{Arrayed, Dimensionality, ImageFormat};
-use crate::{integer::Integer, scalar::Scalar, vector::Vector};
+use crate::{integer::Integer, scalar::Scalar, vector::Vector, vector::VectorTruncateInto};
 
 /// Marker trait for arguments that accept single scalar values or vectors
 /// of scalars. Defines 2-, 3- and 4-component vector types based on the sample type.
-pub trait SampleType<const FORMAT: u32>: Scalar {
+pub trait SampleType<const FORMAT: u32, const COMPONENTS: u32>: Scalar {
+    /// The default vector/scalar of ths sample type
+    type SampleResult: Default;
+
     /// A 2-component vector of this sample type
     type Vec2: Default;
 
@@ -11,74 +14,134 @@ pub trait SampleType<const FORMAT: u32>: Scalar {
     type Vec3: Default;
 
     /// A 4-component vector of this sample type
-    type Vec4: Default;
+    type Vec4: Default + VectorTruncateInto<Self::SampleResult>;
 }
 
 /// Helper macro to implement `SampleType` of various formats for various scalar types.
 macro_rules! sample_type_impls {
-    ($($fmt:ident : $s:ty => ($v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
+    ($($fmt:ident : $n:tt*$s:ty => ($v1:ty, $v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
+        $(sample_type_impls!{@single_rule, $fmt : $n*$s => ($v1,$v2,$v3,$v4)})+
+    };
+    (@single_rule, $fmt:ident : n*$s:ty => ($v1:ty, $v2:ty, $v3:ty, $v4:ty)) => {
+        impl SampleType<{ ImageFormat::$fmt as u32 }, 1> for $s {
+            type SampleResult = $v1;
+            type Vec2 = $v2;
+            type Vec3 = $v3;
+            type Vec4 = $v4;
+        }
+        impl SampleType<{ ImageFormat::$fmt as u32 }, 2> for $s {
+            type SampleResult = $v2;
+            type Vec2 = $v2;
+            type Vec3 = $v3;
+            type Vec4 = $v4;
+        }
+        impl SampleType<{ ImageFormat::$fmt as u32 }, 3> for $s {
+            type SampleResult = $v3;
+            type Vec2 = $v2;
+            type Vec3 = $v3;
+            type Vec4 = $v4;
+        }
+        impl SampleType<{ ImageFormat::$fmt as u32 }, 4> for $s {
+            type SampleResult = $v4;
+            type Vec2 = $v2;
+            type Vec3 = $v3;
+            type Vec4 = $v4;
+        }
+    };
+    (@single_rule, $($fmt:ident : 1*$s:ty => ($v1:ty, $v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
         $(
-            impl SampleType<{ ImageFormat::$fmt as u32 }> for $s {
+            impl SampleType<{ ImageFormat::$fmt as u32 }, 1> for $s {
+                type SampleResult = $v1;
                 type Vec2 = $v2;
                 type Vec3 = $v3;
                 type Vec4 = $v4;
             }
         )+
-    }
+    };
+    (@single_rule, $($fmt:ident : 2*$s:ty => ($v1:ty, $v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
+        $(
+            impl SampleType<{ ImageFormat::$fmt as u32 }, 2> for $s {
+                type SampleResult = $v2;
+                type Vec2 = $v2;
+                type Vec3 = $v3;
+                type Vec4 = $v4;
+            }
+        )+
+    };
+    (@single_rule, $($fmt:ident : 3*$s:ty => ($v1:ty, $v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
+        $(
+            impl SampleType<{ ImageFormat::$fmt as u32 }, 3> for $s {
+                type SampleResult = $v3;
+                type Vec2 = $v2;
+                type Vec3 = $v3;
+                type Vec4 = $v4;
+            }
+        )+
+    };
+    (@single_rule, $($fmt:ident : 4*$s:ty => ($v1:ty, $v2:ty, $v3:ty, $v4:ty)),+ $(,)?) => {
+        $(
+            impl SampleType<{ ImageFormat::$fmt as u32 }, 4> for $s {
+                type SampleResult = $v4;
+                type Vec2 = $v2;
+                type Vec3 = $v3;
+                type Vec4 = $v4;
+            }
+        )+
+    };
 }
 
 sample_type_impls! {
-    Unknown: i8 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Unknown: i16 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Unknown: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Unknown: i64 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Unknown: u8 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Unknown: u16 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Unknown: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Unknown: u64 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Unknown: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Unknown: f64 => (glam::DVec2, glam::DVec3, glam::DVec4),
-    Rgba32f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rgba16f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    R32f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rgba8: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rgba8Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rg32f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rg16f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    R11fG11fB10f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    R16f: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rgba16: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rgb10A2: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rg16: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rg8: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    R16: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    R8: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rgba16Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rg16Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rg8Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    R16Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    R8Snorm: f32 => (glam::Vec2, glam::Vec3, glam::Vec4),
-    Rgba32i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Rgba16i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Rgba8i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    R32i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Rg32i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Rg16i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Rg8i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    R16i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    R8i: i32 => (glam::IVec2, glam::IVec3, glam::IVec4),
-    Rgba32ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Rgba16ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Rgba8ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    R32ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Rgb10A2ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Rg32ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Rg16ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    Rg8ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    R16ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    R8ui: u32 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    R64ui: u64 => (glam::UVec2, glam::UVec3, glam::UVec4),
-    R64i: i64 => (glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: n*i8 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: n*i16 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: n*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: n*i64 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Unknown: n*u8 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: n*u16 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: n*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: n*u64 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Unknown: n*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Unknown: n*f64 => (f64, glam::DVec2, glam::DVec3, glam::DVec4),
+    Rgba32f: 4*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba16f: 4*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    R32f: 1*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba8: 4*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba8Snorm: 4*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg32f: 2*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg16f: 2*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    R11fG11fB10f: 3*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    R16f: 1*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba16: 4*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgb10A2: 4*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg16: 2*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg8: 2*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    R16: 1*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    R8: 1*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba16Snorm: 4*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg16Snorm: 2*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rg8Snorm: 2*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    R16Snorm: 1*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    R8Snorm: 1*f32 => (f32, glam::Vec2, glam::Vec3, glam::Vec4),
+    Rgba32i: 4*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Rgba16i: 4*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Rgba8i: 4*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    R32i: 1*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Rg32i: 2*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Rg16i: 2*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Rg8i: 2*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    R16i: 1*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    R8i: 1*i32 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
+    Rgba32ui: 4*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Rgba16ui: 4*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Rgba8ui: 4*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    R32ui: 1*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Rgb10A2ui: 4*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Rg32ui: 2*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Rg16ui: 2*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    Rg8ui: 2*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    R16ui: 1*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    R8ui: 1*u32 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    R64ui: 1*u64 => (u32, glam::UVec2, glam::UVec3, glam::UVec4),
+    R64i: 1*i64 => (i32, glam::IVec2, glam::IVec3, glam::IVec4),
 }
 
 /// Marker trait for arguments that accept a coordinate for an [`crate::Image`].

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -1,5 +1,7 @@
 //! Traits related to vectors.
 
+use glam::{Vec3Swizzles, Vec4Swizzles};
+
 /// Abstract trait representing a SPIR-V vector type.
 ///
 /// # Safety
@@ -23,3 +25,42 @@ unsafe impl Vector<u32, 4> for glam::UVec4 {}
 unsafe impl Vector<i32, 2> for glam::IVec2 {}
 unsafe impl Vector<i32, 3> for glam::IVec3 {}
 unsafe impl Vector<i32, 4> for glam::IVec4 {}
+
+/// Trait that implements slicing of a vector into a scalar or vector of lower dimensions, by
+/// ignoring the highter dimensions
+pub trait VectorTruncateInto<T> {
+    /// Slices the vector into a lower dimensional type by ignoring the higher components
+    fn truncate_into(self) -> T;
+}
+
+macro_rules! vec_trunc_impl {
+    ($a:ty, $b:ty, $self:ident $(.$($e:tt)*)?) => {
+        impl VectorTruncateInto<$a> for $b {
+            fn truncate_into($self) -> $a {
+                $self $(. $($e)*)?
+            }
+        }
+    };
+}
+macro_rules! vec_trunc_impls {
+    ($s:ty, $v2:ty, $v3:ty, $v4:ty) => {
+        vec_trunc_impl! {$s, $s, self}
+        vec_trunc_impl! {$s, $v2, self.x}
+        vec_trunc_impl! {$s, $v3, self.x}
+        vec_trunc_impl! {$s, $v4, self.x}
+
+        vec_trunc_impl! {$v2, $v2, self}
+        vec_trunc_impl! {$v2, $v3, self.xy()}
+        vec_trunc_impl! {$v2, $v4, self.xy()}
+
+        vec_trunc_impl! {$v3, $v3, self}
+        vec_trunc_impl! {$v3, $v4, self.xyz()}
+
+        vec_trunc_impl! {$v4, $v4, self}
+    };
+}
+
+vec_trunc_impls! { f32, glam::Vec2, glam::Vec3, glam::Vec4 }
+vec_trunc_impls! { f64, glam::DVec2, glam::DVec3, glam::DVec4 }
+vec_trunc_impls! { i32, glam::IVec2, glam::IVec3, glam::IVec4 }
+vec_trunc_impls! { u32, glam::UVec2, glam::UVec3, glam::UVec4 }

--- a/tests/ui/image/components.rs
+++ b/tests/ui/image/components.rs
@@ -1,0 +1,30 @@
+// build-pass
+// compile-flags: -Ctarget-feature=+StorageImageExtendedFormats
+
+use glam::{Vec2, Vec3, Vec4};
+use spirv_std::spirv;
+use spirv_std::{arch, Image};
+
+#[spirv(fragment)]
+pub fn main(
+    #[spirv(descriptor_set = 0, binding = 0)] image1: &Image!(2D, type=f32, sampled, components=1),
+    #[spirv(descriptor_set = 0, binding = 1)] image2: &Image!(2D, type=f32, sampled, components=2),
+    #[spirv(descriptor_set = 0, binding = 2)] image3: &Image!(2D, type=f32, sampled, components=3),
+    #[spirv(descriptor_set = 0, binding = 3)] image4: &Image!(2D, type=f32, sampled),
+    #[spirv(descriptor_set = 0, binding = 4)] image2_implied: &Image!(2D, format = rg16f, sampled),
+    #[spirv(descriptor_set = 0, binding = 5)] image3_implied: &Image!(
+        2D,
+        format = r11f_g11f_b10f,
+        sampled
+    ),
+    output: &mut glam::Vec4,
+) {
+    let coords = glam::IVec2::new(0, 1);
+    let t1: f32 = image1.fetch(coords);
+    let t2: Vec2 = image2.fetch(coords);
+    let t3: Vec3 = image3.fetch(coords);
+    let t4: Vec4 = image4.fetch(coords);
+    let t5: Vec2 = image2_implied.fetch(coords);
+    let t6: Vec3 = image3_implied.fetch(coords);
+    *output = Vec4::splat(t1) + ((t2 + t5).extend(0.0) + t3 + t6).extend(0.0) + t4;
+}

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:198:15
+   --> $SPIRV_STD_SRC/image.rs:195:15
     |
-198 |         Self: HasGather,
+195 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
@@ -25,9 +25,9 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:198:15
+   --> $SPIRV_STD_SRC/image.rs:195:15
     |
-198 |         Self: HasGather,
+195 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -1,34 +1,34 @@
-error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0>: HasGather` is not satisfied
+error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
    --> $DIR/gather_err.rs:15:34
     |
 15  |     let r1: glam::Vec4 = image1d.gather(*sampler, 0.0f32, 0);
-    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 0, 2, 0, 0, 1, 0>`
+    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 0, 2, 0, 0, 1, 0, 4>`
     |
     = help: the following other types implement trait `HasGather`:
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:167:15
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
+   --> $SPIRV_STD_SRC/image.rs:198:15
     |
-167 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
+198 |         Self: HasGather,
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
-error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0>: HasGather` is not satisfied
+error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
    --> $DIR/gather_err.rs:16:34
     |
 16  |     let r2: glam::Vec4 = image3d.gather(*sampler, v3, 0);
-    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 2, 2, 0, 0, 1, 0>`
+    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 2, 2, 0, 0, 1, 0, 4>`
     |
     = help: the following other types implement trait `HasGather`:
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
-   --> $SPIRV_STD_SRC/image.rs:167:15
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
+   --> $SPIRV_STD_SRC/image.rs:198:15
     |
-167 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT>::gather`
+198 |         Self: HasGather,
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -1,7 +1,7 @@
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::deeper_stack
           implicit_not_in_fragment::deep_stack
           implicit_not_in_fragment::main
@@ -10,7 +10,7 @@ error: ImageSampleImplicitLod cannot be used outside a fragment shader
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0>>::sample::<f32, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::main
           main
 

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -1,19 +1,19 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` is not satisfied
    --> $DIR/query_levels_err.rs:12:21
     |
 12  |     *output = image.query_levels();
-    |                     ^^^^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0>`
+    |                     ^^^^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
     |
     = help: the following other types implement trait `HasQueryLevels`:
-              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:817:15
+              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
+   --> $SPIRV_STD_SRC/image.rs:882:15
     |
-817 |         Self: HasQueryLevels,
-    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_levels`
+882 |         Self: HasQueryLevels,
+    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
 
 error: aborting due to previous error
 

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:882:15
+   --> $SPIRV_STD_SRC/image.rs:879:15
     |
-882 |         Self: HasQueryLevels,
+879 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -1,19 +1,19 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQueryLevels` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` is not satisfied
    --> $DIR/query_lod_err.rs:13:21
     |
 13  |     *output = image.query_lod(*sampler, glam::Vec2::new(0.0, 1.0));
-    |                     ^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0>`
+    |                     ^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
     |
     = help: the following other types implement trait `HasQueryLevels`:
-              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:843:15
+              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
+   --> $SPIRV_STD_SRC/image.rs:908:15
     |
-843 |         Self: HasQueryLevels,
-    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_lod`
+908 |         Self: HasQueryLevels,
+    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
 
 error: aborting due to previous error
 

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:908:15
+   --> $SPIRV_STD_SRC/image.rs:905:15
     |
-908 |         Self: HasQueryLevels,
+905 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -1,24 +1,24 @@
-error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0>: HasQuerySize` is not satisfied
+error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4>: HasQuerySize` is not satisfied
    --> $DIR/query_size_err.rs:12:21
     |
 12  |     *output = image.query_size();
-    |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0>`
+    |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0, 4>`
     |
     = help: the following other types implement trait `HasQuerySize`:
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT>
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT>
-              Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT>
-              Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT>
+              Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
+              Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
+              Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
+              Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
+              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
             and 6 others
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:874:15
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
+   --> $SPIRV_STD_SRC/image.rs:939:15
     |
-874 |         Self: HasQuerySize,
-    |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT>::query_size`
+939 |         Self: HasQuerySize,
+    |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
 
 error: aborting due to previous error
 

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -15,9 +15,9 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4>: HasQuerySize` is
               Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
             and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:939:15
+   --> $SPIRV_STD_SRC/image.rs:936:15
     |
-939 |         Self: HasQuerySize,
+936 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod`
               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:983:15
+   --> $SPIRV_STD_SRC/image.rs:980:15
     |
-983 |         Self: HasQuerySizeLod,
+980 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -1,19 +1,19 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0>: HasQuerySizeLod` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod` is not satisfied
    --> $DIR/query_size_lod_err.rs:12:21
     |
 12  |     *output = image.query_size_lod(0);
-    |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0>`
+    |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
     |
     = help: the following other types implement trait `HasQuerySizeLod`:
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:907:15
+              Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
+   --> $SPIRV_STD_SRC/image.rs:983:15
     |
-907 |         Self: HasQuerySizeLod,
-    |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT>::query_size_lod`
+983 |         Self: HasQuerySizeLod,
+    |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
 
 error: aborting due to previous error
 

--- a/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
+++ b/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
@@ -19,7 +19,7 @@ warning: redundant storage class attribute, storage class is deduced from type
 9 |     #[spirv(uniform_constant)] warning: &Image!(2D, type=f32),
   |             ^^^^^^^^^^^^^^^^
 
-error: entry parameter type must be by-reference: `&spirv_std::image::Image<f32, 1, 2, 0, 0, 0, 0>`
+error: entry parameter type must be by-reference: `&spirv_std::image::Image<f32, 1, 2, 0, 0, 0, 0, 4>`
   --> $DIR/bad-deduce-storage-class.rs:15:27
    |
 15 | pub fn issue_585(invalid: Image!(2D, type=f32)) {}


### PR DESCRIPTION
This PR adds a `components` parameter to the `Image` type and `Image!` macro. The value (in range `1..=4`) is implied for any specified format other than `unknown`, and can be explicitely specified when used together with the `type` argument (when omitted, it defaults to 4, which makes it backwards compatible with old code).

This causes the relevant image sampling functions, such as `fetch()`, `sample()`, and `read()`, to return a scalar or vector with those exact number of dimensions, rather than always a 4d vector.

Example usage:
```rust
#[spirv(fragment)]
pub fn main(
    #[spirv(descriptor_set = 0, binding = 0)] image1: &Image!(2D, type=f32, sampled, components=1),
    #[spirv(descriptor_set = 0, binding = 1)] image2: &Image!(2D, type=f32, sampled, components=2),
    #[spirv(descriptor_set = 0, binding = 2)] image3: &Image!(2D, type=f32, sampled, components=3),
    #[spirv(descriptor_set = 0, binding = 3)] image4: &Image!(2D, type=f32, sampled),
    #[spirv(descriptor_set = 0, binding = 4)] image2_implied: &Image!(2D, format=rg16f, sampled),
    #[spirv(descriptor_set = 0, binding = 5)] image3_implied: &Image!(2D, format=r11f_g11f_b10f, sampled),
    output: &mut glam::Vec4,
) {
    let coords = glam::IVec2::new(0, 1);
    let t1 = image1.fetch(coords);         // f32
    let t2 = image2.fetch(coords);         // Vec2
    let t3 = image3.fetch(coords);         // Vec3
    let t4 = image4.fetch(coords);         // Vec4
    let t5 = image2_implied.fetch(coords); // Vec2
    let t6 = image3_implied.fetch(coords); // Vec3
    *output = Vec4::splat(t1) + ((t2 + t5).extend(0.0) + t3 + t6).extend(0.0) + t4;
}
```