### PR TITLE
spirv-builder: force a single CGU (codegen-unit).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added ⭐
+- [PR#1031](https://github.com/EmbarkStudios/rust-gpu/pull/1031) added `Components` generic parameter to `Image` type, allowing images to return lower dimensional vectors and even scalars from the sampling API
+
 ### Changed 🛠
-- [PR#1031](https://github.com/EmbarkStudios/rust-gpu/pull/1031) Added `Components` generic parameter to `Image` type, allowing images to return lower dimensional vectors and even scalars from the sampling API.
+- [PR#1035](https://github.com/EmbarkStudios/rust-gpu/pull/1035) reduced the number of CGUs ("codegen units") used by `spirv-builder` to just `1`
 - [PR#1011](https://github.com/EmbarkStudios/rust-gpu/pull/1011) made `NonWritable` all read-only storage buffers (i.e. those typed `&T`, where `T` doesn't have interior mutability)
 - [PR#1029](https://github.com/EmbarkStudios/rust-gpu/pull/1029) fixed SampledImage::sample() fns being unnecessarily marked as unsafe
 

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -578,6 +578,16 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         join_checking_for_separators(rustflags, "\x1f"),
     );
 
+    let profile_in_env_var = profile.replace('-', "_").to_ascii_uppercase();
+
+    // NOTE(eddyb) there's no parallelism to take advantage of multiple CGUs,
+    // and inter-CGU duplication can be wasteful, so this forces 1 CGU for now.
+    let num_cgus = 1;
+    cargo.env(
+        format!("CARGO_PROFILE_{profile_in_env_var}_CODEGEN_UNITS"),
+        num_cgus.to_string(),
+    );
+
     let build = cargo
         .stderr(Stdio::inherit())
         .current_dir(&builder.path_to_crate)


### PR DESCRIPTION
The main reason `rustc` has a concept of "codegen units" is to allow running LLVM optimizations in parallel.
We have no such parallelism right now, so all CGUs do for us is cause wasteful duplication of work.
(this came up in other work where it caused a massive explosion of debuginfo)

I ran this to get the data in the table below (both before and after the change):
```sh
rm -rf target/spirv-builder/
cargo run -p example-runner-wgpu --release --no-default-features --features use-installed-tools -- -s Mouse
dust -csbrn10 target/spirv-builder/spirv-unknown-vulkan1.1
```

<table>
<tr><th>Before this PR (many CGUs)</th><th>After this PR (1 CGU)</th></tr>
<tr><td>
<pre>128M └─┬ spirv-unknown-vulkan1.1
128M   └─┬ release
117M     ├─┬ deps
 44M     │ ├── libcore-f3590347654738e9.rlib
 38M     │ ├── libcore-f3590347654738e9.rmeta
6.2M     │ ├── libglam-07642c7dac08746c.rlib
5.9M     │ └── libglam-07642c7dac08746c.rmeta
 10M     └─┬ incremental
7.9M       └─┬ spirv_std-3rzoyk5mydowb
7.9M         └─┬ s-gk2fjiu00l-scpc61-tw2x301r7v8h
5.5M           └── dep-graph.bin
</pre>
</td><td>
<pre>123M └─┬ spirv-unknown-vulkan1.1
123M   └─┬ release
112M     ├─┬ deps
 43M     │ ├── libcore-b338bddeac41658a.rlib
 38M     │ ├── libcore-b338bddeac41658a.rmeta
6.2M     │ ├── libglam-3dba180d0288b28f.rlib
5.9M     │ └── libglam-3dba180d0288b28f.rmeta
 10M     └─┬ incremental
7.8M       └─┬ spirv_std-3dftucm2yp1ij
7.8M         └─┬ s-gk2fozx3vf-108z0x5-3fc8kftdgx7kt
5.5M           └── dep-graph.bin
</pre>
</td></tr>
</table>