### PR TITLE
[WIP] linker: also dump SPIR-T on panic, not just during successful compilation.

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
@@ -22,12 +22,6 @@ pub(crate) struct ReportedDiagnostics {
     pub any_errors_were_spirt_bugs: bool,
 }
 
-impl From<ReportedDiagnostics> for rustc_errors::ErrorGuaranteed {
-    fn from(r: ReportedDiagnostics) -> Self {
-        r.rustc_errors_guarantee
-    }
-}
-
 pub(crate) fn report_diagnostics(
     sess: &Session,
     linker_options: &crate::linker::Options,


### PR DESCRIPTION
This is the idea I mentioned in:
* https://github.com/EmbarkStudios/rust-gpu/issues/1086#issuecomment-1655044334

However, opening as draft because the situation is even messier than envisioned and more panic handling is needed (up to an including potentially enabling fine-grained dumping *without the user requesting it*, by running the SPIR-T pipeline again, starting from the same SPIR-V blob, if the initial attempt ended in a panic - care would need to be taken for diagnostics or the panic itself, to not be redundantly reported).