### PR TITLE
Updated SPIR-T for better pretty-printing (esp. `OpExtInst`), and started deduplicating custom debuginfo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (see its documentation for more details about each available panic handling strategy)
 
 ### Changed 🛠
+- [PR#1083](https://github.com/EmbarkStudios/rust-gpu/pull/1083) updated SPIR-T to get pretty-printer
+  improvements (especially for `OpExtInst`, including Rust-GPU's custom ones), and started more
+  aggressively deduplicating custom debuginfo instructions (to make SPIR-T dumps more readable)
 - [PR#1079](https://github.com/EmbarkStudios/rust-gpu/pull/1079) revised `spirv-builder`'s `README.md`,
   and added a way for `docs.rs` to be able to build it (via `cargo +stable doc --no-default-features`)
 - [PR#1070](https://github.com/EmbarkStudios/rust-gpu/pull/1070) made panics (via the `abort` intrinsic)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "spirt"
 version = "0.2.0"
-source = "git+https://github.com/EmbarkStudios/spirt?branch=main#e8b4a474b2de791a27ea793a1d9c932c27a667ef"
+source = "git+https://github.com/EmbarkStudios/spirt?branch=main#cd21d968127035ad3707829849d0466368649299"
 dependencies = [
  "arrayvec",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +597,19 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -2033,6 +2052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustfix"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+
+[[package]]
 name = "serde"
 version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,11 +2280,11 @@ dependencies = [
 [[package]]
 name = "spirt"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24fa996f12f3c667efbceaa99c222b8910a295a14d2c43c3880dfab2752def7"
+source = "git+https://github.com/EmbarkStudios/spirt?branch=main#e8b4a474b2de791a27ea793a1d9c932c27a667ef"
 dependencies = [
  "arrayvec",
  "bytemuck",
+ "derive_more",
  "elsa",
  "indexmap",
  "internal-iterator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "spirt"
 version = "0.2.0"
-source = "git+https://github.com/EmbarkStudios/spirt?branch=main#cd21d968127035ad3707829849d0466368649299"
+source = "git+https://github.com/EmbarkStudios/spirt?branch=main#82daf2516710504986cdc35e0e27455326aeef90"
 dependencies = [
  "arrayvec",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ codegen-units = 256
 opt-level = 3
 incremental = true
 codegen-units = 256
+
+[patch.crates-io]
+spirt = { git = "https://github.com/EmbarkStudios/spirt", branch = "main" }

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -2878,11 +2878,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
             // HACK(eddyb) redirect any possible panic call to an abort, to avoid
             // needing to materialize `&core::panic::Location` or `format_args!`.
-            self.abort_with_message_and_debug_printf_args(
-                // HACK(eddyb) `|` is an ad-hoc convention of `linker::spirt_passes::controlflow`.
-                format!("panicked|{message}"),
-                debug_printf_args,
-            );
+            self.abort_with_kind_and_message_debug_printf("panic", message, debug_printf_args);
             self.undef(result_type)
         } else if let Some(mode) = buffer_load_intrinsic {
             self.codegen_buffer_load_intrinsic(result_type, args, mode)

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -378,8 +378,13 @@ impl CodegenArgs {
             );
             opts.optflag(
                 "",
-                "spirt-keep-custom-debuginfo-in-dumps",
-                "keep custom debuginfo when dumping SPIR-T (instead of lossily prettifying it)",
+                "spirt-strip-custom-debuginfo-from-dumps",
+                "strip custom debuginfo instructions when dumping SPIR-T",
+            );
+            opts.optflag(
+                "",
+                "spirt-keep-debug-sources-in-dumps",
+                "keep file contents debuginfo when dumping SPIR-T",
             );
             opts.optflag(
                 "",
@@ -548,8 +553,10 @@ impl CodegenArgs {
             dump_post_merge: matches_opt_dump_dir_path("dump-post-merge"),
             dump_post_split: matches_opt_dump_dir_path("dump-post-split"),
             dump_spirt_passes: matches_opt_dump_dir_path("dump-spirt-passes"),
-            spirt_keep_custom_debuginfo_in_dumps: matches
-                .opt_present("spirt-keep-custom-debuginfo-in-dumps"),
+            spirt_strip_custom_debuginfo_from_dumps: matches
+                .opt_present("spirt-strip-custom-debuginfo-from-dumps"),
+            spirt_keep_debug_sources_in_dumps: matches
+                .opt_present("spirt-keep-debug-sources-in-dumps"),
             specializer_debug: matches.opt_present("specializer-debug"),
             specializer_dump_instances: matches_opt_path("specializer-dump-instances"),
             print_all_zombie: matches.opt_present("print-all-zombie"),

--- a/crates/rustc_codegen_spirv/src/custom_insts.rs
+++ b/crates/rustc_codegen_spirv/src/custom_insts.rs
@@ -151,9 +151,10 @@ def_custom_insts! {
     // users to do `catch_unwind` at the top-level of their shader to handle
     // panics specially (e.g. by appending to a custom buffer, or using some
     // specific color in a fragment shader, to indicate a panic happened).
-    // NOTE(eddyb) the `message` string follows `debugPrintf` rules, with remaining
-    // operands (collected into `debug_printf_args`) being its formatting arguments.
-    4 => Abort { message, ..debug_printf_args },
+    // NOTE(eddyb) `message_debug_printf` operands form a complete `debugPrintf`
+    // invocation (format string followed by inputs) for the "message", while
+    // `kind` only distinguishes broad categories like `"abort"` vs `"panic"`.
+    4 => Abort { kind, ..message_debug_printf },
 }
 
 impl CustomOp {

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -78,6 +78,7 @@ pub fn link(
                         crate_type,
                         &out_filename,
                         codegen_results,
+                        outputs,
                         &disambiguated_crate_name_for_dumps,
                     );
                 }
@@ -123,6 +124,7 @@ fn link_exe(
     crate_type: CrateType,
     out_filename: &Path,
     codegen_results: &CodegenResults,
+    outputs: &OutputFilenames,
     disambiguated_crate_name_for_dumps: &OsStr,
 ) {
     let mut objects = Vec::new();
@@ -152,6 +154,7 @@ fn link_exe(
         &cg_args,
         &objects,
         &rlibs,
+        outputs,
         disambiguated_crate_name_for_dumps,
     );
     let compile_result = match link_result {
@@ -517,6 +520,7 @@ fn do_link(
     cg_args: &CodegenArgs,
     objects: &[PathBuf],
     rlibs: &[PathBuf],
+    outputs: &OutputFilenames,
     disambiguated_crate_name_for_dumps: &OsStr,
 ) -> linker::LinkResult {
     let load_modules_timer = sess.timer("link_load_modules");
@@ -570,6 +574,7 @@ fn do_link(
         sess,
         modules,
         &cg_args.linker_opts,
+        outputs,
         disambiguated_crate_name_for_dumps,
     );
 

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -409,6 +409,7 @@ pub fn link(
             spirv_tools::binary::from_binary(&spv_words).to_vec()
         };
         let cx = std::rc::Rc::new(spirt::Context::new());
+        crate::custom_insts::register_to_spirt_context(&cx);
         let mut module = {
             let _timer = sess.timer("spirt::Module::lower_from_spv_file");
             match spirt::Module::lower_from_spv_bytes(cx.clone(), spv_bytes) {

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/controlflow.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/controlflow.rs
@@ -342,6 +342,15 @@ pub fn convert_custom_aborts_to_unstructured_returns_in_entry_points(
                                 .unwrap_or_default();
 
                         let fmt_dbg_src_loc = |(file, line, col)| {
+                            // FIXME(eddyb) figure out what is going on with
+                            // these column number conventions, below is a
+                            // related comment from `spirt::print`:
+                            // > // HACK(eddyb) Rust-GPU's column numbers seem
+                            // > // off-by-one wrt what e.g. VSCode expects
+                            // > // for `:line:col` syntax, but it's hard to
+                            // > // tell from the spec and `glslang` doesn't
+                            // > // even emit column numbers at all!
+                            let col = col + 1;
                             format!("{file}:{line}:{col}").replace('%', "%%")
                         };
 

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/debuginfo.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/debuginfo.rs
@@ -25,6 +25,7 @@ pub fn convert_custom_debuginfo_to_spv(module: &mut Module) {
 
             seen_types: FxIndexSet::default(),
             seen_consts: FxIndexSet::default(),
+            seen_data_inst_forms: FxIndexSet::default(),
             seen_global_vars: FxIndexSet::default(),
             seen_funcs: FxIndexSet::default(),
         };
@@ -82,7 +83,7 @@ impl Transformer for CustomDebuginfoToSpv<'_> {
                 if let DataInstKind::SpvExtInst {
                     ext_set,
                     inst: ext_inst,
-                } = data_inst_def.kind
+                } = self.cx[data_inst_def.form].kind
                 {
                     if ext_set == self.custom_ext_inst_set {
                         let custom_op = CustomOp::decode(ext_inst);

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -154,7 +154,7 @@ fn link_with_linker_opts(
                 modules,
                 opts,
                 &OutputFilenames::new(
-                    std::env::current_dir().unwrap_or_default(),
+                    "".into(),
                     "".into(),
                     None,
                     None,

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -2,7 +2,8 @@ use super::{link, LinkResult};
 use pipe::pipe;
 use rspirv::dr::{Loader, Module};
 use rustc_errors::{registry::Registry, TerminalUrl};
-use rustc_session::{config::Input, CompilerIO};
+use rustc_session::config::{Input, OutputFilenames, OutputTypes};
+use rustc_session::CompilerIO;
 use rustc_span::FileName;
 use std::io::Read;
 
@@ -148,7 +149,20 @@ fn link_with_linker_opts(
                 )
             };
 
-            let res = link(&sess, modules, opts, Default::default());
+            let res = link(
+                &sess,
+                modules,
+                opts,
+                &OutputFilenames::new(
+                    std::env::current_dir().unwrap_or_default(),
+                    "".into(),
+                    None,
+                    None,
+                    "".into(),
+                    OutputTypes::new(&[]),
+                ),
+                Default::default(),
+            );
             assert_eq!(sess.has_errors(), res.as_ref().err().copied());
             res.map(|res| match res {
                 LinkResult::SingleModule(m) => *m,

--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -192,11 +192,19 @@ _Note: passes that are not already enabled by default are considered experimenta
 Dump the `SPIR-🇹` module across passes (i.e. all of the versions before/after each pass), as a combined report, to a pair of files (`.spirt` and `.spirt.html`) in `DIR`.  
 <sub>(the `.spirt.html` version of the report is the recommended form for viewing, as it uses tabling for versions, syntax-highlighting-like styling, and use->def linking)</sub>
 
-### `--spirt-keep-custom-debuginfo-in-dumps`
+### `--spirt-strip-custom-debuginfo-from-dumps`
+
+When dumping (pretty-printed) `SPIR-🇹` (e.g. with `--dump-spirt-passes`), strip
+all the custom (Rust-GPU-specific) debuginfo instructions, by converting them
+to the standard SPIR-V debuginfo (which `SPIR-🇹` understands more directly).
+
+The default (keeping the custom instructions) is more verbose, but also lossless,
+if you want to see all instructions exactly as e.g. `--spirt-passes` see them.
+
+### `--spirt-keep-debug-sources-in-dumps`
 
 When dumping (pretty-printed) `SPIR-🇹` (e.g. with `--dump-spirt-passes`), preserve
-all the custom (Rust-GPU-specific) debuginfo instructions, instead of converting
-them to the standard SPIR-V debuginfo (which `SPIR-🇹` pretty-prints specially).
+all the "file contents debuginfo" (i.e. from SPIR-V `OpSource` instructions),
+which will end up being included, in full, at the start of the dump.
 
-The default (of performing that conversion) has prettier results, but is lossier
-if you want to see all instructions exactly as e.g. `--spirt-passes` see them.
+The default (of hiding the file contents) is less verbose, but (arguably) lossier.


### PR DESCRIPTION
Potentially relevant SPIR-T PRs that are included here:
* https://github.com/EmbarkStudios/spirt/pull/33
* https://github.com/EmbarkStudios/spirt/pull/35
* https://github.com/EmbarkStudios/spirt/pull/36
* https://github.com/EmbarkStudios/spirt/pull/45

That last one is the most relevant here, because together with debuginfo deduplication, it causes:
|Before|After|
|-|-|
|<img src="https://github.com/EmbarkStudios/rust-gpu/assets/77424/c61b0e3e-5d1e-4cec-90de-0fb4f42fa58c" height="550">|![image](https://github.com/EmbarkStudios/rust-gpu/assets/77424/2c173006-a20c-49c2-ae32-abf0f5b9a6b9)|

Yes, that's the same function (`sky_shader::henyey_greenstein_phase`), but incomprehensible before.