### PR TITLE
rustup: update to `nightly-2023-05-27`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed 🛠
+- [PR#1071](https://github.com/EmbarkStudios/rust-gpu/pull/1071) updated toolchain to `nightly-2023-05-27`
+
 ## [0.8.0]
 
 ### Added ⭐

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -10,9 +10,9 @@ use std::process::{Command, ExitCode};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2023-04-15"
+channel = "nightly-2023-05-27"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = 84dd17b56a931a631a23dfd5ef2018fd3ef49108"#;
+# commit_hash = 1a5f8bce74ee432f7cc3aa131bc3d6920e06de10"#;
 
 fn get_rustc_commit_hash() -> Result<String, Box<dyn Error>> {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -7,9 +7,9 @@ use crate::spirv_type::SpirvType;
 use rspirv::spirv::{StorageClass, Word};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::ErrorGuaranteed;
-use rustc_index::vec::Idx;
+use rustc_index::Idx;
+use rustc_middle::query::{ExternProviders, Providers};
 use rustc_middle::ty::layout::{FnAbiOf, LayoutOf, TyAndLayout};
-use rustc_middle::ty::query::{ExternProviders, Providers};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{
     self, Const, FloatTy, GeneratorSubsts, IntTy, ParamEnv, PolyFnSig, Ty, TyCtxt, TyKind,
@@ -972,7 +972,7 @@ fn trans_intrinsic_type<'tcx>(
                         .tcx
                         .sess
                         .struct_span_err(span, "#[spirv(matrix)] type fields must all be vectors")
-                        .note(&format!("field type is {}", ty.debug(elem_type, cx)))
+                        .note(format!("field type is {}", ty.debug(elem_type, cx)))
                         .emit());
                 }
             }

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -11,7 +11,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{HirId, MethodKind, Target, CRATE_HIR_ID};
 use rustc_middle::hir::nested_filter;
-use rustc_middle::ty::query::Providers;
+use rustc_middle::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 use std::rc::Rc;
@@ -369,9 +369,9 @@ impl CheckSpirvAttrVisitor<'_> {
                             .sess
                             .struct_span_err(
                                 span,
-                                &format!("only one {category} attribute is allowed on a {target}"),
+                                format!("only one {category} attribute is allowed on a {target}"),
                             )
-                            .span_note(prev_span, &format!("previous {category} attribute"))
+                            .span_note(prev_span, format!("previous {category} attribute"))
                             .emit();
                     }
                 },

--- a/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
+++ b/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
@@ -15,7 +15,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.debug_type(original_type)
         ));
         if original_type != invalid_type {
-            err.note(&format!(
+            err.note(format!(
                 "due to containing type {}",
                 self.debug_type(invalid_type)
             ));
@@ -210,7 +210,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.debug_type(original_type)
         ));
         if original_type != value.ty {
-            err.note(&format!("due to containing type {}", value.ty));
+            err.note(format!("due to containing type {}", value.ty));
         }
         Err(err.emit())
     }

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -438,16 +438,4 @@ impl<'tcx> FnAbiOfHelpers<'tcx> for Builder<'_, 'tcx> {
     }
 }
 
-impl<'tcx> TypeMembershipMethods<'tcx> for CodegenCx<'tcx> {
-    fn set_type_metadata(&self, _function: Self::Function, _typeid: String) {
-        // ignore
-    }
-
-    fn typeid_metadata(&self, _typeid: String) -> Self::Value {
-        todo!()
-    }
-
-    fn set_kcfi_type_metadata(&self, _function: Self::Function, _typeid: u32) {
-        // ignore
-    }
-}
+impl<'tcx> TypeMembershipMethods<'tcx> for CodegenCx<'tcx> {}

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -306,10 +306,10 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                 let storage_class = inst.operands[0].unwrap_storage_class();
                 if storage_class != StorageClass::Generic {
                     self.struct_err("TypePointer in asm! requires `Generic` storage class")
-                        .note(&format!(
+                        .note(format!(
                             "`{storage_class:?}` storage class was specified"
                         ))
-                        .help(&format!(
+                        .help(format!(
                             "the storage class will be inferred automatically (e.g. to `{storage_class:?}`)"
                         ))
                         .emit();

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -152,7 +152,7 @@ impl SpirvValue {
                 cx.tcx
                     .sess
                     .struct_span_err(span, "Can't use type as a value")
-                    .note(&format!("Type: *{}", cx.debug_type(id)))
+                    .note(format!("Type: *{}", cx.debug_type(id)))
                     .emit();
 
                 id

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -36,7 +36,7 @@ fn attrs_to_spirv(attrs: &CodegenFnAttrs) -> FunctionControl {
 impl<'tcx> CodegenCx<'tcx> {
     /// Returns a function if it already exists, or declares a header if it doesn't.
     pub fn get_fn_ext(&self, instance: Instance<'tcx>) -> SpirvValue {
-        assert!(!instance.substs.needs_infer());
+        assert!(!instance.substs.has_infer());
         assert!(!instance.substs.has_escaping_bound_vars());
 
         if let Some(&func) = self.instances.borrow().get(&instance) {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -191,6 +191,7 @@ impl<'tcx> CodegenCx<'tcx> {
         bx.set_span(span);
         bx.call(
             entry_func.ty,
+            None,
             Some(entry_fn_abi),
             entry_func,
             &call_args,
@@ -317,7 +318,7 @@ impl<'tcx> CodegenCx<'tcx> {
                         )
                         .span_help(
                             storage_class_attr.span,
-                            &format!(
+                            format!(
                                 "remove storage class attribute to use `{deduced:?}` as storage class"
                             ),
                         )

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -274,8 +274,8 @@ fn post_link_single_module(
         if let Err(e) = std::fs::write(out_filename, spirv_tools::binary::from_binary(&spv_binary))
         {
             let mut err = sess.struct_err("failed to serialize spirv-binary to disk");
-            err.note(&format!("module `{}`", out_filename.display()));
-            err.note(&format!("I/O error: {e:#}"));
+            err.note(format!("module `{}`", out_filename.display()));
+            err.note(format!("I/O error: {e:#}"));
             err.emit();
         }
 
@@ -324,14 +324,14 @@ fn do_spirv_opt(
                 Level::Fatal | Level::InternalError => {
                     // FIXME(eddyb) this was `struct_fatal` but that doesn't seem
                     // necessary and also lacks `.forget_guarantee()`.
-                    sess.struct_err(&msg.message).forget_guarantee()
+                    sess.struct_err(msg.message).forget_guarantee()
                 }
-                Level::Error => sess.struct_err(&msg.message).forget_guarantee(),
-                Level::Warning => sess.struct_warn(&msg.message),
-                Level::Info | Level::Debug => sess.struct_note_without_error(&msg.message),
+                Level::Error => sess.struct_err(msg.message).forget_guarantee(),
+                Level::Warning => sess.struct_warn(msg.message),
+                Level::Info | Level::Debug => sess.struct_note_without_error(msg.message),
             };
 
-            err.note(&format!("module `{}`", filename.display()));
+            err.note(format!("module `{}`", filename.display()));
             err.emit();
         },
         Some(options),
@@ -341,9 +341,9 @@ fn do_spirv_opt(
         Ok(spirv_tools::binary::Binary::OwnedU32(words)) => words,
         Ok(binary) => binary.as_words().to_vec(),
         Err(e) => {
-            let mut err = sess.struct_warn(&e.to_string());
+            let mut err = sess.struct_warn(e.to_string());
             err.note("spirv-opt failed, leaving as unoptimized");
-            err.note(&format!("module `{}`", filename.display()));
+            err.note(format!("module `{}`", filename.display()));
             err.emit();
             spv_binary
         }
@@ -361,9 +361,9 @@ fn do_spirv_val(
     let validator = val::create(sess.target.options.env.parse().ok());
 
     if let Err(e) = validator.validate(spv_binary, Some(options)) {
-        let mut err = sess.struct_err(&e.to_string());
+        let mut err = sess.struct_err(e.to_string());
         err.note("spirv-val failed");
-        err.note(&format!("module `{}`", filename.display()));
+        err.note(format!("module `{}`", filename.display()));
         err.emit();
     }
 }

--- a/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
+++ b/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
@@ -184,12 +184,12 @@ fn check_tys_equal(
             result
         }
         Err(sess
-            .struct_err(&format!("Types mismatch for {name:?}"))
-            .note(&format!(
+            .struct_err(format!("Types mismatch for {name:?}"))
+            .note(format!(
                 "import type: {}",
                 format_ty_(&ty_defs, import_type)
             ))
-            .note(&format!(
+            .note(format!(
                 "export type: {}",
                 format_ty_(&ty_defs, export_type)
             ))

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -225,6 +225,17 @@ pub fn link(
     }
 
     if opts.early_report_zombies {
+        // HACK(eddyb) `report_and_remove_zombies` is bad at determining whether
+        // some things are dead (such as whole blocks), and there's no reason to
+        // *not* run DCE, given SPIR-T exists and makes DCE mandatory, but we're
+        // still only going to do the minimum necessary ("block ordering").
+        {
+            let _timer = sess.timer("link_block_ordering_pass-before-report_and_remove_zombies");
+            for func in &mut output.functions {
+                simple_passes::block_ordering_pass(func);
+            }
+        }
+
         let _timer = sess.timer("link_report_and_remove_zombies");
         zombies::report_and_remove_zombies(sess, opts, &mut output)?;
     }

--- a/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
+++ b/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
@@ -245,11 +245,11 @@ pub fn check_fragment_insts(sess: &Session, module: &Module) -> Result<()> {
                     .collect::<Vec<_>>()
                     .join("\n");
                 any_err = Some(
-                    sess.struct_err(&format!(
+                    sess.struct_err(format!(
                         "{} cannot be used outside a fragment shader",
                         inst.class.opname
                     ))
-                    .note(&note)
+                    .note(note)
                     .emit(),
                 );
             }

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
@@ -425,7 +425,7 @@ impl DiagnosticReporter<'_> {
                         self.span_regen.spirt_attrs_to_rustc_span(self.cx, attrs)
                     })
                     .unwrap_or(DUMMY_SP);
-                let mut err = self.sess.struct_span_err(def_span, reason);
+                let mut err = self.sess.struct_span_err(def_span, reason.to_string());
                 for use_origin in use_stack_for_def.iter().rev() {
                     use_origin.note(self.cx, &mut self.span_regen, &mut err);
                 }

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -115,6 +115,7 @@ fn link_with_linker_opts(
                 Default::default(),
                 None,
                 None,
+                rustc_interface::util::rustc_version_str().unwrap_or("unknown"),
             );
 
             // HACK(eddyb) inject `write_diags` into `sess`, to work around

--- a/crates/rustc_codegen_spirv/src/linker/zombies.rs
+++ b/crates/rustc_codegen_spirv/src/linker/zombies.rs
@@ -292,7 +292,10 @@ impl<'a> ZombieReporter<'a> {
         match zombie.kind {
             ZombieKind::Leaf => {
                 let reason = self.span_regen.zombie_for_id(zombie.id).unwrap().reason;
-                errors_keyed_by_leaf_id.insert(zombie.id, self.sess.struct_span_err(span, reason));
+                errors_keyed_by_leaf_id.insert(
+                    zombie.id,
+                    self.sess.struct_span_err(span, reason.to_string()),
+                );
             }
             ZombieKind::Uses(zombie_uses) => {
                 for zombie_use in zombie_uses {

--- a/crates/spirv-builder/README.md
+++ b/crates/spirv-builder/README.md
@@ -2,7 +2,7 @@
 <!-- markdownlint-disable-file MD033 -->
 # `spirv-builder`
 
-![Rust version](https://img.shields.io/badge/rust-nightly--2023--04--15-purple.svg)
+![Rust version](https://img.shields.io/badge/rust-nightly--2023--05--27-purple.svg)
 
 This crate gives you `SpirvBuilder`, a tool to build shaders using [rust-gpu][rustgpu].
 
@@ -31,7 +31,7 @@ const SHADER: &[u8] = include_bytes!(env!("my_shaders.spv"));
 
 Because of its nature, `rustc_codegen_spirv`, and therefore `spirv-builder` by extension, require the use of a very specific nightly toolchain of Rust.
 
-**The current toolchain is: `nightly-2023-04-15`.**
+**The current toolchain is: `nightly-2023-05-27`.**
 
 Toolchains for previous versions of `spirv-builder`:
 

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -440,6 +440,10 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         "-Csymbol-mangling-version=v0".to_string(),
         "-Zcrate-attr=feature(register_tool)".to_string(),
         "-Zcrate-attr=register_tool(rust_gpu)".to_string(),
+        // HACK(eddyb) this is the same configuration that we test with, and
+        // ensures no unwanted surprises from e.g. `core` debug assertions.
+        "-Coverflow-checks=off".to_string(),
+        "-Cdebug-assertions=off".to_string(),
     ];
 
     // Wrapper for `env::var` that appropriately informs Cargo of the dependency.

--- a/crates/spirv-std/src/byte_addressable_buffer.rs
+++ b/crates/spirv-std/src/byte_addressable_buffer.rs
@@ -5,16 +5,41 @@ use core::mem;
 #[spirv(buffer_load_intrinsic)]
 #[spirv_std_macros::gpu_only]
 #[allow(improper_ctypes_definitions)]
-unsafe fn buffer_load_intrinsic<T>(_buffer: &[u32], _offset: u32) -> T {
-    unimplemented!()
-} // actually implemented in the compiler
+unsafe fn buffer_load_intrinsic<T>(
+    buffer: &[u32],
+    // FIXME(eddyb) should be `usize`.
+    offset: u32,
+) -> T {
+    // NOTE(eddyb) this doesn't work with `rustc_codegen_spirv` and is only here
+    // for explanatory purposes, and to cause some kind of verbose error if
+    // `#[spirv(buffer_load_intrinsic)]` fails to replace calls to this function.
+    buffer
+        .as_ptr()
+        .cast::<u8>()
+        .add(offset as usize)
+        .cast::<T>()
+        .read()
+}
 
 #[spirv(buffer_store_intrinsic)]
 #[spirv_std_macros::gpu_only]
 #[allow(improper_ctypes_definitions)]
-unsafe fn buffer_store_intrinsic<T>(_buffer: &mut [u32], _offset: u32, _value: T) {
-    unimplemented!()
-} // actually implemented in the compiler
+unsafe fn buffer_store_intrinsic<T>(
+    buffer: &mut [u32],
+    // FIXME(eddyb) should be `usize`.
+    offset: u32,
+    value: T,
+) {
+    // NOTE(eddyb) this doesn't work with `rustc_codegen_spirv` and is only here
+    // for explanatory purposes, and to cause some kind of verbose error if
+    // `#[spirv(buffer_store_intrinsic)]` fails to replace calls to this function.
+    buffer
+        .as_mut_ptr()
+        .cast::<u8>()
+        .add(offset as usize)
+        .cast::<T>()
+        .write(value);
+}
 
 /// `ByteAddressableBuffer` is an untyped blob of data, allowing loads and stores of arbitrary
 /// basic data types at arbitrary indicies. However, all data must be aligned to size 4, each

--- a/crates/spirv-std/src/byte_addressable_buffer.rs
+++ b/crates/spirv-std/src/byte_addressable_buffer.rs
@@ -3,8 +3,9 @@
 use core::mem;
 
 #[spirv(buffer_load_intrinsic)]
+// HACK(eddyb) try to prevent MIR inlining from breaking our intrinsics.
+#[inline(never)]
 #[spirv_std_macros::gpu_only]
-#[allow(improper_ctypes_definitions)]
 unsafe fn buffer_load_intrinsic<T>(
     buffer: &[u32],
     // FIXME(eddyb) should be `usize`.
@@ -22,8 +23,9 @@ unsafe fn buffer_load_intrinsic<T>(
 }
 
 #[spirv(buffer_store_intrinsic)]
+// HACK(eddyb) try to prevent MIR inlining from breaking our intrinsics.
+#[inline(never)]
 #[spirv_std_macros::gpu_only]
-#[allow(improper_ctypes_definitions)]
 unsafe fn buffer_store_intrinsic<T>(
     buffer: &mut [u32],
     // FIXME(eddyb) should be `usize`.

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -89,6 +89,7 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+/// Public re-export of the `spirv-std-macros` crate.
 #[macro_use]
 pub extern crate spirv_std_macros as macros;
 pub use macros::spirv;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2023-04-15"
+channel = "nightly-2023-05-27"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = 84dd17b56a931a631a23dfd5ef2018fd3ef49108
+# commit_hash = 1a5f8bce74ee432f7cc3aa131bc3d6920e06de10
 
 # Whenever changing the nightly channel, update the commit hash above, and make
 # sure to change `REQUIRED_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` also.

--- a/tests/ui/arch/debug_printf_type_checking.stderr
+++ b/tests/ui/arch/debug_printf_type_checking.stderr
@@ -75,9 +75,9 @@ help: the return type of this call is `u32` due to the type of the argument pass
     |                             |
     |                             this argument influences the return type of `spirv_std`
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:134:8
+   --> $SPIRV_STD_SRC/lib.rs:135:8
     |
-134 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+135 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: change the type of the numeric literal from `u32` to `f32`
@@ -102,9 +102,9 @@ help: the return type of this call is `f32` due to the type of the argument pass
     |                             |
     |                             this argument influences the return type of `spirv_std`
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:134:8
+   --> $SPIRV_STD_SRC/lib.rs:135:8
     |
-134 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+135 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: change the type of the numeric literal from `f32` to `u32`
@@ -132,9 +132,12 @@ error[E0277]: the trait bound `{float}: Vector<f32, 2>` is not satisfied
               <UVec3 as Vector<u32, 3>>
             and 5 others
 note: required by a bound in `debug_printf_assert_is_vector`
-   --> $SPIRV_STD_SRC/lib.rs:141:8
+   --> $SPIRV_STD_SRC/lib.rs:142:8
     |
-141 |     V: crate::vector::Vector<TY, SIZE>,
+140 | pub fn debug_printf_assert_is_vector<
+    |        ----------------------------- required by a bound in this function
+141 |     TY: crate::scalar::Scalar,
+142 |     V: crate::vector::Vector<TY, SIZE>,
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `debug_printf_assert_is_vector`
 
 error[E0308]: mismatched types
@@ -154,9 +157,9 @@ help: the return type of this call is `Vec2` due to the type of the argument pas
     |                             |
     |                             this argument influences the return type of `spirv_std`
 note: function defined here
-   --> $SPIRV_STD_SRC/lib.rs:134:8
+   --> $SPIRV_STD_SRC/lib.rs:135:8
     |
-134 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
+135 | pub fn debug_printf_assert_is_type<T>(ty: T) -> T {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `debug_printf` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/dis/entry-pass-mode-cast-array.stderr
+++ b/tests/ui/dis/entry-pass-mode-cast-array.stderr
@@ -3,11 +3,30 @@
 OpLine %5 13 12
 %6 = OpLoad  %7  %8
 OpLine %5 14 4
-%9 = OpCompositeExtract  %10  %6 0
-%11 = OpFAdd  %10  %9 %12
-%13 = OpCompositeInsert  %7  %11 %6 0
-OpLine %5 15 4
-OpStore %14 %13
+%9 = OpULessThan  %10  %11 %12
 OpNoLine
+OpSelectionMerge %13 None
+OpBranchConditional %9 %14 %15
+%14 = OpLabel
+OpLine %5 14 4
+%16 = OpCompositeExtract  %17  %6 0
+%18 = OpFAdd  %17  %16 %19
+%20 = OpCompositeInsert  %7  %18 %6 0
+OpLine %5 15 4
+OpStore %21 %20
+OpNoLine
+OpBranch %13
+%15 = OpLabel
+OpBranch %22
+%22 = OpLabel
+OpLoopMerge %23 %24 None
+OpBranch %25
+%25 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %22
+%23 = OpLabel
+OpBranch %13
+%13 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/issue-731.stderr
+++ b/tests/ui/dis/issue-731.stderr
@@ -3,11 +3,30 @@
 OpLine %5 11 12
 %6 = OpLoad  %7  %8
 OpLine %5 12 4
-%9 = OpCompositeExtract  %10  %6 0
-%11 = OpFAdd  %10  %9 %12
-%13 = OpCompositeInsert  %7  %11 %6 0
-OpLine %5 13 4
-OpStore %14 %13
+%9 = OpULessThan  %10  %11 %12
 OpNoLine
+OpSelectionMerge %13 None
+OpBranchConditional %9 %14 %15
+%14 = OpLabel
+OpLine %5 12 4
+%16 = OpCompositeExtract  %17  %6 0
+%18 = OpFAdd  %17  %16 %19
+%20 = OpCompositeInsert  %7  %18 %6 0
+OpLine %5 13 4
+OpStore %21 %20
+OpNoLine
+OpBranch %13
+%15 = OpLabel
+OpBranch %22
+%22 = OpLabel
+OpLoopMerge %23 %24 None
+OpBranch %25
+%25 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %22
+%23 = OpLabel
+OpBranch %13
+%13 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,13 +1,13 @@
 error: cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2724:9
+    --> $CORE_SRC/intrinsics.rs:2760:9
      |
-2724 |         copy(src, dst, count)
+2760 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
      |
 note: used from within `core::intrinsics::copy::<f32>`
-    --> $CORE_SRC/intrinsics.rs:2710:21
+    --> $CORE_SRC/intrinsics.rs:2746:21
      |
-2710 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+2746 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
      |                     ^^^^
 note: called by `ptr_copy::copy_via_raw_ptr`
     --> $DIR/ptr_copy.rs:28:18

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1188 12
+OpLine %8 1178 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1188 12
+OpLine %8 1178 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1386 8
+OpLine %11 1376 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1386 8
+OpLine %11 1376 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -11,6 +11,9 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4>: HasGather` is no
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
    --> $SPIRV_STD_SRC/image.rs:197:15
     |
+190 |     pub fn gather<F>(
+    |            ------ required by a bound in this associated function
+...
 197 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
@@ -27,6 +30,9 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is no
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
    --> $SPIRV_STD_SRC/image.rs:197:15
     |
+190 |     pub fn gather<F>(
+    |            ------ required by a bound in this associated function
+...
 197 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -12,6 +12,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
    --> $SPIRV_STD_SRC/image.rs:881:15
     |
+879 |     pub fn query_levels(&self) -> u32
+    |            ------------ required by a bound in this associated function
+880 |     where
 881 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
 

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -12,6 +12,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
    --> $SPIRV_STD_SRC/image.rs:907:15
     |
+901 |     pub fn query_lod(
+    |            --------- required by a bound in this associated function
+...
 907 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
 

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -17,6 +17,9 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4>: HasQuerySize` is
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
    --> $SPIRV_STD_SRC/image.rs:938:15
     |
+936 |     pub fn query_size<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(&self) -> Size
+    |            ---------- required by a bound in this associated function
+937 |     where
 938 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
 

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -12,6 +12,9 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod`
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
    --> $SPIRV_STD_SRC/image.rs:982:15
     |
+977 |     pub fn query_size_lod<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(
+    |            -------------- required by a bound in this associated function
+...
 982 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
 

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.rs
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.rs
@@ -8,9 +8,10 @@
 use spirv_std::spirv;
 
 use core::ptr::Unique;
+
 const POINTER: Unique<[u8; 4]> = Unique::<[u8; 4]>::dangling();
 
 #[spirv(fragment)]
-pub fn main() {
-    let _pointer = POINTER;
+pub fn main(output: &mut Unique<[u8; 4]>) {
+    *output = POINTER;
 }

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -1,14 +1,14 @@
 error: pointer has non-null integer address
    |
 note: used from within `allocate_const_scalar::main`
-  --> $DIR/allocate_const_scalar.rs:15:20
+  --> $DIR/allocate_const_scalar.rs:16:5
    |
-15 |     let _pointer = POINTER;
-   |                    ^^^^^^^
+16 |     *output = POINTER;
+   |     ^^^^^^^^^^^^^^^^^
 note: called by `main`
-  --> $DIR/allocate_const_scalar.rs:14:8
+  --> $DIR/allocate_const_scalar.rs:15:8
    |
-14 | pub fn main() {
+15 | pub fn main(output: &mut Unique<[u8; 4]>) {
    |        ^^^^
 
 error: aborting due to previous error

--- a/tests/ui/lang/core/unwrap_or.stderr
+++ b/tests/ui/lang/core/unwrap_or.stderr
@@ -3,9 +3,9 @@
 OpLine %5 13 11
 %6 = OpCompositeInsert  %7  %8 %9 0
 %10 = OpCompositeExtract  %11  %6 1
-OpLine %12 975 14
+OpLine %12 956 14
 %13 = OpBitcast  %14  %8
-OpLine %12 975 8
+OpLine %12 956 8
 %15 = OpIEqual  %16  %13 %17
 OpNoLine
 OpSelectionMerge %18 None


### PR DESCRIPTION
Learned my lesson with `0.8`, so let's get this out of the way early in the `0.9` release cycle.
<sub>(And yes, there was `panic!`-related nonsense to deal with this time too: `if cfg!(debug_assertions)` not being optimized out)</sub>

**EDIT**: had to add a couple commits to `spirv-std` to debug/fix an issue caused by MIR inlining (maybe we should have a way to run our tests with optimizations enabled? they seem a bit fragile otherwise...).