### PR TITLE
Inliner: rewrite IDs on decorations fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (`0.11.1` for `wgpu 0.15`, `0.12.1` for `wgpu 0.16`, and any later versions)
 
 ### Fixed 🩹
-- [PR#1059](https://github.com/EmbarkStudios/rust-gpu/pull/1059) Fix bug where the `inline` pass would not rewrite `OpDecorate` IDs, which would subsequently loose those decorations in later DCE passes.
+- [PR#1059](https://github.com/EmbarkStudios/rust-gpu/pull/1059) fixed the `inline` pass not copying `OpDecorate`s in the callee (which led to their loss).
 
 ## [0.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     you may be able to `cargo update -p naga` to update to a fixed `naga` version  
     (`0.11.1` for `wgpu 0.15`, `0.12.1` for `wgpu 0.16`, and any later versions)
 
+### Fixed 🩹
+- [PR#1059](https://github.com/EmbarkStudios/rust-gpu/pull/1059) Fix bug where the `inline` pass would not rewrite `OpDecorate` IDs, which would subsequently loose those decorations in later DCE passes.
+
 ## [0.7.0]
 
 ### Added ⭐

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -352,7 +352,7 @@ impl Inliner<'_, '_> {
         result
     }
 
-    ///Applies all rewrite rules to the decorations in the header.
+    /// Applies all rewrite rules to the decorations in the header.
     fn apply_rewrite_for_decorations(&mut self, rewrite_rules: &FxHashMap<Word, Word>) {
         // NOTE(siebencorgie): We don't care *what* decoration we rewrite atm. AFAIK there is no case where rewriting
         // the decoration on inline wouldn't be valid.
@@ -360,7 +360,7 @@ impl Inliner<'_, '_> {
             if self.annotations[annotation_idx].class.opcode == Op::Decorate {
                 if let Some(id) = self.annotations[annotation_idx].operands[0].id_ref_any_mut() {
                     if let Some(&rewrite) = rewrite_rules.get(id) {
-                        //Copy decoration instruction and push it.
+                        // Copy decoration instruction and push it.
                         let mut instcpy = self.annotations[annotation_idx].clone();
                         *instcpy.operands[0].id_ref_any_mut().unwrap() = rewrite;
                         self.annotations.push(instcpy);


### PR DESCRIPTION
Currently the inliner only rewrites IDs in the 'inlined_callee_blocks'. Therefore 'OpDecorate %id' on any '%id' that is rewritten is lost in this pass.

This fix applies the rewrite rules to all decorations as well.
