### PR TITLE
Refactor zombie reporting to use `OpSource` and prepare for SPIR-T diagnostics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#1031](https://github.com/EmbarkStudios/rust-gpu/pull/1031) added `Components` generic parameter to `Image` type, allowing images to return lower dimensional vectors and even scalars from the sampling API
 
 ### Changed 🛠
+- [PR#1040](https://github.com/EmbarkStudios/rust-gpu/pull/1040) refactored "zombie" (delayed error) reporting to use SPIR-V `OpSource`, be more helpful, and added `--no-early-report-zombies` to delay it even further  
+  (see also [the `--no-early-report-zombies` codegen args docs](docs/src/codegen-args.md#--no-early-report-zombies))
 - [PR#1035](https://github.com/EmbarkStudios/rust-gpu/pull/1035) reduced the number of CGUs ("codegen units") used by `spirv-builder` to just `1`
 - [PR#1011](https://github.com/EmbarkStudios/rust-gpu/pull/1011) made `NonWritable` all read-only storage buffers (i.e. those typed `&T`, where `T` doesn't have interior mutability)
 - [PR#1029](https://github.com/EmbarkStudios/rust-gpu/pull/1029) fixed SampledImage::sample() fns being unnecessarily marked as unsafe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "either",
  "hashbrown 0.11.2",
  "indexmap",
+ "itertools",
  "lazy_static",
  "libc",
  "num-traits",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -60,6 +60,7 @@ spirv-tools = { version = "0.9", default-features = false }
 rustc_codegen_spirv-types.workspace = true
 spirt = "0.1.0"
 lazy_static = "1.4.0"
+itertools = "0.10.5"
 
 [dev-dependencies]
 pipe = "0.4"

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -210,7 +210,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
                     cx.zombie_with_span(
                         new_id,
                         span,
-                        "Cannot create self-referential types, even through pointers",
+                        "cannot create self-referential types, even through pointers",
                     );
                     Some(new_id)
                 }

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -656,8 +656,15 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
     fn set_span(&mut self, span: Span) {
         self.current_span = Some(span);
-        let (file, line, col) = self.builder.file_line_col_for_op_line(span);
-        self.emit().line(file.file_name_op_string_id, line, col);
+
+        // We may not always have valid spans.
+        // FIXME(eddyb) reduce the sources of this as much as possible.
+        if span.is_dummy() {
+            self.emit().no_line();
+        } else {
+            let (file, line, col) = self.builder.file_line_col_for_op_line(span);
+            self.emit().line(file.file_name_op_string_id, line, col);
+        }
     }
 
     // FIXME(eddyb) change `Self::Function` to be more like a function index.

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -657,11 +657,12 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     fn set_span(&mut self, span: Span) {
         self.current_span = Some(span);
         let loc = self.cx.tcx.sess.source_map().lookup_char_pos(span.lo());
-        let file = self
-            .builder
-            .def_string(format!("{}", loc.file.name.prefer_remapped()));
-        self.emit()
-            .line(file, loc.line as u32, loc.col_display as u32);
+        let file = self.builder.def_debug_file(loc.file);
+        self.emit().line(
+            file.file_name_op_string_id,
+            loc.line as u32,
+            loc.col_display as u32,
+        );
     }
 
     // FIXME(eddyb) change `Self::Function` to be more like a function index.

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -656,13 +656,8 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
     fn set_span(&mut self, span: Span) {
         self.current_span = Some(span);
-        let loc = self.cx.tcx.sess.source_map().lookup_char_pos(span.lo());
-        let file = self.builder.def_debug_file(loc.file);
-        self.emit().line(
-            file.file_name_op_string_id,
-            loc.line as u32,
-            loc.col_display as u32,
-        );
+        let (file, line, col) = self.builder.file_line_col_for_op_line(span);
+        self.emit().line(file.file_name_op_string_id, line, col);
     }
 
     // FIXME(eddyb) change `Self::Function` to be more like a function index.

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -171,7 +171,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         if invalid_seq_cst {
             self.zombie(
                 semantics.def(self),
-                "Cannot use AtomicOrdering=SequentiallyConsistent on Vulkan memory model. Check if AcquireRelease fits your needs.",
+                "cannot use AtomicOrdering=SequentiallyConsistent on Vulkan memory model \
+                 (check if AcquireRelease fits your needs)",
             );
         }
         semantics
@@ -352,11 +353,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     fn zombie_convert_ptr_to_u(&self, def: Word) {
-        self.zombie(def, "Cannot convert pointers to integers");
+        self.zombie(def, "cannot convert pointers to integers");
     }
 
     fn zombie_convert_u_to_ptr(&self, def: Word) {
-        self.zombie(def, "Cannot convert integers to pointers");
+        self.zombie(def, "cannot convert integers to pointers");
     }
 
     fn zombie_ptr_equal(&self, def: Word, inst: &str) {
@@ -1453,21 +1454,16 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 .with_type(dest_ty);
 
             if val_is_ptr || dest_is_ptr {
-                if self.is_system_crate(self.span()) {
-                    self.zombie(
-                        result.def(self),
-                        &format!(
-                            "Cannot cast between pointer and non-pointer types. From: {}. To: {}.",
-                            self.debug_type(val.ty),
-                            self.debug_type(dest_ty)
-                        ),
-                    );
-                } else {
-                    self.struct_err("Cannot cast between pointer and non-pointer types")
-                        .note(&format!("from: {}", self.debug_type(val.ty)))
-                        .note(&format!("to: {}", self.debug_type(dest_ty)))
-                        .emit();
-                }
+                self.zombie(
+                    result.def(self),
+                    &format!(
+                        "cannot cast between pointer and non-pointer types\
+                         \nfrom `{}`\
+                         \n  to `{}`",
+                        self.debug_type(val.ty),
+                        self.debug_type(dest_ty)
+                    ),
+                );
             }
 
             result
@@ -1884,7 +1880,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                     empty(),
                 )
                 .unwrap();
-            self.zombie(dst.def(self), "Cannot memcpy dynamically sized data");
+            self.zombie(dst.def(self), "cannot memcpy dynamically sized data");
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
+++ b/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
@@ -11,7 +11,7 @@ use rustc_target::abi::{Align, Size};
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     fn load_err(&mut self, original_type: Word, invalid_type: Word) -> SpirvValue {
         let mut err = self.struct_err(&format!(
-            "Cannot load type {} in an untyped buffer load",
+            "cannot load type {} in an untyped buffer load",
             self.debug_type(original_type)
         ));
         if original_type != invalid_type {
@@ -206,7 +206,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     fn store_err(&mut self, original_type: Word, value: SpirvValue) -> Result<(), ErrorGuaranteed> {
         let mut err = self.struct_err(&format!(
-            "Cannot store type {} in an untyped buffer store",
+            "cannot store type {} in an untyped buffer store",
             self.debug_type(original_type)
         ));
         if original_type != value.ty {

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -208,7 +208,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             .with_type(result_type);
             self.zombie(
                 result.def(self),
-                "Cannot offset a pointer to an arbitrary element",
+                "cannot offset a pointer to an arbitrary element",
             );
             result
         }
@@ -219,7 +219,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let width = match self.lookup_type(shift.ty) {
             SpirvType::Integer(width, _) => width,
             other => self.fatal(&format!(
-                "Cannot rotate non-integer type: {}",
+                "cannot rotate non-integer type: {}",
                 other.debug(shift.ty, self)
             )),
         };

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -5,14 +5,20 @@ use crate::symbols::Symbols;
 use crate::target::SpirvTarget;
 use crate::target_feature::TargetFeature;
 use rspirv::dr::{Block, Builder, Module, Operand};
-use rspirv::spirv::{AddressingModel, Capability, MemoryModel, Op, StorageClass, Word};
+use rspirv::spirv::{
+    AddressingModel, Capability, MemoryModel, Op, SourceLanguage, StorageClass, Word,
+};
 use rspirv::{binary::Assemble, binary::Disassemble};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::sync::Lrc;
 use rustc_middle::bug;
+use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::Symbol;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{SourceFile, Span, DUMMY_SP};
 use std::assert_matches::assert_matches;
 use std::cell::{RefCell, RefMut};
+use std::hash::{Hash, Hasher};
+use std::iter;
 use std::{fs::File, io::Write, path::Path};
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -321,6 +327,42 @@ struct WithConstLegality<V> {
     legal: Result<(), IllegalConst>,
 }
 
+/// `HashMap` key type (for `debug_file_cache` in `BuilderSpirv`), which is
+/// equivalent to a whole `rustc` `SourceFile`, but has O(1) `Eq` and `Hash`
+/// implementations (i.e. not involving the path or the contents of the file).
+///
+/// This is possible because we can compare `Lrc<SourceFile>`s by equality, as
+/// `rustc`'s `SourceMap` already ensures that only one `SourceFile` will be
+/// allocated for some given file. For hashing, we could hash the address, or
+///
+struct DebugFileKey(Lrc<SourceFile>);
+
+impl PartialEq for DebugFileKey {
+    fn eq(&self, other: &Self) -> bool {
+        let (Self(self_sf), Self(other_sf)) = (self, other);
+        Lrc::ptr_eq(self_sf, other_sf)
+    }
+}
+impl Eq for DebugFileKey {}
+
+impl Hash for DebugFileKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let Self(sf) = self;
+        sf.name_hash.hash(state);
+        sf.src_hash.hash(state);
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct DebugFileSpirv {
+    /// The SPIR-V ID for the result of the `OpString` instruction containing
+    /// the file name - this is what e.g. `OpLine` uses to identify the file.
+    ///
+    /// All other details about the file are also attached to this ID, using
+    /// other instructions that don't produce their own IDs (e.g. `OpSource`).
+    pub file_name_op_string_id: Word,
+}
+
 /// Cursor system:
 ///
 /// The LLVM module builder model (and therefore `codegen_ssa`) assumes that there is a central
@@ -351,6 +393,8 @@ pub struct BuilderCursor {
 }
 
 pub struct BuilderSpirv<'tcx> {
+    source_map: &'tcx SourceMap,
+
     builder: RefCell<Builder>,
 
     // Bidirectional maps between `SpirvConst` and the ID of the defined global
@@ -359,14 +403,20 @@ pub struct BuilderSpirv<'tcx> {
     // allows getting that legality information without additional lookups.
     const_to_id: RefCell<FxHashMap<WithType<SpirvConst<'tcx>>, WithConstLegality<Word>>>,
     id_to_const: RefCell<FxHashMap<Word, WithConstLegality<SpirvConst<'tcx>>>>,
-    string_cache: RefCell<FxHashMap<String, Word>>,
+
+    debug_file_cache: RefCell<FxHashMap<DebugFileKey, DebugFileSpirv>>,
 
     enabled_capabilities: FxHashSet<Capability>,
     enabled_extensions: FxHashSet<Symbol>,
 }
 
 impl<'tcx> BuilderSpirv<'tcx> {
-    pub fn new(sym: &Symbols, target: &SpirvTarget, features: &[TargetFeature]) -> Self {
+    pub fn new(
+        source_map: &'tcx SourceMap,
+        sym: &Symbols,
+        target: &SpirvTarget,
+        features: &[TargetFeature],
+    ) -> Self {
         let version = target.spirv_version();
         let memory_model = target.memory_model();
 
@@ -427,10 +477,11 @@ impl<'tcx> BuilderSpirv<'tcx> {
         builder.memory_model(AddressingModel::Logical, memory_model);
 
         Self {
+            source_map,
             builder: RefCell::new(builder),
             const_to_id: Default::default(),
             id_to_const: Default::default(),
-            string_cache: Default::default(),
+            debug_file_cache: Default::default(),
             enabled_capabilities,
             enabled_extensions,
         }
@@ -637,15 +688,75 @@ impl<'tcx> BuilderSpirv<'tcx> {
         }
     }
 
-    pub fn def_string(&self, s: String) -> Word {
-        use std::collections::hash_map::Entry;
-        match self.string_cache.borrow_mut().entry(s) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let key = entry.key().clone();
-                *entry.insert(self.builder(Default::default()).string(key))
-            }
-        }
+    pub fn def_debug_file(&self, sf: Lrc<SourceFile>) -> DebugFileSpirv {
+        *self
+            .debug_file_cache
+            .borrow_mut()
+            .entry(DebugFileKey(sf))
+            .or_insert_with_key(|DebugFileKey(sf)| {
+                let mut builder = self.builder(Default::default());
+
+                // FIXME(eddyb) remapping might be really bad for being able to
+                // load the sources the later, maybe it should be done at the
+                // very end? (just before linking outputting the final SPIR-V)
+                let file_name_op_string_id = builder.string(sf.name.prefer_remapped().to_string());
+
+                let file_contents = self
+                    .source_map
+                    .span_to_snippet(Span::with_root_ctxt(sf.start_pos, sf.end_pos))
+                    .ok();
+
+                // HACK(eddyb) this logic is duplicated from `spirt::spv::lift`.
+                let op_source_and_continued_chunks = file_contents.as_ref().map(|contents| {
+                    // The maximum word count is `2**16 - 1`, the first word is
+                    // taken up by the opcode & word count, and one extra byte is
+                    // taken up by the nil byte at the end of the LiteralString.
+                    const MAX_OP_SOURCE_CONT_CONTENTS_LEN: usize = (0xffff - 1) * 4 - 1;
+
+                    // `OpSource` has 3 more operands than `OpSourceContinued`,
+                    // and each of them take up exactly one word.
+                    const MAX_OP_SOURCE_CONTENTS_LEN: usize =
+                        MAX_OP_SOURCE_CONT_CONTENTS_LEN - 3 * 4;
+
+                    let (op_source_str, mut all_op_source_continued_str) =
+                        contents.split_at(contents.len().min(MAX_OP_SOURCE_CONTENTS_LEN));
+
+                    // FIXME(eddyb) `spirt::spv::lift` should use this.
+                    let all_op_source_continued_str_chunks = iter::from_fn(move || {
+                        let contents_rest = &mut all_op_source_continued_str;
+                        if contents_rest.is_empty() {
+                            return None;
+                        }
+
+                        // FIXME(eddyb) test with UTF-8! this `split_at` should
+                        // actually take *less* than the full possible size, to
+                        // avoid cutting a UTF-8 sequence.
+                        let (cont_chunk, rest) = contents_rest
+                            .split_at(contents_rest.len().min(MAX_OP_SOURCE_CONT_CONTENTS_LEN));
+                        *contents_rest = rest;
+                        Some(cont_chunk)
+                    });
+                    (op_source_str, all_op_source_continued_str_chunks)
+                });
+
+                if let Some((op_source_str, all_op_source_continued_str_chunks)) =
+                    op_source_and_continued_chunks
+                {
+                    builder.source(
+                        SourceLanguage::Unknown,
+                        0,
+                        Some(file_name_op_string_id),
+                        Some(op_source_str),
+                    );
+                    for cont_chunk in all_op_source_continued_str_chunks {
+                        builder.source_continued(cont_chunk);
+                    }
+                }
+
+                DebugFileSpirv {
+                    file_name_op_string_id,
+                }
+            })
     }
 
     pub fn set_global_initializer(&self, global: Word, initializer: Word) {

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -398,8 +398,7 @@ pub struct BuilderCursor {
 }
 
 pub struct BuilderSpirv<'tcx> {
-    // HACK(eddyb) public only for `decorations`.
-    pub(crate) source_map: &'tcx SourceMap,
+    source_map: &'tcx SourceMap,
     dropless_arena: &'tcx DroplessArena,
 
     builder: RefCell<Builder>,
@@ -705,8 +704,7 @@ impl<'tcx> BuilderSpirv<'tcx> {
         )
     }
 
-    // HACK(eddyb) public only for `decorations`.
-    pub(crate) fn def_debug_file(&self, sf: Lrc<SourceFile>) -> DebugFileSpirv<'tcx> {
+    fn def_debug_file(&self, sf: Lrc<SourceFile>) -> DebugFileSpirv<'tcx> {
         *self
             .debug_file_cache
             .borrow_mut()

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -393,7 +393,8 @@ pub struct BuilderCursor {
 }
 
 pub struct BuilderSpirv<'tcx> {
-    source_map: &'tcx SourceMap,
+    // HACK(eddyb) public only for `decorations`.
+    pub(crate) source_map: &'tcx SourceMap,
 
     builder: RefCell<Builder>,
 
@@ -696,9 +697,6 @@ impl<'tcx> BuilderSpirv<'tcx> {
             .or_insert_with_key(|DebugFileKey(sf)| {
                 let mut builder = self.builder(Default::default());
 
-                // FIXME(eddyb) remapping might be really bad for being able to
-                // load the sources the later, maybe it should be done at the
-                // very end? (just before linking outputting the final SPIR-V)
                 let file_name_op_string_id = builder.string(sf.name.prefer_remapped().to_string());
 
                 let file_contents = self

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -217,7 +217,8 @@ impl<'tcx> CodegenCx<'tcx> {
             .variable(ptr_ty, None, StorageClass::Private, None)
             .with_type(ptr_ty);
         // TODO: These should be StorageClass::Private, so just zombie for now.
-        self.zombie_with_span(result.def_cx(self), span, "Globals are not supported yet");
+        // FIXME(eddyb) why zombie? this looks like it should just work nowadays.
+        self.zombie_with_span(result.def_cx(self), span, "globals are not supported yet");
         result
     }
 }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -70,7 +70,7 @@ impl<'tcx> CodegenCx<'tcx> {
             } else {
                 self.tcx
                     .sess
-                    .span_err(span, format!("Cannot declare {name} as an entry point"));
+                    .span_err(span, format!("cannot declare {name} as an entry point"));
                 return;
             };
             let body = self

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -231,9 +231,9 @@ impl<'tcx> CodegenCx<'tcx> {
             .annotations
             .extend(self.zombie_decorations.into_inner().into_iter().flat_map(
                 |(id, (zombie, src_loc))| {
-                    [zombie.encode(id)]
+                    [zombie.encode_to_inst(id)]
                         .into_iter()
-                        .chain(src_loc.map(|src_loc| src_loc.encode(id)))
+                        .chain(src_loc.map(|src_loc| src_loc.encode_to_inst(id)))
                 },
             ));
         result

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -117,7 +117,7 @@ impl<'tcx> CodegenCx<'tcx> {
         Self {
             tcx,
             codegen_unit,
-            builder: BuilderSpirv::new(&sym, &target, &features),
+            builder: BuilderSpirv::new(tcx.sess.source_map(), &sym, &target, &features),
             instances: Default::default(),
             function_parameter_values: Default::default(),
             type_cache: Default::default(),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -189,7 +189,7 @@ impl<'tcx> CodegenCx<'tcx> {
             word,
             ZombieDecoration {
                 reason: reason.to_string(),
-                span: SerializedSpan::from_rustc(span, self.tcx.sess.source_map()),
+                span: SerializedSpan::from_rustc(span, &self.builder),
             },
         );
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -330,6 +330,11 @@ impl CodegenArgs {
                 "no-compact-ids",
                 "disables compaction of SPIR-V IDs at the end of linking",
             );
+            opts.optflag(
+                "",
+                "no-early-report-zombies",
+                "delays reporting zombies (to allow more legalization)",
+            );
             opts.optflag("", "no-structurize", "disables CFG structurization");
 
             opts.optflag(
@@ -509,6 +514,7 @@ impl CodegenArgs {
             // FIXME(eddyb) clean up this `no-` "negation prefix" situation.
             dce: !matches.opt_present("no-dce"),
             compact_ids: !matches.opt_present("no-compact-ids"),
+            early_report_zombies: !matches.opt_present("no-early-report-zombies"),
             structurize: !matches.opt_present("no-structurize"),
             spirt: !matches.opt_present("no-spirt"),
             spirt_passes: matches

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -40,6 +40,7 @@ compile_error!(
 );
 
 extern crate rustc_apfloat;
+extern crate rustc_arena;
 extern crate rustc_ast;
 extern crate rustc_attr;
 extern crate rustc_codegen_ssa;

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -5,6 +5,9 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_middle::bug;
 use std::collections::hash_map;
 
+// FIXME(eddyb) consider deduplicating the `OpString` and `OpSource` created for
+// file-level debuginfo (but using SPIR-T for linking might be better?).
+
 pub fn remove_duplicate_extensions(module: &mut Module) {
     let mut set = FxHashSet::default();
 

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -20,6 +20,7 @@ mod zombies;
 use std::borrow::Cow;
 
 use crate::codegen_cx::SpirvMetadata;
+use crate::decorations::{CustomDecoration, SrcLocDecoration, ZombieDecoration};
 use either::Either;
 use rspirv::binary::{Assemble, Consumer};
 use rspirv::dr::{Block, Instruction, Loader, Module, ModuleHeader, Operand};
@@ -572,6 +573,14 @@ pub fn link(
             // compact the ids https://github.com/KhronosGroup/SPIRV-Tools/blob/e02f178a716b0c3c803ce31b9df4088596537872/source/opt/compact_ids_pass.cpp#L43
             output.header.as_mut().unwrap().bound = simple_passes::compact_ids(output);
         };
+
+        // FIXME(eddyb) convert these into actual `OpLine`s with a SPIR-T pass,
+        // but that'd require keeping the modules in SPIR-T form (once lowered),
+        // and never loading them back into `rspirv` once lifted back to SPIR-V.
+        SrcLocDecoration::remove_all(output);
+
+        // FIXME(eddyb) might make more sense to rewrite these away on SPIR-T.
+        ZombieDecoration::remove_all(output);
     }
 
     Ok(output)

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
@@ -1,0 +1,383 @@
+use crate::decorations::{CustomDecoration, SpanRegenerator, SrcLocDecoration, ZombieDecoration};
+use rustc_data_structures::fx::FxIndexSet;
+use rustc_errors::{DiagnosticBuilder, ErrorGuaranteed};
+use rustc_session::Session;
+use rustc_span::{Span, DUMMY_SP};
+use smallvec::SmallVec;
+use spirt::visit::{InnerVisit, Visitor};
+use spirt::{
+    spv, Attr, AttrSet, AttrSetDef, Const, Context, DataInstDef, DataInstKind, ExportKey, Exportee,
+    Func, GlobalVar, Module, Type,
+};
+use std::marker::PhantomData;
+use std::{mem, str};
+
+pub(crate) fn report_diagnostics(
+    sess: &Session,
+    linker_options: &crate::linker::Options,
+    module: &Module,
+) -> crate::linker::Result<()> {
+    let cx = &module.cx();
+
+    let mut reporter = DiagnosticReporter {
+        sess,
+        linker_options,
+
+        cx,
+        module,
+
+        seen_attrs: FxIndexSet::default(),
+        seen_types: FxIndexSet::default(),
+        seen_consts: FxIndexSet::default(),
+        seen_global_vars: FxIndexSet::default(),
+        seen_funcs: FxIndexSet::default(),
+
+        use_stack: SmallVec::new(),
+        span_regen: SpanRegenerator::new_spirt(sess.source_map(), module),
+        overall_result: Ok(()),
+    };
+    for (export_key, &exportee) in &module.exports {
+        assert_eq!(reporter.use_stack.len(), 0);
+
+        if let Exportee::Func(func) = exportee {
+            let func_decl = &module.funcs[func];
+            reporter.use_stack.push(UseOrigin::IntraFunc {
+                func_attrs: func_decl.attrs,
+                func_export_key: Some(export_key),
+                inst_attrs: AttrSet::default(),
+                origin: IntraFuncUseOrigin::Other,
+            });
+            export_key.inner_visit_with(&mut reporter);
+            if reporter.seen_funcs.insert(func) {
+                reporter.visit_func_decl(func_decl);
+            }
+            reporter.use_stack.pop();
+        }
+        export_key.inner_visit_with(&mut reporter);
+        exportee.inner_visit_with(&mut reporter);
+    }
+    reporter.overall_result
+}
+
+// HACK(eddyb) version of `decorations::LazilyDecoded` that works for SPIR-T.
+struct LazilyDecoded<D> {
+    encoded: String,
+    _marker: PhantomData<D>,
+}
+
+impl<D> LazilyDecoded<D> {
+    fn decode<'a>(&'a self) -> D
+    where
+        D: CustomDecoration<'a>,
+    {
+        D::decode(&self.encoded)
+    }
+}
+
+fn decode_spv_lit_str_with<R>(imms: &[spv::Imm], f: impl FnOnce(&str) -> R) -> R {
+    let wk = &super::SpvSpecWithExtras::get().well_known;
+
+    // FIXME(eddyb) deduplicate with `spirt::spv::extract_literal_string`.
+    let words = imms.iter().enumerate().map(|(i, &imm)| match (i, imm) {
+        (0, spirt::spv::Imm::Short(k, w) | spirt::spv::Imm::LongStart(k, w))
+        | (1.., spirt::spv::Imm::LongCont(k, w)) => {
+            // FIXME(eddyb) use `assert_eq!` after updating to latest SPIR-T.
+            assert!(k == wk.LiteralString);
+            w
+        }
+        _ => unreachable!(),
+    });
+    let bytes: SmallVec<[u8; 64]> = words
+        .flat_map(u32::to_le_bytes)
+        .take_while(|&byte| byte != 0)
+        .collect();
+
+    f(str::from_utf8(&bytes).expect("invalid UTF-8 in string literal"))
+}
+
+fn try_decode_custom_decoration<'a, D: CustomDecoration<'a>>(
+    attrs_def: &AttrSetDef,
+) -> Option<LazilyDecoded<D>> {
+    let wk = &super::SpvSpecWithExtras::get().well_known;
+
+    attrs_def.attrs.iter().find_map(|attr| {
+        let spv_inst = match attr {
+            Attr::SpvAnnotation(spv_inst) if spv_inst.opcode == wk.OpDecorateString => spv_inst,
+            _ => return None,
+        };
+        let str_imms = spv_inst
+            .imms
+            .strip_prefix(&[spv::Imm::Short(wk.Decoration, wk.UserTypeGOOGLE)])?;
+
+        decode_spv_lit_str_with(str_imms, |prefixed_encoded| {
+            let encoded = prefixed_encoded.strip_prefix(D::ENCODING_PREFIX)?;
+
+            Some(LazilyDecoded {
+                encoded: encoded.to_string(),
+                _marker: PhantomData,
+            })
+        })
+    })
+}
+
+// FIXME(eddyb) this looks a lot like `ReachableUseCollector`, maybe some
+// automation should be built around "deep visitors" in general?
+struct DiagnosticReporter<'a> {
+    sess: &'a Session,
+    linker_options: &'a crate::linker::Options,
+
+    cx: &'a Context,
+    module: &'a Module,
+
+    seen_attrs: FxIndexSet<AttrSet>,
+    seen_types: FxIndexSet<Type>,
+    seen_consts: FxIndexSet<Const>,
+    seen_global_vars: FxIndexSet<GlobalVar>,
+    seen_funcs: FxIndexSet<Func>,
+
+    use_stack: SmallVec<[UseOrigin<'a>; 8]>,
+    span_regen: SpanRegenerator<'a>,
+    overall_result: crate::linker::Result<()>,
+}
+
+enum UseOrigin<'a> {
+    Global {
+        kind: &'static &'static str,
+        attrs: AttrSet,
+    },
+    IntraFunc {
+        func_attrs: AttrSet,
+        func_export_key: Option<&'a ExportKey>,
+
+        inst_attrs: AttrSet,
+        origin: IntraFuncUseOrigin,
+    },
+}
+
+enum IntraFuncUseOrigin {
+    CallCallee,
+    Other,
+}
+
+impl UseOrigin<'_> {
+    fn to_rustc_span(&self, cx: &Context, span_regen: &mut SpanRegenerator<'_>) -> Option<Span> {
+        let mut from_attrs = |attrs: AttrSet| {
+            let attrs_def = &cx[attrs];
+            attrs_def
+                .attrs
+                .iter()
+                .find_map(|attr| match attr {
+                    &Attr::SpvDebugLine {
+                        file_path,
+                        line,
+                        col,
+                    } => span_regen.src_loc_to_rustc(SrcLocDecoration {
+                        file_name: &cx[file_path.0],
+                        line,
+                        col,
+                    }),
+                    _ => None,
+                })
+                .or_else(|| {
+                    span_regen.src_loc_to_rustc(
+                        try_decode_custom_decoration::<SrcLocDecoration<'_>>(attrs_def)?.decode(),
+                    )
+                })
+        };
+        match *self {
+            Self::Global { attrs, .. } => from_attrs(attrs),
+            Self::IntraFunc {
+                func_attrs,
+                inst_attrs,
+                ..
+            } => from_attrs(inst_attrs).or_else(|| from_attrs(func_attrs)),
+        }
+    }
+
+    fn note(
+        &self,
+        cx: &Context,
+        span_regen: &mut SpanRegenerator<'_>,
+        err: &mut DiagnosticBuilder<'_, ErrorGuaranteed>,
+    ) {
+        let wk = &super::SpvSpecWithExtras::get().well_known;
+
+        let name_from_attrs = |attrs: AttrSet, kind| {
+            cx[attrs]
+                .attrs
+                .iter()
+                .find_map(|attr| match attr {
+                    Attr::SpvAnnotation(spv_inst) if spv_inst.opcode == wk.OpName => {
+                        Some(decode_spv_lit_str_with(&spv_inst.imms, |name| {
+                            format!("`{name}`")
+                        }))
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| format!("unnamed {kind}"))
+        };
+        let note = match self {
+            &Self::Global { kind, attrs } => {
+                format!("used by {}", name_from_attrs(attrs, *kind))
+            }
+            Self::IntraFunc {
+                func_attrs,
+                func_export_key,
+                inst_attrs: _,
+                origin,
+            } => {
+                let func_desc = func_export_key
+                    .map(|export_key| match export_key {
+                        &ExportKey::LinkName(name) => format!("function export `{}`", &cx[name]),
+                        ExportKey::SpvEntryPoint { imms, .. } => match imms[..] {
+                            [em @ spv::Imm::Short(em_kind, _), ref name_imms @ ..] => {
+                                // FIXME(eddyb) use `assert_eq!` after updating to latest SPIR-T.
+                                assert!(em_kind == wk.ExecutionModel);
+                                let em = spv::print::operand_from_imms([em]).concat_to_plain_text();
+                                decode_spv_lit_str_with(name_imms, |name| {
+                                    format!(
+                                        "{} entry-point `{name}`",
+                                        em.strip_prefix("ExecutionModel.").unwrap()
+                                    )
+                                })
+                            }
+                            _ => unreachable!(),
+                        },
+                    })
+                    .unwrap_or_else(|| name_from_attrs(*func_attrs, "function"));
+                match origin {
+                    IntraFuncUseOrigin::CallCallee => format!("called by {func_desc}"),
+                    IntraFuncUseOrigin::Other => format!("used from within {func_desc}"),
+                }
+            }
+        };
+
+        let span = self.to_rustc_span(cx, span_regen).unwrap_or(DUMMY_SP);
+        err.span_note(span, note);
+    }
+}
+
+impl DiagnosticReporter<'_> {
+    fn report_from_attrs(&mut self, attrs: AttrSet) {
+        if attrs == AttrSet::default() {
+            return;
+        }
+
+        // Split off the last entry in `self.use_stack` if it's for the definition
+        // that `attrs` come from - this should almost always be the case, except
+        // for instructions inside a function body, or visitor bugs.
+        let (current_def, use_stack_for_def) = self
+            .use_stack
+            .split_last()
+            .filter(
+                |(
+                    &UseOrigin::Global {
+                        attrs: use_attrs, ..
+                    }
+                    | &UseOrigin::IntraFunc {
+                        func_attrs: use_attrs,
+                        ..
+                    },
+                    _,
+                )| { use_attrs == attrs },
+            )
+            .map_or((None, &self.use_stack[..]), |(current, stack)| {
+                (Some(current), stack)
+            });
+
+        let attrs_def = &self.cx[attrs];
+        if !self.linker_options.early_report_zombies {
+            if let Some(zombie) = try_decode_custom_decoration::<ZombieDecoration<'_>>(attrs_def) {
+                let ZombieDecoration { reason } = zombie.decode();
+                let def_span = current_def
+                    .and_then(|def| def.to_rustc_span(self.cx, &mut self.span_regen))
+                    .unwrap_or(DUMMY_SP);
+                let mut err = self.sess.struct_span_err(def_span, reason);
+                for use_origin in use_stack_for_def.iter().rev() {
+                    use_origin.note(self.cx, &mut self.span_regen, &mut err);
+                }
+                self.overall_result = Err(err.emit());
+            }
+        }
+    }
+}
+
+impl Visitor<'_> for DiagnosticReporter<'_> {
+    fn visit_attr_set_use(&mut self, attrs: AttrSet) {
+        // HACK(eddyb) this avoids reporting the same diagnostics more than once.
+        if self.seen_attrs.insert(attrs) {
+            self.report_from_attrs(attrs);
+        }
+    }
+    fn visit_type_use(&mut self, ty: Type) {
+        if self.seen_types.insert(ty) {
+            let ty_def = &self.cx[ty];
+            self.use_stack.push(UseOrigin::Global {
+                kind: &"type",
+                attrs: ty_def.attrs,
+            });
+            self.visit_type_def(ty_def);
+            self.use_stack.pop();
+        }
+    }
+    fn visit_const_use(&mut self, ct: Const) {
+        if self.seen_consts.insert(ct) {
+            let ct_def = &self.cx[ct];
+            self.use_stack.push(UseOrigin::Global {
+                kind: &"constant",
+                attrs: ct_def.attrs,
+            });
+            self.visit_const_def(ct_def);
+            self.use_stack.pop();
+        }
+    }
+
+    fn visit_global_var_use(&mut self, gv: GlobalVar) {
+        if self.seen_global_vars.insert(gv) {
+            let gv_decl = &self.module.global_vars[gv];
+            self.use_stack.push(UseOrigin::Global {
+                // FIXME(eddyb) may be a `&CONST`, or an interface variable,
+                // not necessarily an user variable, so this could be confusing.
+                kind: &"global variable",
+                attrs: gv_decl.attrs,
+            });
+            self.visit_global_var_decl(gv_decl);
+            self.use_stack.pop();
+        }
+    }
+    fn visit_func_use(&mut self, func: Func) {
+        if self.seen_funcs.insert(func) {
+            let func_decl = &self.module.funcs[func];
+            self.use_stack.push(UseOrigin::IntraFunc {
+                func_attrs: func_decl.attrs,
+                func_export_key: None,
+                inst_attrs: AttrSet::default(),
+                origin: IntraFuncUseOrigin::Other,
+            });
+            self.visit_func_decl(func_decl);
+            self.use_stack.pop();
+        }
+    }
+
+    fn visit_data_inst_def(&mut self, data_inst_def: &DataInstDef) {
+        match self.use_stack.last_mut() {
+            Some(UseOrigin::IntraFunc { inst_attrs, .. }) => *inst_attrs = data_inst_def.attrs,
+            _ => unreachable!(),
+        }
+
+        if let DataInstKind::FuncCall(func) = data_inst_def.kind {
+            let replace_origin = |this: &mut Self, new_origin| match this.use_stack.last_mut() {
+                Some(UseOrigin::IntraFunc { origin, .. }) => mem::replace(origin, new_origin),
+                _ => unreachable!(),
+            };
+
+            // HACK(eddyb) visit `func` early, to control its `use_stack`, with
+            // the later visit from `inner_visit_with` ignored as a duplicate.
+            let old_origin = replace_origin(self, IntraFuncUseOrigin::CallCallee);
+            self.visit_func_use(func);
+            replace_origin(self, old_origin);
+        }
+
+        data_inst_def.inner_visit_with(self);
+    }
+}

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -12,7 +12,7 @@ use std::iter::once;
 // FIXME(eddyb) change this to chain through IDs instead of wasting allocations.
 #[derive(Clone)]
 struct ZombieInfo<'a> {
-    serialized: &'a LazilyDeserialized<'static, ZombieDecoration>,
+    serialized: &'a LazilyDeserialized<'static, ZombieDecoration<'a>>,
     stack: Vec<Word>,
 }
 

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -2,140 +2,310 @@
 
 use super::{get_name, get_names};
 use crate::decorations::{CustomDecoration, SpanRegenerator, ZombieDecoration};
-use rspirv::dr::{Instruction, Module};
+use rspirv::dr::{Instruction, Module, Operand};
 use rspirv::spirv::{Op, Word};
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_errors::{DiagnosticBuilder, ErrorGuaranteed};
 use rustc_session::Session;
-use rustc_span::DUMMY_SP;
-use std::iter::once;
+use rustc_span::{Span, DUMMY_SP};
+use smallvec::SmallVec;
 
-// FIXME(eddyb) change this to chain through IDs instead of wasting allocations.
-#[derive(Clone)]
-struct Zombie {
-    leaf_id: Word,
-    stack: Vec<Word>,
+#[derive(Copy, Clone)]
+struct Zombie<'a> {
+    id: Word,
+    kind: &'a ZombieKind,
 }
 
-impl Zombie {
-    fn push_stack(&self, word: Word) -> Self {
-        Self {
-            leaf_id: self.leaf_id,
-            stack: self.stack.iter().cloned().chain(once(word)).collect(),
-        }
+enum ZombieKind {
+    /// Definition annotated with `ZombieDecoration`.
+    Leaf,
+
+    /// Transitively zombie'd by using other zombies, from an instruction.
+    Uses(Vec<ZombieUse>),
+}
+
+struct ZombieUse {
+    used_zombie_id: Word,
+
+    /// Operands of the active `OpLine` at the time of the use, if any.
+    use_file_id_line_col: Option<(Word, u32, u32)>,
+
+    origin: UseOrigin,
+}
+
+enum UseOrigin {
+    GlobalOperandOrResultType,
+    IntraFuncOperandOrResultType { parent_func_id: Word },
+    CallCalleeOperand { caller_func_id: Word },
+}
+
+struct Zombies {
+    id_to_zombie_kind: FxIndexMap<Word, ZombieKind>,
+}
+
+impl Zombies {
+    // FIXME(eddyb) rename all the other methods to say `_inst` explicitly.
+    fn get_zombie_by_id(&self, id: Word) -> Option<Zombie<'_>> {
+        self.id_to_zombie_kind
+            .get(&id)
+            .map(|kind| Zombie { id, kind })
     }
-}
 
-fn contains_zombie<'h>(
-    inst: &Instruction,
-    zombies: &'h FxHashMap<Word, Zombie>,
-) -> Option<&'h Zombie> {
-    if let Some(result_type) = inst.result_type {
-        if let Some(reason) = zombies.get(&result_type) {
-            return Some(reason);
-        }
+    fn zombies_used_from_inst<'a>(
+        &'a self,
+        inst: &'a Instruction,
+    ) -> impl Iterator<Item = Zombie<'a>> + 'a {
+        inst.result_type
+            .into_iter()
+            .chain(inst.operands.iter().filter_map(|op| op.id_ref_any()))
+            .filter_map(move |id| self.get_zombie_by_id(id))
     }
-    inst.operands
-        .iter()
-        .find_map(|op| op.id_ref_any().and_then(|w| zombies.get(&w)))
-}
 
-fn is_zombie<'h>(inst: &Instruction, zombies: &'h FxHashMap<Word, Zombie>) -> Option<&'h Zombie> {
-    if let Some(result_id) = inst.result_id {
-        zombies.get(&result_id)
-    } else {
-        contains_zombie(inst, zombies)
-    }
-}
-
-fn is_or_contains_zombie<'h>(
-    inst: &Instruction,
-    zombies: &'h FxHashMap<Word, Zombie>,
-) -> Option<&'h Zombie> {
-    let result_zombie = inst.result_id.and_then(|result_id| zombies.get(&result_id));
-    result_zombie.or_else(|| contains_zombie(inst, zombies))
-}
-
-fn spread_zombie(module: &Module, zombies: &mut FxHashMap<Word, Zombie>) -> bool {
-    let mut any = false;
-    // globals are easy
-    for inst in module.global_inst_iter() {
-        if let Some(result_id) = inst.result_id {
-            if let Some(reason) = contains_zombie(inst, zombies) {
-                if zombies.contains_key(&result_id) {
-                    continue;
+    fn spread(&mut self, module: &Module) -> bool {
+        let mut any = false;
+        // globals are easy
+        {
+            let mut file_id_line_col = None;
+            for inst in module.global_inst_iter() {
+                match inst.class.opcode {
+                    Op::Line => {
+                        file_id_line_col = Some((
+                            inst.operands[0].unwrap_id_ref(),
+                            inst.operands[1].unwrap_literal_int32(),
+                            inst.operands[2].unwrap_literal_int32(),
+                        ));
+                    }
+                    Op::NoLine => file_id_line_col = None,
+                    _ => {}
                 }
-                let reason = reason.clone();
-                zombies.insert(result_id, reason);
-                any = true;
-            }
-        }
-    }
-    // No need to zombie defs within a function: If any def within a function is zombied, then the
-    // whole function is zombied. But, we don't have to mark the defs within a function as zombie,
-    // because the defs can't escape the function.
-    // HACK(eddyb) one exception to this is function-local variables, which may
-    // be unused and as such cannot be allowed to always zombie the function.
-    for func in &module.functions {
-        let func_id = func.def_id().unwrap();
-        // Can't use zombie.entry() here, due to using the map in contains_zombie
-        if zombies.contains_key(&func_id) {
-            // Func is already zombie, no need to scan it again.
-            continue;
-        }
-        for inst in func.all_inst_iter() {
-            if inst.class.opcode == Op::Variable {
-                let result_id = inst.result_id.unwrap();
-                if let Some(reason) = contains_zombie(inst, zombies) {
-                    if zombies.contains_key(&result_id) {
+
+                if let Some(result_id) = inst.result_id {
+                    if self.id_to_zombie_kind.contains_key(&result_id) {
                         continue;
                     }
-                    let reason = reason.clone();
-                    zombies.insert(result_id, reason);
-                    any = true;
+                    let zombie_uses: Vec<_> = self
+                        .zombies_used_from_inst(inst)
+                        .map(|zombie| ZombieUse {
+                            used_zombie_id: zombie.id,
+                            use_file_id_line_col: file_id_line_col,
+                            origin: UseOrigin::GlobalOperandOrResultType,
+                        })
+                        .collect();
+                    if !zombie_uses.is_empty() {
+                        self.id_to_zombie_kind
+                            .insert(result_id, ZombieKind::Uses(zombie_uses));
+                        any = true;
+                    }
                 }
-            } else if let Some(reason) = is_or_contains_zombie(inst, zombies) {
-                let pushed_reason = reason.push_stack(func_id);
-                zombies.insert(func_id, pushed_reason);
-                any = true;
-                break;
             }
         }
+        // No need to zombie defs within a function: If any def within a function is zombied, then the
+        // whole function is zombied. But, we don't have to mark the defs within a function as zombie,
+        // because the defs can't escape the function.
+        // HACK(eddyb) one exception to this is function-local variables, which may
+        // be unused and as such cannot be allowed to always zombie the function.
+        for func in &module.functions {
+            let func_id = func.def_id().unwrap();
+            if self.id_to_zombie_kind.contains_key(&func_id) {
+                // Func is already zombie, no need to scan it again.
+                continue;
+            }
+
+            let mut all_zombie_uses_in_func = vec![];
+            let mut file_id_line_col = None;
+            for inst in func.all_inst_iter() {
+                match inst.class.opcode {
+                    Op::Line => {
+                        file_id_line_col = Some((
+                            inst.operands[0].unwrap_id_ref(),
+                            inst.operands[1].unwrap_literal_int32(),
+                            inst.operands[2].unwrap_literal_int32(),
+                        ));
+                    }
+                    Op::NoLine => file_id_line_col = None,
+                    _ => {}
+                }
+
+                if inst.class.opcode == Op::Variable {
+                    let result_id = inst.result_id.unwrap();
+                    if self.id_to_zombie_kind.contains_key(&result_id) {
+                        continue;
+                    }
+                    let zombie_uses: Vec<_> = self
+                        .zombies_used_from_inst(inst)
+                        .map(|zombie| ZombieUse {
+                            used_zombie_id: zombie.id,
+                            use_file_id_line_col: file_id_line_col,
+                            origin: UseOrigin::IntraFuncOperandOrResultType {
+                                parent_func_id: func_id,
+                            },
+                        })
+                        .collect();
+                    if !zombie_uses.is_empty() {
+                        self.id_to_zombie_kind
+                            .insert(result_id, ZombieKind::Uses(zombie_uses));
+                        any = true;
+                    }
+                    continue;
+                }
+
+                all_zombie_uses_in_func.extend(
+                    inst.result_id
+                        .and_then(|result_id| self.get_zombie_by_id(result_id))
+                        .into_iter()
+                        .chain(self.zombies_used_from_inst(inst))
+                        .map(|zombie| {
+                            let origin = if inst.class.opcode == Op::FunctionCall
+                                && inst.operands[0] == Operand::IdRef(zombie.id)
+                            {
+                                UseOrigin::CallCalleeOperand {
+                                    caller_func_id: func_id,
+                                }
+                            } else {
+                                UseOrigin::IntraFuncOperandOrResultType {
+                                    parent_func_id: func_id,
+                                }
+                            };
+                            ZombieUse {
+                                used_zombie_id: zombie.id,
+                                use_file_id_line_col: file_id_line_col,
+                                origin,
+                            }
+                        }),
+                );
+            }
+            if !all_zombie_uses_in_func.is_empty() {
+                self.id_to_zombie_kind
+                    .insert(func_id, ZombieKind::Uses(all_zombie_uses_in_func));
+                any = true;
+            }
+        }
+        any
     }
-    any
 }
 
-// If an entry point references a zombie'd value, then the entry point would normally get removed.
-// That's an absolutely horrible experience to debug, though, so instead, create a nice error
-// message containing the stack trace of how the entry point got to the zombie value.
-fn report_error_zombies(
-    sess: &Session,
-    module: &Module,
-    zombies: &FxHashMap<Word, Zombie>,
-) -> super::Result<()> {
-    let mut span_regen = SpanRegenerator::new(sess.source_map(), module);
+struct ZombieReporter<'a> {
+    sess: &'a Session,
+    module: &'a Module,
+    zombies: &'a Zombies,
 
-    let mut result = Ok(());
-    let mut names = None;
-    for root in super::dce::collect_roots(module) {
-        if let Some(zombie) = zombies.get(&root) {
-            let reason = span_regen.zombie_for_id(zombie.leaf_id).unwrap().reason;
-            let span = span_regen
-                .src_loc_for_id(zombie.leaf_id)
-                .and_then(|src_loc| span_regen.src_loc_to_rustc(src_loc))
-                .unwrap_or(DUMMY_SP);
-            let names = names.get_or_insert_with(|| get_names(module));
-            let stack = zombie
-                .stack
-                .iter()
-                .map(|&s| get_name(names, s).into_owned());
-            let stack_note = once("Stack:".to_string())
-                .chain(stack)
-                .collect::<Vec<_>>()
-                .join("\n");
-            result = Err(sess.struct_span_err(span, reason).note(&stack_note).emit());
+    id_to_name: Option<FxHashMap<Word, &'a str>>,
+    span_regen: SpanRegenerator<'a>,
+}
+impl<'a> ZombieReporter<'a> {
+    fn new(sess: &'a Session, module: &'a Module, zombies: &'a Zombies) -> Self {
+        Self {
+            sess,
+            module,
+            zombies,
+
+            id_to_name: None,
+            span_regen: SpanRegenerator::new(sess.source_map(), module),
         }
     }
-    result
+
+    // If an entry point references a zombie'd value, then the entry point would normally get removed.
+    // That's an absolutely horrible experience to debug, though, so instead, create a nice error
+    // message containing the stack trace of how the entry point got to the zombie value.
+    fn report_all(mut self) -> super::Result<()> {
+        let mut result = Ok(());
+        // FIXME(eddyb) this loop means that every entry-point can potentially
+        // list out all the leaves, but that shouldn't be a huge issue.
+        for root_id in super::dce::collect_roots(self.module) {
+            if let Some(zombie) = self.zombies.get_zombie_by_id(root_id) {
+                for (_, mut err) in self.build_errors_keyed_by_leaf_id(zombie) {
+                    result = Err(err.emit());
+                }
+            }
+        }
+        result
+    }
+
+    fn add_use_note_to_err(
+        &mut self,
+        err: &mut DiagnosticBuilder<'a, ErrorGuaranteed>,
+        span: Span,
+        zombie: Zombie<'_>,
+        zombie_use: &ZombieUse,
+    ) {
+        let mut id_to_name = |id, kind| {
+            self.id_to_name
+                .get_or_insert_with(|| get_names(self.module))
+                .get(&id)
+                .map_or_else(
+                    || format!("unnamed {kind} (%{id})"),
+                    |&name| format!("`{name}`"),
+                )
+        };
+        let note = match zombie_use.origin {
+            UseOrigin::GlobalOperandOrResultType => {
+                format!("used by {}", id_to_name(zombie.id, "global"))
+            }
+            UseOrigin::IntraFuncOperandOrResultType { parent_func_id } => {
+                format!(
+                    "used from within {}",
+                    id_to_name(parent_func_id, "function")
+                )
+            }
+            UseOrigin::CallCalleeOperand { caller_func_id } => {
+                format!("called by {}", id_to_name(caller_func_id, "function"))
+            }
+        };
+
+        let span = zombie_use
+            .use_file_id_line_col
+            .and_then(|(file_id, line, col)| {
+                self.span_regen.src_loc_from_op_line(file_id, line, col)
+            })
+            .and_then(|src_loc| self.span_regen.src_loc_to_rustc(src_loc))
+            .unwrap_or(span);
+        err.span_note(span, note);
+    }
+
+    fn build_errors_keyed_by_leaf_id(
+        &mut self,
+        zombie: Zombie<'_>,
+    ) -> FxIndexMap<Word, DiagnosticBuilder<'a, ErrorGuaranteed>> {
+        // FIXME(eddyb) this is a bit inefficient, compared to some kind of
+        // "small map", but this is the error path, and being correct is more
+        // important here - in particular, we don't want to ignore *any* leaves.
+        let mut errors_keyed_by_leaf_id = FxIndexMap::default();
+
+        let span = self
+            .span_regen
+            .src_loc_for_id(zombie.id)
+            .and_then(|src_loc| self.span_regen.src_loc_to_rustc(src_loc))
+            .unwrap_or(DUMMY_SP);
+        match zombie.kind {
+            ZombieKind::Leaf => {
+                let reason = self.span_regen.zombie_for_id(zombie.id).unwrap().reason;
+                errors_keyed_by_leaf_id.insert(zombie.id, self.sess.struct_span_err(span, reason));
+            }
+            ZombieKind::Uses(zombie_uses) => {
+                for zombie_use in zombie_uses {
+                    let used_zombie = self
+                        .zombies
+                        .get_zombie_by_id(zombie_use.used_zombie_id)
+                        .unwrap();
+                    for (leaf_id, err) in self.build_errors_keyed_by_leaf_id(used_zombie) {
+                        use rustc_data_structures::fx::IndexEntry as Entry;
+                        match errors_keyed_by_leaf_id.entry(leaf_id) {
+                            Entry::Occupied(_) => err.cancel(),
+                            Entry::Vacant(entry) => {
+                                self.add_use_note_to_err(
+                                    entry.insert(err),
+                                    span,
+                                    zombie,
+                                    zombie_use,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        errors_keyed_by_leaf_id
+    }
 }
 
 pub fn remove_zombies(
@@ -143,30 +313,35 @@ pub fn remove_zombies(
     opts: &super::Options,
     module: &mut Module,
 ) -> super::Result<()> {
-    let mut zombies = ZombieDecoration::decode_all(module)
-        .map(|(id, _)| {
-            (
-                id,
-                Zombie {
-                    leaf_id: id,
-                    stack: vec![],
-                },
-            )
-        })
-        .collect();
+    let mut zombies = Zombies {
+        id_to_zombie_kind: ZombieDecoration::decode_all(module)
+            .map(|(id, _)| (id, ZombieKind::Leaf))
+            .collect(),
+    };
     // Note: This is O(n^2).
-    while spread_zombie(module, &mut zombies) {}
+    while zombies.spread(module) {}
 
-    let result = report_error_zombies(sess, module, &zombies);
+    let result = ZombieReporter::new(sess, module, &zombies).report_all();
 
     // FIXME(eddyb) use `log`/`tracing` instead.
     if opts.print_all_zombie {
         let mut span_regen = SpanRegenerator::new(sess.source_map(), module);
-        for (&zombie_id, zombie) in &zombies {
-            let reason = span_regen.zombie_for_id(zombie.leaf_id).unwrap().reason;
+        for &zombie_id in zombies.id_to_zombie_kind.keys() {
+            let mut zombie_leaf_id = zombie_id;
+            let mut infection_chain = SmallVec::<[_; 4]>::new();
+            loop {
+                zombie_leaf_id = match zombies.get_zombie_by_id(zombie_leaf_id).unwrap().kind {
+                    ZombieKind::Leaf => break,
+                    // FIXME(eddyb) this is all very lossy and should probably go away.
+                    ZombieKind::Uses(zombie_uses) => zombie_uses[0].used_zombie_id,
+                };
+                infection_chain.push(zombie_leaf_id);
+            }
+
+            let reason = span_regen.zombie_for_id(zombie_leaf_id).unwrap().reason;
             eprint!("zombie'd %{zombie_id} because {reason}");
-            if zombie_id != zombie.leaf_id {
-                eprint!(" (infected by %{})", zombie.leaf_id);
+            if !infection_chain.is_empty() {
+                eprint!(" (infected via {:?})", infection_chain);
             }
             eprintln!();
         }
@@ -176,54 +351,46 @@ pub fn remove_zombies(
         let mut span_regen = SpanRegenerator::new(sess.source_map(), module);
         let names = get_names(module);
         for f in &module.functions {
-            if let Some(zombie) = is_zombie(f.def.as_ref().unwrap(), &zombies) {
+            if let Some(zombie) = zombies.get_zombie_by_id(f.def_id().unwrap()) {
+                let mut zombie_leaf_id = zombie.id;
+                loop {
+                    zombie_leaf_id = match zombies.get_zombie_by_id(zombie_leaf_id).unwrap().kind {
+                        ZombieKind::Leaf => break,
+                        // FIXME(eddyb) this is all very lossy and should probably go away.
+                        ZombieKind::Uses(zombie_uses) => zombie_uses[0].used_zombie_id,
+                    };
+                }
+
                 let name = get_name(&names, f.def_id().unwrap());
-                let reason = span_regen.zombie_for_id(zombie.leaf_id).unwrap().reason;
+                let reason = span_regen.zombie_for_id(zombie_leaf_id).unwrap().reason;
                 eprintln!("function removed {name:?} because {reason:?}");
             }
         }
     }
 
-    module
-        .capabilities
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .extensions
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .ext_inst_imports
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    if module
-        .memory_model
-        .as_ref()
-        .map_or(false, |inst| is_zombie(inst, &zombies).is_some())
+    // FIXME(eddyb) this should be unnecessary, either something is unused, and
+    // it will get DCE'd *anyway*, or it caused an error.
     {
-        module.memory_model = None;
+        let keep = |inst: &Instruction| {
+            if let Some(result_id) = inst.result_id {
+                zombies.get_zombie_by_id(result_id).is_none()
+            } else {
+                zombies.zombies_used_from_inst(inst).next().is_none()
+            }
+        };
+        module.capabilities.retain(keep);
+        module.extensions.retain(keep);
+        module.ext_inst_imports.retain(keep);
+        module.memory_model = module.memory_model.take().filter(keep);
+        module.entry_points.retain(keep);
+        module.execution_modes.retain(keep);
+        module.debug_string_source.retain(keep);
+        module.debug_names.retain(keep);
+        module.debug_module_processed.retain(keep);
+        module.annotations.retain(keep);
+        module.types_global_values.retain(keep);
+        module.functions.retain(|f| keep(f.def.as_ref().unwrap()));
     }
-    module
-        .entry_points
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .execution_modes
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .debug_string_source
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .debug_names
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .debug_module_processed
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .annotations
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .types_global_values
-        .retain(|inst| is_zombie(inst, &zombies).is_none());
-    module
-        .functions
-        .retain(|f| is_zombie(f.def.as_ref().unwrap(), &zombies).is_none());
 
     result
 }

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -121,7 +121,7 @@ fn report_error_zombies(
             let reason = span_regen.zombie_for_id(zombie.leaf_id).unwrap().reason;
             let span = span_regen
                 .src_loc_for_id(zombie.leaf_id)
-                .and_then(|src_loc| span_regen.src_loc_to_rustc(&src_loc))
+                .and_then(|src_loc| span_regen.src_loc_to_rustc(src_loc))
                 .unwrap_or(DUMMY_SP);
             let names = names.get_or_insert_with(|| get_names(module));
             let stack = zombie

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -308,7 +308,7 @@ impl<'a> ZombieReporter<'a> {
     }
 }
 
-pub fn remove_zombies(
+pub fn report_and_remove_zombies(
     sess: &Session,
     opts: &super::Options,
     module: &mut Module,

--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -135,6 +135,12 @@ Disables compaction of SPIR-V IDs at the end of linking. Causes absolutely ginor
 emitted. Useful if you're println debugging IDs in the linker (although spirv-opt will compact them
 anyway, be careful).
 
+### `--no-early-report-zombies`
+
+Delays reporting zombies (aka "deferred errors") even further, to allow more legalization.
+Currently this also replaces the zombie reporting with a SPIR-T-based version
+(which may become the default in the future).
+
 ### `--no-structurize`
 
 Disables CFG structurization. Probably results in invalid modules.

--- a/tests/ui/dis/asm_op_decorate.not_spirt.rs
+++ b/tests/ui/dis/asm_op_decorate.not_spirt.rs
@@ -6,6 +6,7 @@
 // compile-flags: -C target-feature=+RuntimeDescriptorArray,+ext:SPV_EXT_descriptor_indexing
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/asm_op_decorate.spirt.rs
+++ b/tests/ui/dis/asm_op_decorate.spirt.rs
@@ -6,6 +6,7 @@
 // compile-flags: -C target-feature=+RuntimeDescriptorArray,+ext:SPV_EXT_descriptor_indexing
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/custom_entry_point.not_spirt.rs
+++ b/tests/ui/dis/custom_entry_point.not_spirt.rs
@@ -5,6 +5,7 @@
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/custom_entry_point.spirt.rs
+++ b/tests/ui/dis/custom_entry_point.spirt.rs
@@ -5,6 +5,7 @@
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/generic-fn-op-name.not_spirt.rs
+++ b/tests/ui/dis/generic-fn-op-name.not_spirt.rs
@@ -7,6 +7,7 @@
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 #![feature(adt_const_params)]

--- a/tests/ui/dis/generic-fn-op-name.spirt.rs
+++ b/tests/ui/dis/generic-fn-op-name.spirt.rs
@@ -7,6 +7,7 @@
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 #![feature(adt_const_params)]

--- a/tests/ui/dis/issue-723-output.not_spirt.rs
+++ b/tests/ui/dis/issue-723-output.not_spirt.rs
@@ -17,6 +17,7 @@
 // build-pass
 // compile-flags: -C debuginfo=0 -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/issue-723-output.spirt.rs
+++ b/tests/ui/dis/issue-723-output.spirt.rs
@@ -17,6 +17,7 @@
 // build-pass
 // compile-flags: -C debuginfo=0 -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/non-writable-storage_buffer.not_spirt.rs
+++ b/tests/ui/dis/non-writable-storage_buffer.not_spirt.rs
@@ -7,6 +7,7 @@
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/non-writable-storage_buffer.not_spirt.stderr
+++ b/tests/ui/dis/non-writable-storage_buffer.not_spirt.stderr
@@ -8,8 +8,8 @@ OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-%2 = OpString "$OPSTRING_FILENAME/non-writable-storage_buffer.not_spirt.rs"
-%3 = OpString "$OPSTRING_FILENAME/cell.rs"
+%2 = OpString "$OPSTRING_FILENAME/cell.rs"
+%3 = OpString "$OPSTRING_FILENAME/non-writable-storage_buffer.not_spirt.rs"
 OpName %4 "buf_imm"
 OpName %5 "buf_mut"
 OpName %6 "buf_interior_mut"

--- a/tests/ui/dis/non-writable-storage_buffer.spirt.rs
+++ b/tests/ui/dis/non-writable-storage_buffer.spirt.rs
@@ -7,6 +7,7 @@
 // build-pass
 // compile-flags: -C llvm-args=--disassemble-globals
 // normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,4 +1,4 @@
-error: Cannot memcpy dynamically sized data
+error: cannot memcpy dynamically sized data
     --> $CORE_SRC/intrinsics.rs:2460:9
      |
 2460 |         copy(src, dst, count)

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -2,7 +2,7 @@ error: Cannot memcpy dynamically sized data
     --> $CORE_SRC/intrinsics.rs:2460:9
      |
 2460 |         copy(src, dst, count)
-     |         ^^^^^^^^^^^^^^^^^^^^^
+     |         ^
      |
      = note: Stack:
              core::intrinsics::copy::<f32>

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -4,11 +4,26 @@ error: Cannot memcpy dynamically sized data
 2460 |         copy(src, dst, count)
      |         ^
      |
-     = note: Stack:
-             core::intrinsics::copy::<f32>
-             ptr_copy::copy_via_raw_ptr
-             ptr_copy::main
-             main
+note: used from within `core::intrinsics::copy::<f32>`
+    --> $CORE_SRC/intrinsics.rs:2447:21
+     |
+2447 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+     |                     ^
+note: called by `ptr_copy::copy_via_raw_ptr`
+    --> $DIR/ptr_copy.rs:30:18
+     |
+30   |         unsafe { core::ptr::copy(src, dst, 1) }
+     |                  ^
+note: called by `ptr_copy::main`
+    --> $DIR/ptr_copy.rs:35:5
+     |
+35   |     copy_via_raw_ptr(&i, o);
+     |     ^
+note: called by `main`
+    --> $DIR/ptr_copy.rs:33:1
+     |
+33   | #[spirv(fragment)]
+     | ^
 
 error: aborting due to previous error
 

--- a/tests/ui/lang/consts/nested-ref-in-composite.stderr
+++ b/tests/ui/lang/consts/nested-ref-in-composite.stderr
@@ -2,7 +2,7 @@ error: constant arrays/structs cannot contain pointers to other constants
   --> $DIR/nested-ref-in-composite.rs:20:17
    |
 20 |     *pair_out = pair_deep_load(&(&123, &3.14));
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^
    |
    = note: Stack:
            nested_ref_in_composite::main_pair
@@ -12,7 +12,7 @@ error: constant arrays/structs cannot contain pointers to other constants
   --> $DIR/nested-ref-in-composite.rs:25:19
    |
 25 |     *array3_out = array3_deep_load(&[&0, &1, &2]);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^
    |
    = note: Stack:
            nested_ref_in_composite::main_array3

--- a/tests/ui/lang/consts/nested-ref-in-composite.stderr
+++ b/tests/ui/lang/consts/nested-ref-in-composite.stderr
@@ -4,9 +4,16 @@ error: constant arrays/structs cannot contain pointers to other constants
 20 |     *pair_out = pair_deep_load(&(&123, &3.14));
    |                 ^
    |
-   = note: Stack:
-           nested_ref_in_composite::main_pair
-           main_pair
+note: used from within `nested_ref_in_composite::main_pair`
+  --> $DIR/nested-ref-in-composite.rs:20:17
+   |
+20 |     *pair_out = pair_deep_load(&(&123, &3.14));
+   |                 ^
+note: called by `main_pair`
+  --> $DIR/nested-ref-in-composite.rs:18:1
+   |
+18 | #[spirv(fragment)]
+   | ^
 
 error: constant arrays/structs cannot contain pointers to other constants
   --> $DIR/nested-ref-in-composite.rs:25:19
@@ -14,9 +21,16 @@ error: constant arrays/structs cannot contain pointers to other constants
 25 |     *array3_out = array3_deep_load(&[&0, &1, &2]);
    |                   ^
    |
-   = note: Stack:
-           nested_ref_in_composite::main_array3
-           main_array3
+note: used from within `nested_ref_in_composite::main_array3`
+  --> $DIR/nested-ref-in-composite.rs:25:19
+   |
+25 |     *array3_out = array3_deep_load(&[&0, &1, &2]);
+   |                   ^
+note: called by `main_array3`
+  --> $DIR/nested-ref-in-composite.rs:23:1
+   |
+23 | #[spirv(fragment)]
+   | ^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -1,8 +1,15 @@
 error: pointer has non-null integer address
-  |
-  = note: Stack:
-          allocate_const_scalar::main
-          main
+   |
+note: used from within `allocate_const_scalar::main`
+  --> $DIR/allocate_const_scalar.rs:15:20
+   |
+15 |     let _pointer = POINTER;
+   |                    ^
+note: called by `main`
+  --> $DIR/allocate_const_scalar.rs:13:1
+   |
+13 | #[spirv(fragment)]
+   | ^
 
 error: aborting due to previous error
 

--- a/tests/ui/lang/core/ref/member_ref_arg-broken.rs
+++ b/tests/ui/lang/core/ref/member_ref_arg-broken.rs
@@ -1,0 +1,53 @@
+// FIXME(eddyb) this is like `member_ref_arg`, but testing the error messages
+// in some broken cases - this test should eventually pass, but for now
+// we care more that the error messages do not regress too much.
+
+// build-fail
+// normalize-stderr-not_spirt "36\[%36\]" -> "$$ID[%$$ID]"
+// normalize-stderr-spirt     "38\[%38\]" -> "$$ID[%$$ID]"
+// normalize-stderr-test "(note: module `.*)\.(not_spirt|spirt)`" -> "$1.{not_spirt,spirt}`"
+
+use spirv_std::spirv;
+
+struct S {
+    x: u32,
+    y: u32,
+}
+
+// NOTE(eddyb) `#[inline(never)]` is for blocking inlining at the e.g. MIR level,
+// whereas any Rust-GPU-specific legalization will intentially ignore it.
+
+#[inline(never)]
+fn f(x: &u32) -> u32 {
+    *x
+}
+
+#[inline(never)]
+fn g(xy: (&u32, &u32)) -> (u32, u32) {
+    (*xy.0, *xy.1)
+}
+
+#[inline(never)]
+fn h(xyz: (&u32, &u32, &u32)) -> (u32, u32, u32) {
+    (*xyz.0, *xyz.1, *xyz.2)
+}
+
+// FIXME(eddyb) the reason this doesn't work while the others do, is somewhat
+// subtle - specifically, we currently have some passes (`destructure_composites`
+// and `spirt_passes::reduce`) which can handle single-level `OpComposite*`
+// instructions, but the extra nesting here stops them dead in their tracks
+// (they're also not really the right solution for this problem, such composites
+// should just never exist by-value, and `qptr` may very well get rid of them).
+#[inline(never)]
+fn h_newtyped(xyz: ((&u32, &u32, &u32),)) -> (u32, u32, u32) {
+    (*xyz.0 .0, *xyz.0 .1, *xyz.0 .2)
+}
+
+#[spirv(fragment)]
+pub fn main() {
+    let s = S { x: 2, y: 2 };
+    f(&s.x);
+    g((&s.x, &s.y));
+    h((&s.x, &s.y, &s.x));
+    h_newtyped(((&s.x, &s.y, &s.x),));
+}

--- a/tests/ui/lang/core/ref/member_ref_arg-broken.stderr
+++ b/tests/ui/lang/core/ref/member_ref_arg-broken.stderr
@@ -1,0 +1,11 @@
+warning: `#[inline(never)]` function `member_ref_arg_broken::h` needs to be inlined because it has illegal argument or return types
+
+warning: `#[inline(never)]` function `member_ref_arg_broken::h_newtyped` needs to be inlined because it has illegal argument or return types
+
+error: error:0:0 - OpLoad Pointer <id> '$ID[%$ID]' is not a logical pointer.
+  |
+  = note: spirv-val failed
+  = note: module `$TEST_BUILD_DIR/lang/core/ref/member_ref_arg-broken.{not_spirt,spirt}`
+
+error: aborting due to previous error; 2 warnings emitted
+

--- a/tests/ui/lang/core/ref/zst_member_ref_arg-broken.rs
+++ b/tests/ui/lang/core/ref/zst_member_ref_arg-broken.rs
@@ -1,0 +1,34 @@
+// FIXME(eddyb) this is like `zst_member_ref_arg`, but testing the error messages
+// in some broken cases (see issue #1037) - this test should eventually pass, but
+// for now we care more that the error messages do not regress too much.
+
+// build-fail
+
+use spirv_std::spirv;
+struct A;
+struct B;
+
+pub struct S<Z, W = ()> {
+    x: A,
+    y: B,
+
+    z: Z,
+    w: W,
+}
+
+fn f(x: &B) {}
+
+#[spirv(fragment)]
+pub fn main_scalar(#[spirv(push_constant)] s: &S<usize>) {
+    f(&s.y);
+}
+
+#[spirv(fragment)]
+pub fn main_scalar_pair(#[spirv(push_constant)] s: &S<usize, usize>) {
+    f(&s.y);
+}
+
+#[spirv(fragment)]
+pub fn main_scalar_scalar_pair_nested(#[spirv(push_constant)] s: &S<(usize, usize)>) {
+    f(&s.y);
+}

--- a/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
+++ b/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
@@ -1,0 +1,29 @@
+error: Cannot cast between pointer types
+  --> $DIR/zst_member_ref_arg-broken.rs:23:5
+   |
+23 |     f(&s.y);
+   |     ^^^^^^^
+   |
+   = note: from: *u32
+   = note: to: *struct B {  }
+
+error: Cannot cast between pointer types
+  --> $DIR/zst_member_ref_arg-broken.rs:28:5
+   |
+28 |     f(&s.y);
+   |     ^^^^^^^
+   |
+   = note: from: *struct S<usize, usize> { u32, u32 }
+   = note: to: *struct B {  }
+
+error: Cannot cast between pointer types
+  --> $DIR/zst_member_ref_arg-broken.rs:33:5
+   |
+33 |     f(&s.y);
+   |     ^^^^^^^
+   |
+   = note: from: *struct (usize, usize) { u32, u32 }
+   = note: to: *struct B {  }
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
+++ b/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
@@ -1,29 +1,59 @@
-error: Cannot cast between pointer types
-  --> $DIR/zst_member_ref_arg-broken.rs:23:5
-   |
-23 |     f(&s.y);
-   |     ^^^^^^^
-   |
-   = note: from: *u32
-   = note: to: *struct B {  }
-
-error: Cannot cast between pointer types
-  --> $DIR/zst_member_ref_arg-broken.rs:28:5
-   |
-28 |     f(&s.y);
-   |     ^^^^^^^
-   |
-   = note: from: *struct S<usize, usize> { u32, u32 }
-   = note: to: *struct B {  }
-
-error: Cannot cast between pointer types
+error: cannot cast between pointer types
+       from `*struct (usize, usize) { u32, u32 }`
+         to `*struct B {  }`
   --> $DIR/zst_member_ref_arg-broken.rs:33:5
    |
 33 |     f(&s.y);
-   |     ^^^^^^^
+   |     ^
    |
-   = note: from: *struct (usize, usize) { u32, u32 }
-   = note: to: *struct B {  }
+note: used from within `zst_member_ref_arg_broken::main_scalar_scalar_pair_nested`
+  --> $DIR/zst_member_ref_arg-broken.rs:33:5
+   |
+33 |     f(&s.y);
+   |     ^
+note: called by `main_scalar_scalar_pair_nested`
+  --> $DIR/zst_member_ref_arg-broken.rs:31:1
+   |
+31 | #[spirv(fragment)]
+   | ^
+
+error: cannot cast between pointer types
+       from `*struct (usize, usize) { u32, u32 }`
+         to `*struct B {  }`
+  --> $DIR/zst_member_ref_arg-broken.rs:33:5
+   |
+33 |     f(&s.y);
+   |     ^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar`
+  --> $DIR/zst_member_ref_arg-broken.rs:23:5
+   |
+23 |     f(&s.y);
+   |     ^
+note: called by `main_scalar`
+  --> $DIR/zst_member_ref_arg-broken.rs:21:1
+   |
+21 | #[spirv(fragment)]
+   | ^
+
+error: cannot cast between pointer types
+       from `*struct (usize, usize) { u32, u32 }`
+         to `*struct B {  }`
+  --> $DIR/zst_member_ref_arg-broken.rs:33:5
+   |
+33 |     f(&s.y);
+   |     ^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar_pair`
+  --> $DIR/zst_member_ref_arg-broken.rs:28:5
+   |
+28 |     f(&s.y);
+   |     ^
+note: called by `main_scalar_pair`
+  --> $DIR/zst_member_ref_arg-broken.rs:26:1
+   |
+26 | #[spirv(fragment)]
+   | ^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This PR has roughly three broad stages:
1. standard SPIR-V `OpSource` is used instead of `rustc` `SourceFile` hashes
   * suboptimal because it keeps Rust source code in the SPIR-V files
     * impact greatly redunced thanks to https://github.com/EmbarkStudios/rust-gpu/pull/1035
     * the `OpSource`s still get stripped out out at the very end by default
     * there's sadly no standard way (even with `NonSemantic` debuginfo extensions) to use the paths+hashes approach in SPIR-V
   * `rustc` `SourceFile`s can still be accurately regenerated from the paths+sources
   * using the standard `OpSource` mechanism might allow other tools to work well long-term
2. better reporting of the "zombie" (deferred errors) usage stack trace
   * (see also below for a longer example)
   * mostly using information that was already there (just cumbersome to extract outside of SPIR-T)
   * this PR also replaces all "error in use code, zombie in `core` & friends" logic to *always* zombie, as the errors are on average higher-quality now for zombies
3. a SPIR-T pass for reporting diagnostics, along the above lines
   * only zombies for now (gated behind `--no-early-report-zombies`, which makes it replace the existing zombie reporting pass, i.e. the "early zombie reporting")
   * this is most of what's needed to integrate https://github.com/EmbarkStudios/spirt/pull/22

---

For 2. we have this change in diagnostics:
<table>
<tr><th>before this PR</th><th>after this PR</th></tr>
<tr><td><pre>
error: Cannot memcpy dynamically sized data
    --> $CORE_SRC/intrinsics.rs:2460:9
     |
2460 |         copy(src, dst, count)
     |         ^^^^^^^^^^^^^^^^^^^^^
     |
     = note: Stack:
             core::intrinsics::copy::<f32>
             ptr_copy::copy_via_raw_ptr
             ptr_copy::main
             main
</pre></td><td><pre>
error: cannot memcpy dynamically sized data
    --> $CORE_SRC/intrinsics.rs:2460:9
     |
2460 |         copy(src, dst, count)
     |         ^
     |
note: used from within `core::intrinsics::copy::<f32>`
    --> $CORE_SRC/intrinsics.rs:2447:21
     |
2447 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     |                     ^
note: called by `ptr_copy::copy_via_raw_ptr`
    --> $DIR/ptr_copy.rs:30:18
     |
30   |         unsafe { core::ptr::copy(src, dst, 1) }
     |                  ^
note: called by `ptr_copy::main`
    --> $DIR/ptr_copy.rs:35:5
     |
35   |     copy_via_raw_ptr(&i, o);
     |     ^
note: called by `main`
    --> $DIR/ptr_copy.rs:33:1
     |
33   | #[spirv(fragment)]
     | ^
</pre></td></tr></table>