### PR TITLE
Faster Windows CI with 16 core runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: ubuntu-20.04-16core
             target: x86_64-unknown-linux-gnu
-          - os: windows-latest
+          - os: windows-2022-16core
             target: x86_64-pc-windows-msvc
           - os: macOS-latest-xl
             target: x86_64-apple-darwin


### PR DESCRIPTION
Attempted this back in #923 & 718aa89edf61e2e6123ab9f8f1013577fe2bbc6e  but ran into some unknown issues with it. This attempts it again to see if GitHub has resolved the issues.

Reduces build time from 15:30 to 9:40 min.
