### PR TITLE
example-runner-wgpu: add `--force-spirv-passthru` and rely on it for `debugPrintf`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added ⭐
+- [PR#1036](https://github.com/EmbarkStudios/rust-gpu/pull/1036) added a `--force-spirv-passthru` flag to `example-runner-wgpu`, to bypass Naga (`wgpu`'s shader translator),
+  used it to test `debugPrintf` for `wgpu`,  and updated `ShaderPanicStrategy::DebugPrintfThenExit` docs to reflect what "enabling `debugPrintf`" looks like for `wgpu`  
+  <sub><sup>(e.g. `VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation VK_LAYER_ENABLES=VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT DEBUG_PRINTF_TO_STDOUT=1`)</sup></sub>
 - [PR#1080](https://github.com/EmbarkStudios/rust-gpu/pull/1080) added `debugPrintf`-based
   panic reporting, with the desired behavior selected via `spirv_builder::ShaderPanicStrategy`
   (see its documentation for more details about each available panic handling strategy)

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -2648,7 +2648,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             // HACK(eddyb) redirect any possible panic call to an abort, to avoid
             // needing to materialize `&core::panic::Location` or `format_args!`.
             // FIXME(eddyb) find a way to extract the original message.
-            self.abort_with_message("panic!(...)".into());
+            self.abort_with_message("panicked: <unknown message>".into());
             self.undef(result_type)
         } else if let Some(mode) = buffer_load_intrinsic {
             self.codegen_buffer_load_intrinsic(result_type, args, mode)

--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -339,7 +339,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
     }
 
     fn abort(&mut self) {
-        self.abort_with_message("intrinsics::abort()".into());
+        self.abort_with_message("aborted: intrinsics::abort() called".into());
     }
 
     fn assume(&mut self, _val: Self::Value) {

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -211,8 +211,6 @@ pub fn compile_shaders() -> Vec<SpvFile> {
 
     SpirvBuilder::new("examples/shaders/sky-shader", "spirv-unknown-vulkan1.1")
         .print_metadata(MetadataPrintout::None)
-        // HACK(eddyb) having the `ash` runner do this is the easiest way I found
-        // to test this `panic!` feature with actual `debugPrintf` support.
         .shader_panic_strategy(spirv_builder::ShaderPanicStrategy::DebugPrintfThenExit {
             print_inputs: true,
             print_backtrace: true,
@@ -380,10 +378,10 @@ impl RenderBase {
         };
 
         let device: ash::Device = {
-            let mut device_extension_names_raw = vec![khr::Swapchain::name().as_ptr()];
-            if options.debug_layer {
-                device_extension_names_raw.push(vk::KhrShaderNonSemanticInfoFn::name().as_ptr());
-            }
+            let device_extension_names_raw = [
+                khr::Swapchain::name().as_ptr(),
+                vk::KhrShaderNonSemanticInfoFn::name().as_ptr(),
+            ];
             let features = vk::PhysicalDeviceFeatures {
                 shader_clip_distance: 1,
                 ..Default::default()

--- a/examples/runners/wgpu/src/graphics.rs
+++ b/examples/runners/wgpu/src/graphics.rs
@@ -1,6 +1,5 @@
-use crate::maybe_watch;
+use crate::{maybe_watch, CompiledShaderModules, Options};
 
-use super::Options;
 use shared::ShaderConstants;
 use winit::{
     event::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent},
@@ -34,9 +33,9 @@ fn mouse_button_index(button: MouseButton) -> usize {
 
 async fn run(
     options: Options,
-    event_loop: EventLoop<wgpu::ShaderModuleDescriptorSpirV<'static>>,
+    event_loop: EventLoop<CompiledShaderModules>,
     window: Window,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'static>,
+    compiled_shader_modules: CompiledShaderModules,
 ) {
     let backends = wgpu::util::backend_bits_from_env()
         .unwrap_or(wgpu::Backends::VULKAN | wgpu::Backends::METAL);
@@ -135,7 +134,7 @@ async fn run(
             |pending| pending.preferred_format,
             |(_, surface_config)| surface_config.format,
         ),
-        shader_binary,
+        compiled_shader_modules,
     );
 
     let start = std::time::Instant::now();
@@ -336,24 +335,45 @@ fn create_pipeline(
     device: &wgpu::Device,
     pipeline_layout: &wgpu::PipelineLayout,
     surface_format: wgpu::TextureFormat,
-    shader_binary: wgpu::ShaderModuleDescriptorSpirV<'_>,
+    compiled_shader_modules: CompiledShaderModules,
 ) -> wgpu::RenderPipeline {
     // FIXME(eddyb) automate this decision by default.
-    let module = if options.force_spirv_passthru {
-        unsafe { device.create_shader_module_spirv(&shader_binary) }
-    } else {
-        let wgpu::ShaderModuleDescriptorSpirV { label, source } = shader_binary;
-        device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label,
-            source: wgpu::ShaderSource::SpirV(source),
-        })
+    let create_module = |module| {
+        if options.force_spirv_passthru {
+            unsafe { device.create_shader_module_spirv(&module) }
+        } else {
+            let wgpu::ShaderModuleDescriptorSpirV { label, source } = module;
+            device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label,
+                source: wgpu::ShaderSource::SpirV(source),
+            })
+        }
     };
+
+    let vs_entry_point = shaders::main_vs;
+    let fs_entry_point = shaders::main_fs;
+
+    let vs_module_descr = compiled_shader_modules.spv_module_for_entry_point(vs_entry_point);
+    let fs_module_descr = compiled_shader_modules.spv_module_for_entry_point(fs_entry_point);
+
+    // HACK(eddyb) avoid calling `device.create_shader_module` twice unnecessarily.
+    let vs_fs_same_module = std::ptr::eq(&vs_module_descr.source[..], &fs_module_descr.source[..]);
+
+    let vs_module = &create_module(vs_module_descr);
+    let fs_module;
+    let fs_module = if vs_fs_same_module {
+        vs_module
+    } else {
+        fs_module = create_module(fs_module_descr);
+        &fs_module
+    };
+
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,
         layout: Some(pipeline_layout),
         vertex: wgpu::VertexState {
-            module: &module,
-            entry_point: shaders::main_vs,
+            module: vs_module,
+            entry_point: vs_entry_point,
             buffers: &[],
         },
         primitive: wgpu::PrimitiveState {
@@ -372,8 +392,8 @@ fn create_pipeline(
             alpha_to_coverage_enabled: false,
         },
         fragment: Some(wgpu::FragmentState {
-            module: &module,
-            entry_point: shaders::main_fs,
+            module: fs_module,
+            entry_point: fs_entry_point,
             targets: &[Some(wgpu::ColorTargetState {
                 format: surface_format,
                 blend: None,
@@ -410,7 +430,7 @@ pub fn start(
 
     // Build the shader before we pop open a window, since it might take a while.
     let initial_shader = maybe_watch(
-        options.shader,
+        options,
         #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
         {
             let proxy = event_loop.create_proxy();

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -197,11 +197,16 @@ fn maybe_watch(
     }
     #[cfg(any(target_os = "android", target_arch = "wasm32"))]
     {
-        match shader {
-            RustGPUShader::Simplest => wgpu::include_spirv_raw!(env!("simplest_shader.spv")),
+        let module = match options.shader {
+            RustGPUShader::Simplest => {
+                wgpu::include_spirv_raw!(env!("simplest_shader.spv"))
+            }
             RustGPUShader::Sky => wgpu::include_spirv_raw!(env!("sky_shader.spv")),
             RustGPUShader::Compute => wgpu::include_spirv_raw!(env!("compute_shader.spv")),
             RustGPUShader::Mouse => wgpu::include_spirv_raw!(env!("mouse_shader.spv")),
+        };
+        CompiledShaderModules {
+            named_spv_modules: vec![(None, module)],
         }
     }
 }


### PR DESCRIPTION
Not sure yet if this is the way to do it, but I used this for testing the mouse shader (before #1018).

---

**EDIT**: turns out that this is the main requirement for using `debugPrintf` from `wgpu`!

<table><tr><td>

Quick demo panic:

```patch
--- a/examples/shaders/sky-shader/src/lib.rs
+++ b/examples/shaders/sky-shader/src/lib.rs
@@ -65,2 +65,3 @@ fn sun_intensity(zenith_angle_cos: f32) -> f32 {
     let cutoff_angle = PI / 1.95; // Earth shadow hack
+    assert!(zenith_angle_cos > 0.07479);
     SUN_INTENSITY_FACTOR
```
Enabling `debugPrintf` output without code changes (nor debug mode):
```sh
VK_LOADER_LAYERS_ENABLE='VK_LAYER_KHRONOS_validation' \
VK_LAYER_ENABLES='VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT' \
DEBUG_PRINTF_TO_STDOUT=1 \
  cargo run -p example-runner-wgpu --release -- --force-spirv-passthru
```
(also check out the updated `DebugPrintfThenExit` docs!)

</td><td><img src="https://github.com/EmbarkStudios/rust-gpu/assets/77424/2f6b4143-f968-42bc-adee-4d25d0615d9d"></td></tr>