### PR TITLE
rustup: update to `nightly-2023-09-30`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed 🛠
+- [PR#1100](https://github.com/EmbarkStudios/rust-gpu/pull/1100) updated toolchain to `nightly-2023-09-30`
 - [PR#1091](https://github.com/EmbarkStudios/rust-gpu/pull/1091) updated toolchain to `nightly-2023-08-29`
 - [PR#1085](https://github.com/EmbarkStudios/rust-gpu/pull/1085) updated toolchain to `nightly-2023-07-08`
 

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -10,9 +10,9 @@ use std::process::{Command, ExitCode};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain.toml");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2023-08-29"
+channel = "nightly-2023-09-30"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = 4e78abb437a0478d1f42115198ee45888e5330fd"#;
+# commit_hash = 8ce4540bd6fe7d58d4bc05f1b137d61937d3cf72"#;
 
 fn get_rustc_commit_hash() -> Result<String, Box<dyn Error>> {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));

--- a/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
+++ b/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
@@ -181,7 +181,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             // PassMode::Pair is identical to PassMode::Direct - it's returned as a struct
             PassMode::Direct(_) | PassMode::Pair(_, _) => (),
-            PassMode::Cast(_, _) => {
+            PassMode::Cast { .. } => {
                 self.fatal("PassMode::Cast not supported in codegen_buffer_load_intrinsic")
             }
             PassMode::Indirect { .. } => {
@@ -349,7 +349,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             PassMode::Ignore => return,
             PassMode::Direct(_) => false,
             PassMode::Pair(_, _) => true,
-            PassMode::Cast(_, _) => {
+            PassMode::Cast { .. } => {
                 self.fatal("PassMode::Cast not supported in codegen_buffer_store_intrinsic")
             }
             PassMode::Indirect { .. } => {

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx> ArgAbiMethods<'tcx> for Builder<'a, 'tcx> {
             PassMode::Pair(..) => {
                 OperandValue::Pair(next(self, idx), next(self, idx)).store(self, dst);
             }
-            PassMode::Cast(_, _) | PassMode::Indirect { .. } => span_bug!(
+            PassMode::Cast { .. } | PassMode::Indirect { .. } => span_bug!(
                 self.span(),
                 "query hooks should've made this `PassMode` impossible: {:#?}",
                 arg_abi
@@ -328,7 +328,7 @@ impl<'a, 'tcx> ArgAbiMethods<'tcx> for Builder<'a, 'tcx> {
             PassMode::Direct(_) | PassMode::Pair(..) => {
                 OperandValue::Immediate(val).store(self, dst);
             }
-            PassMode::Cast(_, _) | PassMode::Indirect { .. } => span_bug!(
+            PassMode::Cast { .. } | PassMode::Indirect { .. } => span_bug!(
                 self.span(),
                 "query hooks should've made this `PassMode` impossible: {:#?}",
                 arg_abi

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -790,7 +790,7 @@ impl<'tcx> BuilderSpirv<'tcx> {
 
                 let file_contents = self
                     .source_map
-                    .span_to_snippet(Span::with_root_ctxt(sf.start_pos, sf.end_pos))
+                    .span_to_snippet(Span::with_root_ctxt(sf.start_pos, sf.end_position()))
                     .ok();
 
                 // HACK(eddyb) this logic is duplicated from `spirt::spv::lift`.

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -18,8 +18,8 @@ use rustc_codegen_ssa::traits::{
     AsmMethods, BackendTypes, DebugInfoMethods, GlobalAsmOperandRef, MiscMethods,
 };
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_middle::mir;
 use rustc_middle::mir::mono::CodegenUnit;
-use rustc_middle::mir::Body;
 use rustc_middle::ty::layout::{HasParamEnv, HasTyCtxt};
 use rustc_middle::ty::{Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt};
 use rustc_session::Session;
@@ -861,8 +861,8 @@ impl<'tcx> DebugInfoMethods<'tcx> for CodegenCx<'tcx> {
         _instance: Instance<'tcx>,
         _fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
         _llfn: Self::Function,
-        _mir: &Body<'_>,
-    ) -> Option<FunctionDebugContext<Self::DIScope, Self::DILocation>> {
+        _mir: &mir::Body<'tcx>,
+    ) -> Option<FunctionDebugContext<'tcx, Self::DIScope, Self::DILocation>> {
         // TODO: This is ignored. Do we want to implement this at some point?
         None
     }

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -104,7 +104,6 @@ use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::mir::mono::{MonoItem, MonoItemData};
 use rustc_middle::mir::pretty::write_mir_pretty;
-use rustc_middle::query;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, Instance, InstanceDef, TyCtxt};
 use rustc_session::config::{self, OutputFilenames, OutputType};
@@ -219,7 +218,7 @@ impl CodegenBackend for SpirvCodegenBackend {
         }
     }
 
-    fn provide(&self, providers: &mut query::Providers) {
+    fn provide(&self, providers: &mut rustc_middle::util::Providers) {
         // FIXME(eddyb) this is currently only passed back to us, specifically
         // into `target_machine_factory` (which is a noop), but it might make
         // sense to move some of the target feature parsing into here.
@@ -227,10 +226,6 @@ impl CodegenBackend for SpirvCodegenBackend {
 
         crate::abi::provide(providers);
         crate::attr::provide(providers);
-    }
-
-    fn provide_extern(&self, providers: &mut query::ExternProviders) {
-        crate::abi::provide_extern(providers);
     }
 
     fn codegen_crate(

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -616,11 +616,10 @@ pub(crate) fn run_thin(
     if cgcx.opts.cg.linker_plugin_lto.enabled() {
         unreachable!("We should never reach this case if the LTO step is deferred to the linker");
     }
-    if cgcx.lto != Lto::ThinLocal {
-        for _ in cgcx.each_linked_rlib_for_lto.iter() {
-            bug!("TODO: Implement whatever the heck this is");
-        }
-    }
+    assert!(
+        cgcx.lto == Lto::ThinLocal,
+        "no actual LTO implemented in Rust-GPU"
+    );
     let mut thin_buffers = Vec::with_capacity(modules.len());
     let mut module_names = Vec::with_capacity(modules.len() + cached_modules.len());
 

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -146,14 +146,15 @@ fn link_with_linker_opts(
                     output_file: None,
                     temps_dir: None,
                 },
-                None,
+                Default::default(),
                 Registry::new(&[]),
                 Default::default(),
                 Default::default(),
-                None,
-                None,
+                Default::default(),
+                Default::default(),
                 rustc_interface::util::rustc_version_str().unwrap_or("unknown"),
-                None,
+                Default::default(),
+                Default::default(),
             );
 
             // HACK(eddyb) inject `write_diags` into `sess`, to work around
@@ -179,6 +180,7 @@ fn link_with_linker_opts(
                 modules,
                 opts,
                 &OutputFilenames::new(
+                    "".into(),
                     "".into(),
                     "".into(),
                     None,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2023-08-29"
+channel = "nightly-2023-09-30"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = 4e78abb437a0478d1f42115198ee45888e5330fd
+# commit_hash = 8ce4540bd6fe7d58d4bc05f1b137d61937d3cf72
 
 # Whenever changing the nightly channel, update the commit hash above, and make
 # sure to change `REQUIRED_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` also.

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,13 +1,13 @@
 error: cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2771:9
+    --> $CORE_SRC/intrinsics.rs:2778:9
      |
-2771 |         copy(src, dst, count)
+2778 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
      |
 note: used from within `core::intrinsics::copy::<f32>`
-    --> $CORE_SRC/intrinsics.rs:2757:21
+    --> $CORE_SRC/intrinsics.rs:2764:21
      |
-2757 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+2764 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
      |                     ^^^^
 note: called by `ptr_copy::copy_via_raw_ptr`
     --> $DIR/ptr_copy.rs:28:18

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1180 8
+OpLine %8 1183 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1180 8
+OpLine %8 1183 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1379 8
+OpLine %11 1382 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1379 8
+OpLine %11 1382 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
+++ b/tests/ui/lang/core/ref/zst_member_ref_arg-broken.stderr
@@ -1,5 +1,41 @@
+error: cannot offset a pointer to an arbitrary element
+  --> $DIR/zst_member_ref_arg-broken.rs:23:7
+   |
+23 |     f(&s.y);
+   |       ^^^^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar`
+  --> $DIR/zst_member_ref_arg-broken.rs:23:7
+   |
+23 |     f(&s.y);
+   |       ^^^^
+note: called by `main_scalar`
+  --> $DIR/zst_member_ref_arg-broken.rs:22:8
+   |
+22 | pub fn main_scalar(#[spirv(push_constant)] s: &S<usize>) {
+   |        ^^^^^^^^^^^
+
 error: cannot cast between pointer types
        from `*u32`
+         to `*u8`
+  --> $DIR/zst_member_ref_arg-broken.rs:23:7
+   |
+23 |     f(&s.y);
+   |       ^^^^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar`
+  --> $DIR/zst_member_ref_arg-broken.rs:23:7
+   |
+23 |     f(&s.y);
+   |       ^^^^
+note: called by `main_scalar`
+  --> $DIR/zst_member_ref_arg-broken.rs:22:8
+   |
+22 | pub fn main_scalar(#[spirv(push_constant)] s: &S<usize>) {
+   |        ^^^^^^^^^^^
+
+error: cannot cast between pointer types
+       from `*u8`
          to `*struct B {  }`
   --> $DIR/zst_member_ref_arg-broken.rs:23:5
    |
@@ -17,8 +53,44 @@ note: called by `main_scalar`
 22 | pub fn main_scalar(#[spirv(push_constant)] s: &S<usize>) {
    |        ^^^^^^^^^^^
 
+error: cannot offset a pointer to an arbitrary element
+  --> $DIR/zst_member_ref_arg-broken.rs:28:7
+   |
+28 |     f(&s.y);
+   |       ^^^^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar_pair`
+  --> $DIR/zst_member_ref_arg-broken.rs:28:7
+   |
+28 |     f(&s.y);
+   |       ^^^^
+note: called by `main_scalar_pair`
+  --> $DIR/zst_member_ref_arg-broken.rs:27:8
+   |
+27 | pub fn main_scalar_pair(#[spirv(push_constant)] s: &S<usize, usize>) {
+   |        ^^^^^^^^^^^^^^^^
+
 error: cannot cast between pointer types
        from `*struct S<usize, usize> { u32, u32 }`
+         to `*u8`
+  --> $DIR/zst_member_ref_arg-broken.rs:28:7
+   |
+28 |     f(&s.y);
+   |       ^^^^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar_pair`
+  --> $DIR/zst_member_ref_arg-broken.rs:28:7
+   |
+28 |     f(&s.y);
+   |       ^^^^
+note: called by `main_scalar_pair`
+  --> $DIR/zst_member_ref_arg-broken.rs:27:8
+   |
+27 | pub fn main_scalar_pair(#[spirv(push_constant)] s: &S<usize, usize>) {
+   |        ^^^^^^^^^^^^^^^^
+
+error: cannot cast between pointer types
+       from `*u8`
          to `*struct B {  }`
   --> $DIR/zst_member_ref_arg-broken.rs:28:5
    |
@@ -36,8 +108,44 @@ note: called by `main_scalar_pair`
 27 | pub fn main_scalar_pair(#[spirv(push_constant)] s: &S<usize, usize>) {
    |        ^^^^^^^^^^^^^^^^
 
+error: cannot offset a pointer to an arbitrary element
+  --> $DIR/zst_member_ref_arg-broken.rs:33:7
+   |
+33 |     f(&s.y);
+   |       ^^^^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar_scalar_pair_nested`
+  --> $DIR/zst_member_ref_arg-broken.rs:33:7
+   |
+33 |     f(&s.y);
+   |       ^^^^
+note: called by `main_scalar_scalar_pair_nested`
+  --> $DIR/zst_member_ref_arg-broken.rs:32:8
+   |
+32 | pub fn main_scalar_scalar_pair_nested(#[spirv(push_constant)] s: &S<(usize, usize)>) {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: cannot cast between pointer types
        from `*struct (usize, usize) { u32, u32 }`
+         to `*u8`
+  --> $DIR/zst_member_ref_arg-broken.rs:33:7
+   |
+33 |     f(&s.y);
+   |       ^^^^
+   |
+note: used from within `zst_member_ref_arg_broken::main_scalar_scalar_pair_nested`
+  --> $DIR/zst_member_ref_arg-broken.rs:33:7
+   |
+33 |     f(&s.y);
+   |       ^^^^
+note: called by `main_scalar_scalar_pair_nested`
+  --> $DIR/zst_member_ref_arg-broken.rs:32:8
+   |
+32 | pub fn main_scalar_scalar_pair_nested(#[spirv(push_constant)] s: &S<(usize, usize)>) {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot cast between pointer types
+       from `*u8`
          to `*struct B {  }`
   --> $DIR/zst_member_ref_arg-broken.rs:33:5
    |
@@ -55,5 +163,5 @@ note: called by `main_scalar_scalar_pair_nested`
 32 | pub fn main_scalar_scalar_pair_nested(#[spirv(push_constant)] s: &S<(usize, usize)>) {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
I'm not really sure what's going on with the changed test, but it seems harmless, in that the errors changed from one error about `*T -> *U` to two errors (`*T -> *i8` + `*i8 -> *U`), each (AFAICT the upstream `*i8` GEP hasn't changed, maybe debuginfo or some other aspect of MIR causes the intermediary type to be more directly exhibited?).