### PR TITLE
Add `rustfmt.toml` with `version = "Two"` to enable formatting array patterns.

### DIFF
--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -42,7 +42,9 @@ fn check_toolchain_version() -> Result<(), Box<dyn Error>> {
             return Err(Box::<dyn Error>::from(format!(
                 "error: building from local source while `REQUIRED_RUST_TOOLCHAIN` (defined in `{}`) doesn't match `{}`",
                 file!(),
-                std::path::Path::new("../../rust-toolchain.toml").canonicalize()?.display()
+                std::path::Path::new("../../rust-toolchain.toml")
+                    .canonicalize()?
+                    .display()
             )));
         }
     }

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -162,7 +162,7 @@ pub(crate) fn provide(providers: &mut Providers) {
         if hide_niche {
             layout = tcx.mk_layout(LayoutS {
                 largest_niche: None,
-                ..clone_layout(layout.0 .0)
+                ..clone_layout(layout.0.0)
             });
         }
 

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -2397,10 +2397,13 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             // HACK(eddyb) this is basically a `try` block.
             let remove_format_args_if_possible = || -> Option<()> {
                 let format_args_id = match args {
-                    &[SpirvValue {
-                        kind: SpirvValueKind::Def(format_args_id),
-                        ..
-                    }, _] => format_args_id,
+                    &[
+                        SpirvValue {
+                            kind: SpirvValueKind::Def(format_args_id),
+                            ..
+                        },
+                        _,
+                    ] => format_args_id,
 
                     _ => return None,
                 };
@@ -2503,15 +2506,13 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
                 let (rt_args_slice_ptr_id, rt_args_count) = match try_rev_take(3)?[..] {
                     [
-                        // HACK(eddyb) comment works around `rustfmt` array bugs.
                         Inst::Call(call_ret_id, callee_id, ref call_args),
                         Inst::Store(st_dst_id, st_val_id),
                         Inst::Load(ld_val_id, ld_src_id),
-                    ]
-                        if self.fmt_args_new_fn_ids.borrow().contains(&callee_id)
-                            && call_ret_id == st_val_id
-                            && st_dst_id == ld_src_id
-                            && ld_val_id == format_args_id =>
+                    ] if self.fmt_args_new_fn_ids.borrow().contains(&callee_id)
+                        && call_ret_id == st_val_id
+                        && st_dst_id == ld_src_id
+                        && ld_val_id == format_args_id =>
                     {
                         require_local_var(st_dst_id)?;
                         match call_args[..] {
@@ -2565,7 +2566,6 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                     {
                         let rt_arg_var_id = match init_of_rt_arg_var_insts[..] {
                             [
-                                // HACK(eddyb) comment works around `rustfmt` array bugs.
                                 Inst::Bitcast(b, _),
                                 Inst::Bitcast(a, _),
                                 Inst::AccessChain(a_ptr, a_base_ptr, SpirvConst::U32(0)),
@@ -2587,7 +2587,6 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                             copy_from_rt_arg_var_to_rt_args_array_insts.split_at(4);
                         let (a, b) = match copy_loads[..] {
                             [
-                                // HACK(eddyb) comment works around `rustfmt` array bugs.
                                 Inst::AccessChain(a_ptr, a_base_ptr, SpirvConst::U32(0)),
                                 Inst::Load(a_ld_val, a_ld_src),
                                 Inst::AccessChain(b_ptr, b_base_ptr, SpirvConst::U32(1)),
@@ -2601,8 +2600,11 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                         };
                         match copy_stores[..] {
                             [
-                                // HACK(eddyb) comment works around `rustfmt` array bugs.
-                                Inst::InBoundsAccessChain(array_slot_ptr, array_base_ptr, SpirvConst::U32(array_idx)),
+                                Inst::InBoundsAccessChain(
+                                    array_slot_ptr,
+                                    array_base_ptr,
+                                    SpirvConst::U32(array_idx),
+                                ),
                                 Inst::AccessChain(a_ptr, a_base_ptr, SpirvConst::U32(0)),
                                 Inst::Store(a_st_dst, a_st_val),
                                 Inst::AccessChain(b_ptr, b_base_ptr, SpirvConst::U32(1)),
@@ -2611,9 +2613,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                                 && array_idx as usize == rt_arg_idx
                                 && [a_base_ptr, b_base_ptr] == [array_slot_ptr; 2]
                                 && (a, b) == (a_st_val, b_st_val)
-                                && (a_ptr, b_ptr) == (a_st_dst, b_st_dst) =>
-                            {
-                            }
+                                && (a_ptr, b_ptr) == (a_st_dst, b_st_dst) => {}
                             _ => return None,
                         }
                     }

--- a/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
+++ b/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
@@ -177,7 +177,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 return SpirvValue {
                     kind: SpirvValueKind::IllegalTypeUsed(result_type),
                     ty: result_type,
-                }
+                };
             }
             // PassMode::Pair is identical to PassMode::Direct - it's returned as a struct
             PassMode::Direct(_) | PassMode::Pair(_, _) => (),

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -719,10 +719,12 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
         // FIXME(eddyb) try multiple signatures until one fits.
         let mut sig = match instruction_signatures(instruction.class.opcode)? {
-            [sig @ InstSig {
-                output_type: Some(_),
-                ..
-            }] => *sig,
+            [
+                sig @ InstSig {
+                    output_type: Some(_),
+                    ..
+                },
+            ] => *sig,
             _ => return None,
         };
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -487,10 +487,10 @@ impl<'tcx> CodegenCx<'tcx> {
                     *offset += size;
                 } else {
                     assert_eq!(
-                    offset.bytes_usize(),
-                    alloc.inner().len(),
-                    "create_const_alloc must consume all bytes of an Allocation after an unsized struct"
-                );
+                        offset.bytes_usize(),
+                        alloc.inner().len(),
+                        "create_const_alloc must consume all bytes of an Allocation after an unsized struct"
+                    );
                 }
                 self.constant_composite(ty, values.into_iter())
             }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -500,7 +500,7 @@ impl CodegenArgs {
             Some(v) => {
                 return Err(rustc_session::getopts::Fail::UnrecognizedOption(
                     v.to_string(),
-                ))
+                ));
             }
         };
 

--- a/crates/rustc_codegen_spirv/src/custom_decorations.rs
+++ b/crates/rustc_codegen_spirv/src/custom_decorations.rs
@@ -472,11 +472,7 @@ impl<'a> SpanRegenerator<'a> {
                     })
                     .unwrap_or(false);
 
-                if sf_src_matches {
-                    Some(sf)
-                } else {
-                    None
-                }
+                if sf_src_matches { Some(sf) } else { None }
             });
         }
         file.as_deref()

--- a/crates/rustc_codegen_spirv/src/linker/mem2reg.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mem2reg.rs
@@ -125,10 +125,11 @@ fn compute_idom(preds: &[Vec<usize>], reachable_blocks: &[bool]) -> Vec<Option<u
             }
         }
     }
-    assert!(idom
-        .iter()
-        .enumerate()
-        .all(|(i, x)| x.is_some() == reachable_blocks[i]));
+    assert!(
+        idom.iter()
+            .enumerate()
+            .all(|(i, x)| x.is_some() == reachable_blocks[i])
+    );
     idom
 }
 

--- a/crates/rustc_codegen_spirv/src/linker/specializer.rs
+++ b/crates/rustc_codegen_spirv/src/linker/specializer.rs
@@ -1276,7 +1276,7 @@ impl<'a, S: Specialization> InferCx<'a, S> {
                         return Ok(Match {
                             ambiguous: true,
                             ..Match::default()
-                        })
+                        });
                     }
                     InferOperand::Var(_) => return Err(Unapplicable),
                     InferOperand::Instance(instance) => instance,

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
@@ -233,11 +233,11 @@ const _: () = {
     use spirt::{func_at::*, visit::*, *};
 
     impl<
-            'a,
-            S,
-            VCR: FnMut(&mut S, FuncAt<'a, ControlRegion>),
-            VCN: FnMut(&mut S, FuncAt<'a, ControlNode>),
-        > Visitor<'a> for VisitAllControlRegionsAndNodes<S, VCR, VCN>
+        'a,
+        S,
+        VCR: FnMut(&mut S, FuncAt<'a, ControlRegion>),
+        VCN: FnMut(&mut S, FuncAt<'a, ControlNode>),
+    > Visitor<'a> for VisitAllControlRegionsAndNodes<S, VCR, VCN>
     {
         // FIXME(eddyb) this is excessive, maybe different kinds of
         // visitors should exist for module-level and func-level?

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -299,7 +299,9 @@ fn type_mismatch() {
     let result = assemble_and_link(&[&a, &b]);
     assert_eq!(
         result.err().as_deref(),
-        Some("error: Types mismatch for \"foo\"\n  |\n  = note: import type: (TypeFloat)\n  = note: export type: (TypeInt)")
+        Some(
+            "error: Types mismatch for \"foo\"\n  |\n  = note: import type: (TypeFloat)\n  = note: export type: (TypeInt)"
+        )
     );
 }
 

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -649,7 +649,7 @@ fn parse_entry_attrs(
                                 format!(
                                     "#[spirv({name}(..))] unknown attribute argument {attr_name}"
                                 ),
-                            ))
+                            ));
                         }
                     }
                 } else {

--- a/crates/spirv-std/macros/src/image.rs
+++ b/crates/spirv-std/macros/src/image.rs
@@ -463,9 +463,11 @@ mod params {
             "r8ui" => ImageFormat::R8ui,
             "r64ui" => ImageFormat::R64ui,
             "r64i" => ImageFormat::R64i,
-            _ => return Err(
-                "Unknown specified image format. Use `type=<type>` instead if this is intentional.",
-            ),
+            _ => {
+                return Err(
+                    "Unknown specified image format. Use `type=<type>` instead if this is intentional.",
+                );
+            }
         })
     }
 

--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -492,7 +492,7 @@ fn debug_printf_inner(input: DebugPrintfInput) -> TokenStream {
                         return parsing_error(
                             "Unterminated format specifier: missing type after precision",
                             span,
-                        )
+                        );
                     }
                 };
 
@@ -506,17 +506,19 @@ fn debug_printf_inner(input: DebugPrintfInput) -> TokenStream {
                         return parsing_error(
                             "Unterminated format specifier: missing type after decimal point",
                             span,
-                        )
+                        );
                     }
                 };
 
                 while ch.is_ascii_digit() {
                     ch = match chars.next() {
                         Some(ch) => ch,
-                        None => return parsing_error(
-                            "Unterminated format specifier: missing type after fraction precision",
-                            span,
-                        ),
+                        None => {
+                            return parsing_error(
+                                "Unterminated format specifier: missing type after fraction precision",
+                                span,
+                            );
+                        }
                     };
                 }
             }
@@ -527,7 +529,7 @@ fn debug_printf_inner(input: DebugPrintfInput) -> TokenStream {
                     Some('3') => 3,
                     Some('4') => 4,
                     Some(ch) => {
-                        return parsing_error(&format!("Invalid width for vector: {ch}"), span)
+                        return parsing_error(&format!("Invalid width for vector: {ch}"), span);
                     }
                     None => return parsing_error("Missing vector dimensions specifier", span),
                 };
@@ -543,7 +545,7 @@ fn debug_printf_inner(input: DebugPrintfInput) -> TokenStream {
                         return parsing_error(
                             &format!("Unrecognised vector type specifier: '{ch}'"),
                             span,
-                        )
+                        );
                     }
                 };
 
@@ -555,7 +557,7 @@ fn debug_printf_inner(input: DebugPrintfInput) -> TokenStream {
                         return parsing_error(
                             &format!("Unrecognised format specifier: '{ch}'"),
                             span,
-                        )
+                        );
                     }
                 };
 

--- a/crates/spirv-std/shared/src/image_params.rs
+++ b/crates/spirv-std/shared/src/image_params.rs
@@ -25,11 +25,7 @@ pub enum Arrayed {
 
 impl From<bool> for Arrayed {
     fn from(val: bool) -> Self {
-        if val {
-            Self::True
-        } else {
-            Self::False
-        }
+        if val { Self::True } else { Self::False }
     }
 }
 
@@ -102,11 +98,7 @@ pub enum Multisampled {
 
 impl From<bool> for Multisampled {
     fn from(val: bool) -> Self {
-        if val {
-            Self::True
-        } else {
-            Self::False
-        }
+        if val { Self::True } else { Self::False }
     }
 }
 

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -5,9 +5,6 @@ use crate::vector::VectorTruncateInto;
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
 
-// Rustfmt formats long marker trait impls over multiple lines which makes them
-// harder to read.
-#[rustfmt::skip]
 mod params;
 
 /// Contains extra image operands

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -120,14 +120,14 @@ pub struct Image<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         DIM,
@@ -166,14 +166,14 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         DIM,
@@ -458,13 +458,13 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const SAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const SAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         DIM,
@@ -680,14 +680,14 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         DIM,
@@ -749,14 +749,14 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         DIM,
@@ -818,13 +818,13 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         { Dimensionality::SubpassData as u32 },
@@ -866,15 +866,15 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    > Image<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+> Image<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 {
     /// Query the number of mipmap levels.
     #[crate::macros::gpu_only]
@@ -955,14 +955,14 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         DIM,
@@ -1000,13 +1000,13 @@ impl<
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     Image<
         SampledType,
         { Dimensionality::TwoD as u32 },
@@ -1047,14 +1047,14 @@ pub struct SampledImage<I> {
 }
 
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     SampledImage<
         Image<
             SampledType,
@@ -1205,15 +1205,15 @@ pub trait ImageWithMethods<
 
 #[crate::macros::gen_sample_param_permutations]
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DIM: u32,
-        const DEPTH: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const FORMAT: u32,
-        const COMPONENTS: u32,
-    >
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DIM: u32,
+    const DEPTH: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const FORMAT: u32,
+    const COMPONENTS: u32,
+>
     ImageWithMethods<
         SampledType,
         DIM,
@@ -1420,13 +1420,13 @@ impl<
 /// `OpTypeImage` must be 0."
 pub trait HasGather {}
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasGather
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasGather
     for Image<
         SampledType,
         { Dimensionality::TwoD as u32 },
@@ -1440,13 +1440,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasGather
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasGather
     for Image<
         SampledType,
         { Dimensionality::Rect as u32 },
@@ -1460,13 +1460,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasGather
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasGather
     for Image<
         SampledType,
         { Dimensionality::Cube as u32 },
@@ -1486,14 +1486,14 @@ impl<
 /// "Its Dim operand must be one of 1D, 2D, 3D, or Cube."
 pub trait HasQueryLevels {}
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQueryLevels
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQueryLevels
     for Image<
         SampledType,
         { Dimensionality::OneD as u32 },
@@ -1507,14 +1507,14 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQueryLevels
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQueryLevels
     for Image<
         SampledType,
         { Dimensionality::TwoD as u32 },
@@ -1528,14 +1528,14 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQueryLevels
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQueryLevels
     for Image<
         SampledType,
         { Dimensionality::ThreeD as u32 },
@@ -1549,14 +1549,14 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQueryLevels
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQueryLevels
     for Image<
         SampledType,
         { Dimensionality::Cube as u32 },
@@ -1577,13 +1577,13 @@ impl<
 /// 3D, or Cube, it must also have either an MS of 1 or a Sampled of 0 or 2."
 pub trait HasQuerySize {}
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::OneD as u32 },
@@ -1597,12 +1597,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::OneD as u32 },
@@ -1616,12 +1616,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::OneD as u32 },
@@ -1635,13 +1635,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::TwoD as u32 },
@@ -1655,12 +1655,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::TwoD as u32 },
@@ -1674,12 +1674,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::TwoD as u32 },
@@ -1693,13 +1693,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::ThreeD as u32 },
@@ -1713,12 +1713,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::ThreeD as u32 },
@@ -1732,12 +1732,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::ThreeD as u32 },
@@ -1751,13 +1751,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::Cube as u32 },
@@ -1771,12 +1771,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::Cube as u32 },
@@ -1790,12 +1790,12 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::Cube as u32 },
@@ -1809,14 +1809,14 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::Rect as u32 },
@@ -1830,14 +1830,14 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const MULTISAMPLED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySize
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const MULTISAMPLED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySize
     for Image<
         SampledType,
         { Dimensionality::Buffer as u32 },
@@ -1857,13 +1857,13 @@ impl<
 /// "Its Dim operand must be one of 1D, 2D, 3D, or Cube, and its MS must be 0."
 pub trait HasQuerySizeLod {}
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySizeLod
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySizeLod
     for Image<
         SampledType,
         { Dimensionality::OneD as u32 },
@@ -1877,13 +1877,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySizeLod
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySizeLod
     for Image<
         SampledType,
         { Dimensionality::TwoD as u32 },
@@ -1897,13 +1897,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySizeLod
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySizeLod
     for Image<
         SampledType,
         { Dimensionality::ThreeD as u32 },
@@ -1917,13 +1917,13 @@ impl<
 {
 }
 impl<
-        SampledType: SampleType<FORMAT, COMPONENTS>,
-        const DEPTH: u32,
-        const FORMAT: u32,
-        const ARRAYED: u32,
-        const SAMPLED: u32,
-        const COMPONENTS: u32,
-    > HasQuerySizeLod
+    SampledType: SampleType<FORMAT, COMPONENTS>,
+    const DEPTH: u32,
+    const FORMAT: u32,
+    const ARRAYED: u32,
+    const SAMPLED: u32,
+    const COMPONENTS: u32,
+> HasQuerySizeLod
     for Image<
         SampledType,
         { Dimensionality::Cube as u32 },

--- a/examples/shaders/shared/src/lib.rs
+++ b/examples/shaders/shared/src/lib.rs
@@ -57,11 +57,7 @@ pub fn acos_approx(v: f32) -> f32 {
     let mut res = -0.155972 * x + 1.56467; // p(x)
     res *= (1.0f32 - x).sqrt();
 
-    if v >= 0.0 {
-        res
-    } else {
-        PI - res
-    }
+    if v >= 0.0 { res } else { PI - res }
 }
 
 pub fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+# HACK(eddyb) needed to format array/slice patterns at all, because it was a
+# breaking change (see https://github.com/rust-lang/rustfmt/pull/4994).
+version = "Two"

--- a/tests/ui/arch/execute_callable.rs
+++ b/tests/ui/arch/execute_callable.rs
@@ -4,8 +4,6 @@
 use spirv_std::spirv;
 
 #[spirv(ray_generation)]
-// Rustfmt will eat long attributes (https://github.com/rust-lang/rustfmt/issues/4579)
-#[rustfmt::skip]
 pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)]
     acceleration_structure: &spirv_std::ray_tracing::AccelerationStructure,

--- a/tests/ui/arch/ray_query_initialize_khr.rs
+++ b/tests/ui/arch/ray_query_initialize_khr.rs
@@ -6,8 +6,6 @@ use spirv_std::ray_tracing::{AccelerationStructure, RayFlags, RayQuery};
 use spirv_std::spirv;
 
 #[spirv(fragment)]
-// Rustfmt eats long attributes <https://github.com/rust-lang/rustfmt/issues/4579>
-#[rustfmt::skip]
 pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] acceleration_structure: &AccelerationStructure,
     #[spirv(ray_payload)] payload: &mut Vec3,

--- a/tests/ui/arch/trace_ray_khr.rs
+++ b/tests/ui/arch/trace_ray_khr.rs
@@ -4,8 +4,6 @@
 use spirv_std::spirv;
 
 #[spirv(ray_generation)]
-// Rustfmt will eat long attributes (https://github.com/rust-lang/rustfmt/issues/4579)
-#[rustfmt::skip]
 pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)]
     acceleration_structure: &spirv_std::ray_tracing::AccelerationStructure,

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:200:15
+   --> $SPIRV_STD_SRC/image.rs:197:15
     |
-200 |         Self: HasGather,
+197 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
@@ -25,9 +25,9 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:200:15
+   --> $SPIRV_STD_SRC/image.rs:197:15
     |
-200 |         Self: HasGather,
+197 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:884:15
+   --> $SPIRV_STD_SRC/image.rs:881:15
     |
-884 |         Self: HasQueryLevels,
+881 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:910:15
+   --> $SPIRV_STD_SRC/image.rs:907:15
     |
-910 |         Self: HasQueryLevels,
+907 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -15,9 +15,9 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4>: HasQuerySize` is
               Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
             and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:941:15
+   --> $SPIRV_STD_SRC/image.rs:938:15
     |
-941 |         Self: HasQuerySize,
+938 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
 
 error: aborting due to previous error

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod`
               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:985:15
+   --> $SPIRV_STD_SRC/image.rs:982:15
     |
-985 |         Self: HasQuerySizeLod,
+982 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
 
 error: aborting due to previous error

--- a/tests/ui/lang/core/ref/member_ref_arg-broken.rs
+++ b/tests/ui/lang/core/ref/member_ref_arg-broken.rs
@@ -39,7 +39,7 @@ fn h(xyz: (&u32, &u32, &u32)) -> (u32, u32, u32) {
 // should just never exist by-value, and `qptr` may very well get rid of them).
 #[inline(never)]
 fn h_newtyped(xyz: ((&u32, &u32, &u32),)) -> (u32, u32, u32) {
-    (*xyz.0 .0, *xyz.0 .1, *xyz.0 .2)
+    (*xyz.0.0, *xyz.0.1, *xyz.0.2)
 }
 
 #[spirv(fragment)]


### PR DESCRIPTION
Was checking something about SPIR-T CI and realized I'd forgotten I ended up with a `rustfmt.toml` for SPIR-T that contained `version = "Two"` because of this PR:
* https://github.com/rust-lang/rustfmt/pull/4994

I'm not really sure why a decision was taken to not enable formatting array/slice patterns by default, making them nearly-unusable in non-trivial cases, but this is the result.

You'll notice there's many more changes than just array/slice patterns, looks like `version = "Two"` also enables a few more quality-of-life improvements as well, and I'm not sure if it's the direct cause but I was also able to remove some `#[rustfmt::skip]`s which didn't do anything anymore (see the second commit).