### PR TITLE
Update clap (replacing structopt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -202,17 +241,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -387,18 +415,43 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cocoa"
@@ -439,6 +492,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "com-rs"
@@ -482,9 +541,9 @@ dependencies = [
 name = "compiletests"
 version = "0.0.0"
 dependencies = [
+ "clap",
  "compiletest_rs",
  "rustc_codegen_spirv",
- "structopt",
 ]
 
 [[package]]
@@ -764,10 +823,10 @@ dependencies = [
  "ash-molten",
  "ash-window",
  "cfg-if",
+ "clap",
  "raw-window-handle 0.5.2",
  "shared",
  "spirv-builder",
- "structopt",
  "winit",
 ]
 
@@ -788,13 +847,13 @@ dependencies = [
  "android_logger",
  "bytemuck",
  "cfg-if",
+ "clap",
  "console_error_panic_hook",
  "console_log",
  "env_logger",
  "futures",
  "shared",
  "spirv-builder",
- "structopt",
  "strum",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1161,13 +1220,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1262,7 +1318,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1703,7 +1759,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1935,30 +1991,6 @@ checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
 dependencies = [
  "toml_datetime",
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -2558,33 +2590,9 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -2601,7 +2609,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2674,15 +2682,6 @@ dependencies = [
  "libc",
  "num_cpus",
  "term",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2823,10 +2822,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version-compare"

--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -18,7 +18,7 @@ ash = "0.37"
 ash-window = "0.12"
 raw-window-handle = "0.5.1"
 winit = { version = "0.29.0", features = ["rwh_05"] }
-structopt = "0.3.20"
+clap = { version = "4", features = ["derive"] }
 cfg-if = "1.0.0"
 shared = { path = "../../shaders/shared" }
 spirv-builder = { workspace = true, default-features = false }

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -93,22 +93,22 @@ use std::{
     thread,
 };
 
-use structopt::StructOpt;
+use clap::Parser;
 
 use spirv_builder::{MetadataPrintout, SpirvBuilder};
 
 use shared::ShaderConstants;
 
-#[derive(Debug, StructOpt)]
-#[structopt()]
+#[derive(Debug, Parser)]
+#[command()]
 pub struct Options {
     /// Use Vulkan debug layer (requires Vulkan SDK installed)
-    #[structopt(short, long)]
+    #[arg(short, long)]
     debug_layer: bool,
 }
 
 pub fn main() {
-    let options = Options::from_args();
+    let options = Options::parse();
     let shaders = compile_shaders();
 
     // runtime setup

--- a/examples/runners/wgpu/Cargo.toml
+++ b/examples/runners/wgpu/Cargo.toml
@@ -23,7 +23,7 @@ futures = { version = "0.3", default-features = false, features = ["std", "execu
 # Vulkan SDK or MoltenVK needs to be installed for `vulkan-portability` to work on macOS
 wgpu = { version = "0.18.0", features = ["spirv", "vulkan-portability"] }
 winit = { version = "0.29.0", features = ["android-native-activity", "rwh_05"] }
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 strum = { version = "0.23.0", default_features = false, features = ["std", "derive"] }
 bytemuck = "1.6.3"
 

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -70,8 +70,8 @@
 // crate-specific exceptions:
 // #![allow()]
 
+use clap::Parser;
 use std::borrow::Cow;
-use structopt::StructOpt;
 use strum::{Display, EnumString};
 
 // NOTE(eddyb) while this could theoretically work on the web, it needs more work.
@@ -211,13 +211,13 @@ fn maybe_watch(
     }
 }
 
-#[derive(StructOpt, Clone)]
-#[structopt(name = "example-runner-wgpu")]
+#[derive(Parser, Clone)]
+#[command()]
 pub struct Options {
-    #[structopt(short, long, default_value = "Sky")]
+    #[arg(short, long, default_value = "Sky")]
     shader: RustGPUShader,
 
-    #[structopt(long)]
+    #[arg(long)]
     force_spirv_passthru: bool,
 }
 
@@ -225,7 +225,7 @@ pub struct Options {
 pub fn main(
     #[cfg(target_os = "android")] android_app: winit::platform::android::activity::AndroidApp,
 ) {
-    let options: Options = Options::from_args();
+    let options = Options::parse();
 
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     if options.shader == RustGPUShader::Compute {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,4 +16,4 @@ use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
 [dependencies]
 compiletest = { version = "0.9.0", package = "compiletest_rs" }
 rustc_codegen_spirv.workspace = true
-structopt = "0.3.21"
+clap = { version = "4", features = ["derive"] }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -1,28 +1,23 @@
+use clap::Parser;
 use std::{
     env,
     io::{Error, ErrorKind, Result},
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
-#[structopt(
-    name = "cargo compiletest",
-    no_version,
-    // HACK(eddyb) avoid "USAGE:" saying "compiletests".
-    usage = "cargo compiletest [FLAGS] [FILTER]..."
-)]
+#[derive(Parser)]
+#[command(bin_name = "cargo compiletest")]
 struct Opt {
     /// Automatically update stderr/stdout files.
-    #[structopt(long)]
+    #[arg(long)]
     bless: bool,
 
     /// The environment to compile to the SPIR-V tests.
-    #[structopt(long, default_value = "spv1.3")]
+    #[arg(long, default_value = "spv1.3")]
     target_env: String,
 
     /// Only run tests that match these filters.
-    #[structopt(name = "FILTER")]
+    #[arg(name = "FILTER")]
     filters: Vec<String>,
 }
 
@@ -57,7 +52,7 @@ impl DepKind {
 }
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let tests_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workspace_root = tests_dir.parent().unwrap();


### PR DESCRIPTION
Clap has inlined the `structopt` functionality (under the `derive` feature).

Fixes the remaining security warning at https://github.com/EmbarkStudios/rust-gpu/security/dependabot