### PR TITLE
Use `.rsplit_once("/src/")` instead of `.split_once("/src/")`.

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
@@ -332,7 +332,7 @@ impl DiagnosticReporter<'_> {
             let prefix = match level {
                 DiagLevel::Bug(location) => {
                     let location = location.to_string();
-                    let location = match location.split_once("/src/") {
+                    let location = match location.rsplit_once("/src/") {
                         Some((_path_prefix, intra_src)) => intra_src,
                         None => &location,
                     };


### PR DESCRIPTION
Didn't realize it would be a problem (and it's only after `spirt 0.2.0` was release), but it caused:
```
error: SPIR-T BUG [github.com-1ecc6299db9ec823/spirt-0.2.0/src/qptr/analyze.rs:210:58] merge_mem: conflicts:
```
Whereas the intended output (which this PR gets from `rsplit_once`) was:
```
error: SPIR-T BUG [qptr/analyze.rs:210:58] merge_mem: conflicts:
```
`spirt::print` has the same bug but that's less user-visible so I won't bother releasing `0.2.1` today.