### PR TITLE
[WIP] mouse shader example on android w/ touch

### DIFF
--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -214,7 +214,7 @@ fn maybe_watch(
 #[derive(StructOpt, Clone)]
 #[structopt(name = "example-runner-wgpu")]
 pub struct Options {
-    #[structopt(short, long, default_value = "Sky")]
+    #[structopt(short, long, default_value = "Mouse")]
     shader: RustGPUShader,
 
     #[structopt(long)]


### PR DESCRIPTION
Blocked on:
* ~~https://github.com/EmbarkStudios/rust-gpu/pull/1033~~
  * ~~Android logging fixes + some backstory~~
* https://github.com/EmbarkStudios/rust-gpu/pull/1018
  * to get the mouse shader working via naga
* https://github.com/gfx-rs/wgpu/pull/3693
  * to unbreak `wgpu` on the Oculus Quest 2

https://user-images.githubusercontent.com/77424/232196155-a932912f-d1f2-4bfa-a0c0-4b356fa82ac2.mp4

<br>
Looking at it, this shader should probably just have an extra bit to control whether to show the "cursor" UI at all (but this isn't something shadertoy ever accounted for, and my data model here mostly matches theirs).