### PR TITLE
example-runner-wgpu: bump `android_logger` to unbreak Android logging.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,15 +79,15 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_log-sys"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+checksum = "27f0fc03f560e1aebde41c2398b691cb98b5ea5996a6184a7a67bbbb77448969"
 
 [[package]]
 name = "android_logger"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8619b80c242aa7bd638b5c7ddd952addeecb71f69c75e33f1d47b2804f8f883a"
+checksum = "3fa490e751f3878eb9accb9f18988eca52c2337ce000a8bf31ef50d4c723ca9e"
 dependencies = [
  "android_log-sys",
  "env_logger",

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -32,7 +32,7 @@ env_logger = "0.10.0"
 spirv-builder = { workspace = true, features = ["watch"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.11.0"
+android_logger = "0.13.0"
 # NOTE(eddyb) `winit` feature `android-native-activity` is always enabled above,
 # to avoid specifying the dependency twice, but only applies to android builds.
 

--- a/examples/runners/wgpu/src/graphics.rs
+++ b/examples/runners/wgpu/src/graphics.rs
@@ -378,7 +378,7 @@ pub fn start(
         if #[cfg(target_os = "android")] {
             android_logger::init_once(
                 android_logger::Config::default()
-                    .with_min_level("info".parse().unwrap()),
+                    .with_max_level("info".parse().unwrap()),
             );
 
             use winit::platform::android::EventLoopBuilderExtAndroid;


### PR DESCRIPTION
I don't fully understand what was wrong with this before, but it acted like `== Info` instead of `>= Info` or `<= Info` (neither warn/error *nor* debug/trace, were present, and this seems impossible given the code of `android_logger 0.11.3`, but maybe it was doing both `<= Info` and `>= Info`, just in two different places?).


With this PR, warn/error logging can also be seen, and I get this on my Android-based VR headset:
```
--------- beginning of main
04-14 14:43:25.916 11925 11925 I ple_runner_wgp: Late-enabling -Xcheck:jni
04-14 14:43:25.951 11925 11925 E ple_runner_wgp: Unknown bits set in runtime_flags: 0x8000
04-14 14:43:25.995 11925 11925 W System  : ClassLoader referenced unknown path: 
04-14 14:43:26.047 11925 11950 D vulkan  : searching for layers in '/data/app/rust.example_runner_wgpu-bfL6xwGnSgxGZ0IesoqcBg==/lib/arm64'
04-14 14:43:26.048 11925 11925 D android_activity::nat..: Start: 0x7a6cc648c0
04-14 14:43:26.048 11925 11950 D vulkan  : searching for layers in '/data/app/rust.example_runner_wgpu-bfL6xwGnSgxGZ0IesoqcBg==/base.apk!/lib/arm64-v8a'
04-14 14:43:26.048 11925 11950 I wgpu_hal::vulkan::ins..: Unable to find extension: VK_EXT_debug_utils
04-14 14:43:26.048 11925 11950 W wgpu_hal::vulkan::ins..: Unable to find layer: VK_LAYER_KHRONOS_validation
04-14 14:43:26.051 11925 11925 W Thread-1: type=1400 audit(0.0:321): avc: denied { ioctl } for path="/dev/kgsl-3d0" dev="tmpfs" ino=1206 ioctlcmd=0x958 scontext=u:r:untrusted_app:s0:c94,c256,c512,c768 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=0
04-14 14:43:26.052 11925 11950 I AdrenoVK-0: ===== BEGIN DUMP OF OVERRIDDEN SETTINGS =====
04-14 14:43:26.052 11925 11950 I AdrenoVK-0: ===== END DUMP OF OVERRIDDEN SETTINGS =====
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: QUALCOMM build          : d66bb48e17, I18aabff2be
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Build Date              : 11/28/22
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Shader Compiler Version : E031.41.07.00
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Local Branch            : 
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Remote Branch           : refs/tags/AU_LINUX_ANDROID_LA.UM.8.12.C3.10.00.00.670.284
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Remote Branch           : NONE
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Reconstruct Branch      : NOTHING
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Build Config            : S P 8.0.12 AArch64
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Driver Path             : /vendor/lib64/hw/vulkan.kona.so
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Driver Version          : 0687.0
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: PFP                     : 0x016dd110
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: ME                      : 0x00000000
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Application Name    : wgpu
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Application Version : 0x00000001
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Engine Name         : wgpu-hal
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Engine Version      : 0x00000002
04-14 14:43:26.054 11925 11950 I AdrenoVK-0: Api Version         : 0x004030ee
04-14 14:43:26.054 11925 11950 I wgpu_hal::vulkan::ins..: Instance version: 0x401000
04-14 14:43:26.054 11925 11950 I wgpu_hal::vulkan::ins..: Enabling device properties2
04-14 14:43:26.057 11925 11950 I wgpu_core::instance: Adapter Vulkan AdapterInfo { name: "Adreno (TM) 650", vendor: 20803, device: 100990978, device_type: IntegratedGpu, driver: "Qualcomm Technologies Inc. Adreno Vulkan Driver", driver_info: "Driver Build: d66bb48e17, I18aabff2be, 1669663408\nDate: 11/28/22\nCompiler Version: E031.41.07.00\nDriver Branch: \n", backend: Vulkan }
04-14 14:43:26.057 11925 11950 W wgpu_core::instance: Missing downlevel flags: SURFACE_VIEW_FORMATS
04-14 14:43:26.057 11925 11950 W wgpu_core::instance: The underlying API or device in use does not support enough features to be a fully compliant implementation of WebGPU. A subset of the features can still be used. If you are running this program on native and not in a browser and wish to limit the features you use to the supported subset, call Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current platform supports.
04-14 14:43:26.057 11925 11950 I wgpu_core::instance: DownlevelCapabilities {
04-14 14:43:26.057 11925 11950 I wgpu_core::instance:     flags: COMPUTE_SHADERS | FRAGMENT_WRITABLE_STORAGE | INDIRECT_EXECUTION | BASE_VERTEX | READ_ONLY_DEPTH_STENCIL | NON_POWER_OF_TWO_MIPMAPPED_TEXTURES | CUBE_ARRAY_TEXTURES | COMPARISON_SAMPLERS | INDEPENDENT_BLEND | VERTEX_STORAGE | ANISOTROPIC_FILTERING | FRAGMENT_STORAGE | MULTISAMPLED_SHADING | DEPTH_TEXTURE_AND_BUFFER_COPIES | WEBGPU_TEXTURE_FORMAT_SUPPORT | BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED | UNRESTRICTED_INDEX_BUFFER | FULL_DRAW_INDEX_UINT32 | DEPTH_BIAS_CLAMP | VIEW_FORMATS | UNRESTRICTED_EXTERNAL_TEXTURE_COPIES,
04-14 14:43:26.057 11925 11950 I wgpu_core::instance:     limits: DownlevelLimits,
04-14 14:43:26.057 11925 11950 I wgpu_core::instance:     shader_model: Sm5,
04-14 14:43:26.057 11925 11950 I wgpu_core::instance: }
04-14 14:43:26.057 11925 11950 D wgpu_hal::vulkan::ada..: Supported extensions: ["VK_KHR_swapchain", "VK_KHR_image_format_list", "VK_KHR_imageless_framebuffer", "VK_KHR_driver_properties", "VK_KHR_timeline_semaphore", "VK_EXT_image_robustness", "VK_EXT_robustness2"]
04-14 14:43:26.059 11925 11950 W wgpu_hal::vulkan: Unrecognized device error ERROR_INITIALIZATION_FAILED
04-14 14:43:26.059 11925 11950 E wgpu::backend::direct: Error in Adapter::request_device: Not enough memory left
04-14 14:43:26.059 11925 11949 I RustStdoutStderr: thread '<unnamed>' panicked at 'Failed to create device: RequestDeviceError', examples/runners/wgpu/src/graphics.rs:89:10
04-14 14:43:26.059 11925 11949 I RustStdoutStderr: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
04-14 14:43:26.059 11925 11950 I wgpu_core::hub: Dropping Global
```

There's still a bunch of wonkery here, `Not enough memory left` should be "device lost" or something instead, or `ERROR_INITIALIZATION_FAILED` be used as indication that a fallback should be used, etc.

The explanation for why there is even an error is that `VK_KHR_timeline_semaphore` is broken in AdrenoVK on this headset (Oculus Quest 2) with the latest update, because the userspace AdrenoVK component advertises it but it's blocked by SELinux(?) - the `path="/dev/kgsl-3d0" ... ioctlcmd=0x958` message, which [AFAICT is `IOCTL_KGSL_TIMELINE_CREATE`](https://sourcegraph.com/search?q=context:global+KGSL_IOC_TYPE%2C+0x58&patternType=standard&sm=1).

I am also not the first to run into this, e.g.: https://communityforums.atmeta.com/t5/Quest-Development/Issue-with-VK-KHR-timeline-semaphore/td-p/1027690

By locally patching `wgpu` (**not included in this PR**), I was able to get this:

https://user-images.githubusercontent.com/77424/232193906-e92e19b4-d52f-4608-915d-c5f53414770e.mp4