### PR TITLE
Faster Mac CI with new XL builders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macOS-latest
+          - os: macOS-latest-xl
             target: x86_64-apple-darwin
           - os: ubuntu-20.04-16core
             target: aarch64-linux-android


### PR DESCRIPTION
Use 12 core machines instead of 3 core. This reduces build time from 17 minutes to 8 minutes.
