### PR TITLE
Added barrier to panic loop.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -363,7 +363,7 @@ impl<'a, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'tcx> {
             let uint = builder.type_int(32, 0);
             let memory = builder.constant_u32(uint, memory);
             let semantics = builder.constant_u32(uint, semantics);
-            builder.memory_barrier(memory, semantics).unwrap()
+            builder.memory_barrier(memory, semantics).unwrap();
         }
         self.br(abort_loop_bb);
 


### PR DESCRIPTION
Related to #1048.

On `panic!`, rustc_codegen_spirv emits a `loop {}`, but this can be optimized away with spirv-opt due to the AgressiveDCE pass. This PR inserts a memory_barrier inside the loop which prevents it from being removed. 

This ensures that shaders that panic, ie from out of bounds accesses, will not silently continue execution but hang the app. 

Unfortunately the wgpu compute example errors with `UnsupportedInstruction(Function, MemoryBarrier)`, likely naga does not support barriers. 

It does work using `create_shader_module_spirv` and enabling the features `Features::SPIRV_SHADER_PASSTHROUGH | Features::TIMESTAMP_QUERY_INSIDE_PASSES`. 

Edit:
Replaced with https://github.com/charles-r-earp/rust-gpu/tree/panic-abort.

The idea is for panic! to emit OpKill / OpTerminateInvocation and replace that with a return from the entry point after inlining. Additionally it will use debug_printfln! if available so that it's easier to detect panics while developing. 
