### PR TITLE
Show `panic!` messages via `debugPrintf`, even including some runtime arguments (`{u,i,f}32` as `{}` or `{:?}`).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added ⭐
+- [PR#1082](https://github.com/EmbarkStudios/rust-gpu/pull/1082) added partial
+  support for extracting `format_args!` from `panic!`s, and converting them to
+  `debugPrintf` calls (if enabled via `ShaderPanicStrategy`), including runtime
+  arguments (`u32`/`i32`/`f32` with `Display`/`Debug` formatting, for now)
 - [PR#1081](https://github.com/EmbarkStudios/rust-gpu/pull/1081) added the ability
   to access SPIR-V specialization constants (`OpSpecConstant`) via entry-point
   inputs declared as `#[spirv(spec_constant(id = ..., default = ...))] x: u32`  

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -172,12 +172,16 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
         let str_ty = self
             .layout_of(self.tcx.types.str_)
             .spirv_type(DUMMY_SP, self);
-        // FIXME(eddyb) include the actual byte data.
         (
             self.def_constant(
                 self.type_ptr_to(str_ty),
                 SpirvConst::PtrTo {
-                    pointee: self.undef(str_ty).def_cx(self),
+                    pointee: self
+                        .constant_composite(
+                            str_ty,
+                            s.bytes().map(|b| self.const_u8(b).def_cx(self)),
+                        )
+                        .def_cx(self),
                 },
             ),
             self.const_usize(len as u64),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -61,16 +61,16 @@ pub struct CodegenCx<'tcx> {
     pub libm_intrinsics: RefCell<FxHashMap<Word, super::builder::libm_intrinsics::LibmIntrinsic>>,
 
     /// All `panic!(...)`s and builtin panics (from MIR `Assert`s) call into one
-    /// of these lang items, which we always replace with an "abort", erasing
-    /// anything passed in.
-    //
-    // FIXME(eddyb) we should not erase anywhere near as much, but `format_args!`
-    // is not representable due to containg Rust slices, and Rust 2021 has made
-    // it mandatory even for `panic!("...")` (that were previously separate).
+    /// of these lang items, which we always replace with an "abort".
     pub panic_entry_point_ids: RefCell<FxHashSet<Word>>,
 
     /// `core::fmt::Arguments::new_{v1,const}` instances (for Rust 2021 panics).
     pub fmt_args_new_fn_ids: RefCell<FxHashSet<Word>>,
+
+    /// `core::fmt::rt::Argument::new_*::<T>` instances (for panics' `format_args!`),
+    /// with their `T` type (i.e. of the value being formatted), and formatting
+    /// "specifier" as a `char` (' ' for `Display`, `x` for `LowerHex`, etc.)
+    pub fmt_rt_arg_new_fn_ids_to_ty_and_spec: RefCell<FxHashMap<Word, (Ty<'tcx>, char)>>,
 
     /// Intrinsic for loading a <T> from a &[u32]. The PassMode is the mode of the <T>.
     pub buffer_load_intrinsic_fn_id: RefCell<FxHashMap<Word, &'tcx PassMode>>,
@@ -131,6 +131,7 @@ impl<'tcx> CodegenCx<'tcx> {
             libm_intrinsics: Default::default(),
             panic_entry_point_ids: Default::default(),
             fmt_args_new_fn_ids: Default::default(),
+            fmt_rt_arg_new_fn_ids_to_ty_and_spec: Default::default(),
             buffer_load_intrinsic_fn_id: Default::default(),
             buffer_store_intrinsic_fn_id: Default::default(),
             i8_i16_atomics_allowed: false,

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -562,6 +562,9 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         // ensures no unwanted surprises from e.g. `core` debug assertions.
         "-Coverflow-checks=off".to_string(),
         "-Cdebug-assertions=off".to_string(),
+        // HACK(eddyb) we need this for `core::fmt::rt::Argument::new_*` calls
+        // to *never* be inlined, so we can pattern-match the calls themselves.
+        "-Zinline-mir=off".to_string(),
     ];
 
     // Wrapper for `env::var` that appropriately informs Cargo of the dependency.

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -346,14 +346,20 @@ fn rust_flags(codegen_backend_path: &Path) -> String {
         // to rebuild crates compiled with it when it changes (this used to be
         // the default until https://github.com/rust-lang/rust/pull/93969).
         "-Zbinary-dep-depinfo",
-        "-Coverflow-checks=off",
-        "-Cdebug-assertions=off",
-        "-Cdebuginfo=2",
-        "-Cembed-bitcode=no",
-        &format!("-Ctarget-feature=+{}", target_features.join(",+")),
         "-Csymbol-mangling-version=v0",
         "-Zcrate-attr=feature(register_tool)",
         "-Zcrate-attr=register_tool(rust_gpu)",
+        // HACK(eddyb) this is the same configuration that we test with, and
+        // ensures no unwanted surprises from e.g. `core` debug assertions.
+        "-Coverflow-checks=off",
+        "-Cdebug-assertions=off",
+        // HACK(eddyb) we need this for `core::fmt::rt::Argument::new_*` calls
+        // to *never* be inlined, so we can pattern-match the calls themselves.
+        "-Zinline-mir=off",
+        // NOTE(eddyb) flags copied from `spirv-builder` are all above this line.
+        "-Cdebuginfo=2",
+        "-Cembed-bitcode=no",
+        &format!("-Ctarget-feature=+{}", target_features.join(",+")),
     ]
     .join(" ")
 }


### PR DESCRIPTION
Also, this PR moves us in the direction of "preferring fewer optimizations" (we now force `-Zinline-mir=off`),
as that makes it easier to e.g. reliably pattern-match on the generated SPIR-V.

---

By adding some out of bounds indexing to the `sky-shader`, and running:
`VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation VK_LAYER_ENABLES=VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT DEBUG_PRINTF_TO_
STDOUT=1 cargo run -p example-runner-wgpu --release -- --force-spirv-passthru`, we get:

![image](https://github.com/EmbarkStudios/rust-gpu/assets/77424/f4b826a0-a391-4412-91a1-4b00cde44573)

---

Note that bounds-checking panics come from a `core` function which happens to do:
```rust
panic!("index out of bounds: the len is {len} but the index is {index}")
```
(that is, we don't special-case bounds-checking panics, and simple `Display`/`Debug` formatting of 32-bit integers/floats, including `usize`/`isize`, should work, and we can do a lot more in the future)

**TODO**: changelog.