### PR TITLE
Add missing `--no-infer-storage-classes` docs to `codegen-args.md`.

### DIFF
--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -141,6 +141,15 @@ Delays reporting zombies (aka "deferred errors") even further, to allow more leg
 Currently this also replaces the zombie reporting with a SPIR-T-based version
 (which may become the default in the future).
 
+### `--no-infer-storage-classes`
+
+Disables the old SPIR-V "Storage Class" (i.e. address space) inference pass,
+to allow testing alternatives to it (such as SPIR-T `qptr` passes).
+
+Note that this will produce illegal SPIR-V by default, and you need e.g.
+`--spirt-passes=qptr` in order to regain legal "Storage Class" assignments  
+(see [SPIR-T `qptr` PR](https://github.com/EmbarkStudios/spirt/pull/24) for more information on `qptr` in general)
+
 ### `--no-structurize`
 
 Disables CFG structurization. Probably results in invalid modules.


### PR DESCRIPTION
I wrote this for the PR that added `--no-infer-storage-classes`, but forgot to actually commit it.