### PR TITLE
Update the build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Discord](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 [![Documentation](https://img.shields.io/badge/docs-API-blue)](https://embarkstudios.github.io/rust-gpu/api/rustc_codegen_spirv)
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu)
-[![Build status](https://github.com/EmbarkStudios/rust-gpu/workflows/Continuous%20integration/badge.svg?branch=main)](https://github.com/EmbarkStudios/rust-gpu/actions)
+[![Build status](https://github.com/EmbarkStudios/rust-gpu/actions/workflows/ci.yaml/badge.svg)](https://github.com/EmbarkStudios/rust-gpu/actions/workflows/ci.yaml)
 </div>
 
 ## Current Status 🚧


### PR DESCRIPTION
Fixes the build badge:

![Screenshot from 2024-01-03 15-27-21](https://github.com/EmbarkStudios/rust-gpu/assets/277251/4a89f6dc-b090-44e2-b2a4-6f3024b20101)
