### PR TITLE
Lower aborts (incl. panics) to "return from entry-point", instead of infinite loops.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed 🛠
+- [PR#1070](https://github.com/EmbarkStudios/rust-gpu/pull/1070) made panics (via the `abort` intrinsic)
+  early-exit (i.e. `return` from) the shader entry-point, instead of looping infinitely
 - [PR#1071](https://github.com/EmbarkStudios/rust-gpu/pull/1071) updated toolchain to `nightly-2023-05-27`
 
 ## [0.8.0]

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -2457,8 +2457,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                         let is_standard_debug = [Op::Line, Op::NoLine].contains(&inst.class.opcode);
                         let is_custom_debug = inst.class.opcode == Op::ExtInst
                             && inst.operands[0].unwrap_id_ref() == custom_ext_inst_set_import
-                            && [CustomOp::SetDebugSrcLoc, CustomOp::ClearDebugSrcLoc]
-                                .contains(&CustomOp::decode_from_ext_inst(inst));
+                            && CustomOp::decode_from_ext_inst(inst).is_debuginfo();
                         !(is_standard_debug || is_custom_debug)
                     });
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -62,7 +62,7 @@ pub struct CodegenCx<'tcx> {
 
     /// All `panic!(...)`s and builtin panics (from MIR `Assert`s) call into one
     /// of these lang items, which we always replace with an "abort", erasing
-    /// anything passed in (and that "abort" is just an infinite loop for now).
+    /// anything passed in.
     //
     // FIXME(eddyb) we should not erase anywhere near as much, but `format_args!`
     // is not representable due to containg Rust slices, and Rust 2021 has made

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/controlflow.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/controlflow.rs
@@ -1,0 +1,69 @@
+//! SPIR-T passes related to control-flow.
+
+use crate::custom_insts::{self, CustomOp};
+use spirt::{cfg, ControlNodeKind, DataInstKind, DeclDef, ExportKey, Exportee, Module, TypeCtor};
+
+/// Replace our custom extended instruction `Abort`s with standard `OpReturn`s,
+/// but only in entry-points (and only before CFG structurization).
+pub fn convert_custom_aborts_to_unstructured_returns_in_entry_points(module: &mut Module) {
+    let cx = &module.cx();
+    let wk = &super::SpvSpecWithExtras::get().well_known;
+
+    let custom_ext_inst_set = cx.intern(&custom_insts::CUSTOM_EXT_INST_SET[..]);
+
+    for (export_key, exportee) in &module.exports {
+        let func = match (export_key, exportee) {
+            (ExportKey::SpvEntryPoint { .. }, &Exportee::Func(func)) => func,
+            _ => continue,
+        };
+
+        let func_decl = &mut module.funcs[func];
+        assert!(match &cx[func_decl.ret_type].ctor {
+            TypeCtor::SpvInst(spv_inst) => spv_inst.opcode == wk.OpTypeVoid,
+            _ => false,
+        });
+
+        let func_def_body = match &mut func_decl.def {
+            DeclDef::Present(def) => def,
+            DeclDef::Imported(_) => continue,
+        };
+
+        let rpo_regions = func_def_body
+            .unstructured_cfg
+            .as_ref()
+            .expect("Abort->OpReturn can only be done on unstructured CFGs")
+            .rev_post_order(func_def_body);
+        for region in rpo_regions {
+            let region_def = &func_def_body.control_regions[region];
+            let control_node_def = match region_def.children.iter().last {
+                Some(last_node) => &mut func_def_body.control_nodes[last_node],
+                _ => continue,
+            };
+            let block_insts = match &mut control_node_def.kind {
+                ControlNodeKind::Block { insts } => insts,
+                _ => continue,
+            };
+
+            let terminator = &mut func_def_body
+                .unstructured_cfg
+                .as_mut()
+                .unwrap()
+                .control_inst_on_exit_from[region];
+            if let cfg::ControlInstKind::Unreachable = terminator.kind {
+                let abort_inst = block_insts.iter().last.filter(|&last_inst| {
+                    match func_def_body.data_insts[last_inst].kind {
+                        DataInstKind::SpvExtInst { ext_set, inst } => {
+                            ext_set == custom_ext_inst_set
+                                && CustomOp::decode(inst) == CustomOp::Abort
+                        }
+                        _ => false,
+                    }
+                });
+                if let Some(abort_inst) = abort_inst {
+                    block_insts.remove(abort_inst, &mut func_def_body.data_insts);
+                    terminator.kind = cfg::ControlInstKind::Return;
+                }
+            }
+        }
+    }
+}

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/debuginfo.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/debuginfo.rs
@@ -85,7 +85,8 @@ impl Transformer for CustomDebuginfoToSpv<'_> {
                 } = data_inst_def.kind
                 {
                     if ext_set == self.custom_ext_inst_set {
-                        match CustomOp::decode(ext_inst).with_operands(&data_inst_def.inputs) {
+                        let custom_op = CustomOp::decode(ext_inst);
+                        match custom_op.with_operands(&data_inst_def.inputs) {
                             CustomInst::SetDebugSrcLoc {
                                 file,
                                 line_start: line,
@@ -125,6 +126,12 @@ impl Transformer for CustomDebuginfoToSpv<'_> {
                             | CustomInst::PopInlinedCallFrame => {
                                 insts_to_remove.push(inst);
                                 continue;
+                            }
+                            CustomInst::Abort => {
+                                assert!(
+                                    !custom_op.is_debuginfo(),
+                                    "`CustomOp::{custom_op:?}` debuginfo not lowered"
+                                );
                             }
                         }
                     }

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
@@ -677,6 +677,7 @@ impl<'a> Visitor<'a> for DiagnosticReporter<'a> {
                                         _ => unreachable!(),
                                     }
                                 }
+                                CustomInst::Abort => {}
                             },
                         }
                     }

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
@@ -1,5 +1,6 @@
 //! SPIR-T pass infrastructure and supporting utilities.
 
+pub(crate) mod controlflow;
 pub(crate) mod debuginfo;
 pub(crate) mod diagnostics;
 mod fuse_selects;
@@ -92,6 +93,8 @@ macro_rules! def_spv_spec_with_extra_well_known {
 }
 def_spv_spec_with_extra_well_known! {
     opcode: spv::spec::Opcode = [
+        OpTypeVoid,
+
         OpConstantComposite,
 
         OpBitcast,

--- a/tests/ui/dis/entry-pass-mode-cast-array.stderr
+++ b/tests/ui/dis/entry-pass-mode-cast-array.stderr
@@ -17,15 +17,6 @@ OpStore %21 %20
 OpNoLine
 OpBranch %13
 %15 = OpLabel
-OpBranch %22
-%22 = OpLabel
-OpLoopMerge %23 %24 None
-OpBranch %25
-%25 = OpLabel
-OpBranch %24
-%24 = OpLabel
-OpBranch %22
-%23 = OpLabel
 OpBranch %13
 %13 = OpLabel
 OpReturn

--- a/tests/ui/dis/index_user_dst.stderr
+++ b/tests/ui/dis/index_user_dst.stderr
@@ -15,15 +15,6 @@ OpLine %5 10 21
 OpNoLine
 OpBranch %14
 %16 = OpLabel
-OpBranch %21
-%21 = OpLabel
-OpLoopMerge %22 %23 None
-OpBranch %24
-%24 = OpLabel
-OpBranch %23
-%23 = OpLabel
-OpBranch %21
-%22 = OpLabel
 OpBranch %14
 %14 = OpLabel
 OpReturn

--- a/tests/ui/dis/issue-731.stderr
+++ b/tests/ui/dis/issue-731.stderr
@@ -17,15 +17,6 @@ OpStore %21 %20
 OpNoLine
 OpBranch %13
 %15 = OpLabel
-OpBranch %22
-%22 = OpLabel
-OpLoopMerge %23 %24 None
-OpBranch %25
-%25 = OpLabel
-OpBranch %24
-%24 = OpLabel
-OpBranch %22
-%23 = OpLabel
 OpBranch %13
 %13 = OpLabel
 OpReturn


### PR DESCRIPTION
We currently map the `abort` intrinsic (used almost exclusively for panic) to infinite loops, and they either:
- are optimized out by `spirv-opt` or drivers (i.e. treated as UB)
  - this obviously changes the semantics, and if a conditional panic protected against some UB, now that UB is unconditional and could affect more code
  - worst case, unwanted side-effects could run (e.g. writes of corrupted values, to buffers)
- are preserved by *both* `spirv-opt` *and* drivers, and cause a timeout when used
  - see these previous discussions for what it take to *intentionally* cause this (cc @charles-r-earp):
    - https://github.com/EmbarkStudios/rust-gpu/issues/1048
    - https://github.com/EmbarkStudios/rust-gpu/pull/1055
  - however, this is only a reliable option cross-hardware only for compute-only Vulkan queues (not just compute *shaders*, but compute shaders on a non-graphical queue), where the timeout can't block other work
  - worst case, one can easily accidentally hang *their entire* desktop if GPU compositing is involved
    - (yes I've done this to myself while trying out the barrier trick, no it wasn't fun)

With infinite loops being so terrible, I propose we move towards a "well-defined invocation exit" approach, where we keep the "abort" as a custom instruction (using our "extended instruction set", added in #1064), and then effectively emulate the semantics of [`OpTerminateInvocation`](https://www.khronos.org/registry/SPIR-V/specs/unified1/SPIRV.html#OpTerminateInvocation) for it by:
- inlining any function that uses our custom `Abort` (either directly, or transitively through some functions *it* calls) - in the end, we should end up with `Abort`s only used directly from entry-points
- in entry-points, we rewrite `Abort`s to a plain `OpReturn` (from the entry-point, i.e. exiting the invocation)
  - we could potentially have a mode where we generate a `debugPrintf` call at this point, with the same inlining-aware "backtrace" we use elsewhere, so that the user gets some feedback if they have the validation layers enabled (and/or try to extract a panic message when we generate the abort in the first place, too)

This PR implements that proposal (but without any `debugPrintf` conveniences), and so far it seems to work great, but I haven't tested the performance impact (i.e. where before the infinite loops were optimized away, now we're seeing an actual cost to various e.g. bounds checks, that need to *do something* at all).

There are also other ways of implementing this, and we could do the `Abort` -> `OpReturn` rewriting very late (if we think it would be better than letting the SPIR-T structurizer see it), so there's some room to explore mitigations to perf issues, if they arise.

~~(I will leave this PR as draft until we're sure about the perf aspects)~~