### PR TITLE
rustup: update to `nightly-2023-04-15`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (using ranges instead of just the starting position, and tracking inlined calls)
 
 ### Changed 🛠
+- [PR#1067](https://github.com/EmbarkStudios/rust-gpu/pull/1067) updated toolchain to `nightly-2023-04-15`
 - [PR#1038](https://github.com/EmbarkStudios/rust-gpu/pull/1038) relaxed `glam` version requirements (from only `0.22`, to `>=0.22, <=0.24`)
 
 ### Removed 🔥
@@ -66,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (see also [the `--no-early-report-zombies` codegen args docs](docs/src/codegen-args.md#--no-early-report-zombies))
 - [PR#1035](https://github.com/EmbarkStudios/rust-gpu/pull/1035) reduced the number of CGUs ("codegen units") used by `spirv-builder` to just `1`
 - [PR#1011](https://github.com/EmbarkStudios/rust-gpu/pull/1011) made `NonWritable` all read-only storage buffers (i.e. those typed `&T`, where `T` doesn't have interior mutability)
-- [PR#1029](https://github.com/EmbarkStudios/rust-gpu/pull/1029) fixed SampledImage::sample() fns being unnecessarily marked as unsafe
+- [PR#1029](https://github.com/EmbarkStudios/rust-gpu/pull/1029) fixed `SampledImage::sample` `fn`s being unnecessarily marked as `unsafe`
+- [PR#1005](https://github.com/EmbarkStudios/rust-gpu/pull/1005) updated toolchain to `nightly-2023-03-04`
 
 ### Fixed 🩹
 - [PR#1041](https://github.com/EmbarkStudios/rust-gpu/pull/1041) fixed `Image::gather()` not always returning a `Vec4`.

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -10,9 +10,9 @@ use std::process::{Command, ExitCode};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2023-03-04"
+channel = "nightly-2023-04-15"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = 44cfafe2fafe816395d3acc434663a45d5178c41"#;
+# commit_hash = 84dd17b56a931a631a23dfd5ef2018fd3ef49108"#;
 
 fn get_rustc_commit_hash() -> Result<String, Box<dyn Error>> {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -424,7 +424,7 @@ impl<'tcx> ConvSpirvType<'tcx> for TyAndLayout<'tcx> {
                 if let TyKind::Adt(adt, _) = self.ty.kind() {
                     if let Variants::Single { index } = self.variants {
                         for i in self.fields.index_by_increasing_offset() {
-                            let field = &adt.variants()[index].fields[i];
+                            let field = &adt.variants()[index].fields[i.into()];
                             field_names.push(field.name);
                         }
                     }
@@ -711,7 +711,7 @@ fn trans_struct<'tcx>(cx: &CodegenCx<'tcx>, span: Span, ty: TyAndLayout<'tcx>) -
         field_offsets.push(offset);
         if let Variants::Single { index } = ty.variants {
             if let TyKind::Adt(adt, _) = ty.ty.kind() {
-                let field = &adt.variants()[index].fields[i];
+                let field = &adt.variants()[index].fields[i.into()];
                 field_names.push(field.name);
             } else {
                 // FIXME(eddyb) this looks like something that should exist in rustc.

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -683,6 +683,11 @@ impl<'tcx> BuilderSpirv<'tcx> {
         &self,
         span: Span,
     ) -> (DebugFileSpirv<'tcx>, Range<(u32, u32)>) {
+        // HACK(eddyb) this is similar to what `#[track_caller]` does, and it
+        // allows us to point to the use site of a macro, instead of inside the
+        // macro (but ideally we would record the entire macro backtrace).
+        let span = span.ctxt().outer_expn().expansion_cause().unwrap_or(span);
+
         let (lo, hi) = (span.lo(), span.hi());
 
         let lo_loc = self.source_map.lookup_char_pos(lo);

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -127,6 +127,10 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
     fn const_undef(&self, ty: Self::Type) -> Self::Value {
         self.undef(ty)
     }
+    fn const_poison(&self, ty: Self::Type) -> Self::Value {
+        // No distinction between undef and poison.
+        self.const_undef(ty)
+    }
     fn const_int(&self, t: Self::Type, i: i64) -> Self::Value {
         self.constant_int(t, i as u64)
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -69,7 +69,7 @@ pub struct CodegenCx<'tcx> {
     // it mandatory even for `panic!("...")` (that were previously separate).
     pub panic_entry_point_ids: RefCell<FxHashSet<Word>>,
 
-    /// `core::fmt::Arguments::new_v1` instances (for Rust 2021 panics).
+    /// `core::fmt::Arguments::new_{v1,const}` instances (for Rust 2021 panics).
     pub fmt_args_new_fn_ids: RefCell<FxHashSet<Word>>,
 
     /// Intrinsic for loading a <T> from a &[u32]. The PassMode is the mode of the <T>.

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -19,7 +19,7 @@
 #![feature(assert_matches)]
 #![feature(result_flattening)]
 #![feature(lint_reasons)]
-#![feature(once_cell)]
+#![feature(lazy_cell)]
 // crate-specific exceptions:
 #![allow(
     unsafe_code,                // rustc_codegen_ssa requires unsafe functions in traits to be impl'd
@@ -104,7 +104,7 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::mir::mono::{Linkage, MonoItem, Visibility};
 use rustc_middle::mir::pretty::write_mir_pretty;
 use rustc_middle::ty::print::with_no_trimmed_paths;
-use rustc_middle::ty::{self, query, DefIdTree, Instance, InstanceDef, TyCtxt};
+use rustc_middle::ty::{self, query, Instance, InstanceDef, TyCtxt};
 use rustc_session::config::{self, OutputFilenames, OutputType};
 use rustc_session::Session;
 use rustc_span::symbol::{sym, Symbol};

--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -195,6 +195,8 @@ pub fn gpu_only(_attr: TokenStream, item: TokenStream) -> TokenStream {
         block,
     } = syn::parse_macro_input!(item as syn::ItemFn);
 
+    // FIXME(eddyb) this looks like a clippy false positive (`sig` is used below).
+    #[allow(clippy::redundant_clone)]
     let fn_name = sig.ident.clone();
 
     let sig_cpu = syn::Signature {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2023-03-04"
+channel = "nightly-2023-04-15"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = 44cfafe2fafe816395d3acc434663a45d5178c41
+# commit_hash = 84dd17b56a931a631a23dfd5ef2018fd3ef49108
 
 # Whenever changing the nightly channel, update the commit hash above, and make
-# sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also.
+# sure to change `REQUIRED_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` also.

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,13 +1,13 @@
 error: cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2460:9
+    --> $CORE_SRC/intrinsics.rs:2724:9
      |
-2460 |         copy(src, dst, count)
+2724 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
      |
 note: used from within `core::intrinsics::copy::<f32>`
-    --> $CORE_SRC/intrinsics.rs:2447:21
+    --> $CORE_SRC/intrinsics.rs:2710:21
      |
-2447 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+2710 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
      |                     ^^^^
 note: called by `ptr_copy::copy_via_raw_ptr`
     --> $DIR/ptr_copy.rs:28:18

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1157 8
+OpLine %8 1188 12
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1157 8
+OpLine %8 1188 12
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1354 8
+OpLine %11 1386 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1354 8
+OpLine %11 1386 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/lang/core/unwrap_or.stderr
+++ b/tests/ui/lang/core/unwrap_or.stderr
@@ -3,9 +3,9 @@
 OpLine %5 13 11
 %6 = OpCompositeInsert  %7  %8 %9 0
 %10 = OpCompositeExtract  %11  %6 1
-OpLine %12 967 14
+OpLine %12 975 14
 %13 = OpBitcast  %14  %8
-OpLine %12 967 8
+OpLine %12 975 8
 %15 = OpIEqual  %16  %13 %17
 OpNoLine
 OpSelectionMerge %18 None

--- a/tests/ui/spirv-attr/invalid-matrix-type-empty.rs
+++ b/tests/ui/spirv-attr/invalid-matrix-type-empty.rs
@@ -4,9 +4,7 @@
 use spirv_std::spirv;
 
 #[spirv(matrix)]
-pub struct _EmptyStruct {}
+pub struct EmptyStruct {}
 
 #[spirv(fragment)]
-pub fn _entry() {
-    let _empty_struct = _EmptyStruct {};
-}
+pub fn entry(#[spirv(push_constant)] matrix: &EmptyStruct) {}

--- a/tests/ui/spirv-attr/invalid-matrix-type-empty.stderr
+++ b/tests/ui/spirv-attr/invalid-matrix-type-empty.stderr
@@ -1,8 +1,8 @@
 error: #[spirv(matrix)] type must have at least two fields
  --> $DIR/invalid-matrix-type-empty.rs:7:1
   |
-7 | pub struct _EmptyStruct {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^
+7 | pub struct EmptyStruct {}
+  | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is the last step before we can release `0.8`.

**EDIT**: this ended up needing a messy refactor to our panic handling (see second commit) due to:
* https://github.com/rust-lang/rust/pull/101959