### PR TITLE
Add specialization constants via `#[spirv(spec_constant(id = 123))] x: u32` entry-point inputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added ⭐
+- [PR#1081](https://github.com/EmbarkStudios/rust-gpu/pull/1081) added the ability
+  to access SPIR-V specialization constants (`OpSpecConstant`) via entry-point
+  inputs declared as `#[spirv(spec_constant(id = ..., default = ...))] x: u32`  
+  (see also [the `#[spirv(spec_constant)]` attribute documentation](docs/src/attributes.md#specialization-constants))
 - [PR#1036](https://github.com/EmbarkStudios/rust-gpu/pull/1036) added a `--force-spirv-passthru` flag to `example-runner-wgpu`, to bypass Naga (`wgpu`'s shader translator),
   used it to test `debugPrintf` for `wgpu`,  and updated `ShaderPanicStrategy::DebugPrintfThenExit` docs to reflect what "enabling `debugPrintf`" looks like for `wgpu`  
   <sub><sup>(e.g. `VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation VK_LAYER_ENABLES=VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT DEBUG_PRINTF_TO_STDOUT=1`)</sup></sub>
 - [PR#1080](https://github.com/EmbarkStudios/rust-gpu/pull/1080) added `debugPrintf`-based
-  panic reporting, with the desired behavior selected via `spirv_builder::ShaderPanicStrategy`
+  panic reporting, with the desired behavior selected via `spirv_builder::ShaderPanicStrategy`  
   (see its documentation for more details about each available panic handling strategy)
 
 ### Changed 🛠

--- a/examples/runners/cpu/src/main.rs
+++ b/examples/runners/cpu/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
                 * vec2(WIDTH as f32, HEIGHT as f32);
 
             // evaluate the fragment shader for the specific pixel
-            let color = shader_module::fs(&push_constants, frag_coord);
+            let color = shader_module::fs(&push_constants, frag_coord, 1);
 
             color_u32_from_vec4(color)
         })

--- a/tests/ui/dis/spec_constant-attr.rs
+++ b/tests/ui/dis/spec_constant-attr.rs
@@ -1,0 +1,29 @@
+#![crate_name = "spec_constant_attr"]
+
+// Tests the various forms of `#[spirv(spec_constant)]`.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+// FIXME(eddyb) this should use revisions to track both the `vulkan1.2` output
+// and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
+// are not supported in `compiletest-rs`.
+// ignore-vulkan1.2
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(
+    #[spirv(spec_constant(id = 1))] no_default: u32,
+    #[spirv(spec_constant(id = 2, default = 0))] default_0: u32,
+    #[spirv(spec_constant(id = 123, default = 123))] default_123: u32,
+    #[spirv(spec_constant(id = 0xffff_ffff, default = 0xffff_ffff))] max_id_and_default: u32,
+
+    out: &mut u32,
+) {
+    *out = no_default + default_0 + default_123 + max_id_and_default;
+}

--- a/tests/ui/dis/spec_constant-attr.stderr
+++ b/tests/ui/dis/spec_constant-attr.stderr
@@ -1,0 +1,30 @@
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/spec_constant-attr.rs"
+OpName %4 "no_default"
+OpName %5 "default_0"
+OpName %6 "default_123"
+OpName %7 "max_id_and_default"
+OpName %2 "out"
+OpDecorate %4 SpecId 1
+OpDecorate %5 SpecId 2
+OpDecorate %6 SpecId 123
+OpDecorate %7 SpecId 4294967295
+OpDecorate %2 Location 0
+%8 = OpTypeInt 32 0
+%9 = OpTypePointer Output %8
+%10 = OpTypeVoid
+%11 = OpTypeFunction %10
+%4 = OpSpecConstant  %8  0
+%5 = OpSpecConstant  %8  0
+%6 = OpSpecConstant  %8  123
+%7 = OpSpecConstant  %8  4294967295
+%2 = OpVariable  %9  Output

--- a/tests/ui/spirv-attr/invariant-invalid.stderr
+++ b/tests/ui/spirv-attr/invariant-invalid.stderr
@@ -1,4 +1,4 @@
-error: #[spirv(invariant)] is only valid on Output variables
+error: `#[spirv(invariant)]` is only valid on Output variables
  --> $DIR/invariant-invalid.rs:7:21
   |
 7 | pub fn main(#[spirv(invariant)] input: f32) {}


### PR DESCRIPTION
Quoting some of the documentation I added to `docs/src/attributes.md`:

> Entry point inputs also allow access to [SPIR-V "specialization constants"](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#SpecializationSection),
> which are each associated with an user-specified numeric "ID" (SPIR-V `SpecId`),
> used to override them later ("specializing" the shader):
> * in Vulkan: [during pipeline creation, via `VkSpecializationInfo`](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap10.html#pipelines-specialization-constants)
> * in WebGPU: [during pipeline creation, via `GPUProgrammableStage`<i>`#constants`</i>](https://www.w3.org/TR/webgpu/#gpuprogrammablestage)
>   * note: WebGPU calls them ["pipeline-overridable constants"](https://gpuweb.github.io/gpuweb/wgsl/#pipeline-overridable)
> * in OpenCL: [via `clSetProgramSpecializationConstant()` calls, before `clBuildProgram()`](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clSetProgramSpecializationConstant.html)
> 
> If a "specialization constant" is not overriden, it falls back to its *default*
> value, which is either user-specified (via `default = ...`), or `0` otherwise.
> 
> While only "specialization constants" of type `u32` are currently supported, it's
> always possible to *manually* create values of other types, from one or more `u32`s.
> 
> Example:
> 
> ```rust
> #[spirv(vertex)]
> fn main(
>     // Default is implicitly `0`, if not specified.
>     #[spirv(spec_constant(id = 1))] no_default: u32,
> 
>     // IDs don't need to be sequential or obey any order.
>     #[spirv(spec_constant(id = 9000, default = 123))] default_123: u32,
> 
>     // Assembling a larger value out of multiple `u32` is also possible.
>     #[spirv(spec_constant(id = 100))] x_u64_lo: u32,
>     #[spirv(spec_constant(id = 101))] x_u64_hi: u32,
> ) {
>     let x_u64 = ((x_u64_hi as u64) << 32) | (x_u64_lo as u64);
> }
> ```

---

There's not much else to it, quite bare-bones, but I wanted to have something for @VZout before the release.