### PR TITLE
spirv-std: only enable `glam`&`num-traits`'s `libm` features on SPIR-V targets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ spirv-builder = { path = "./crates/spirv-builder", version = "=0.9.0", default-f
 rustc_codegen_spirv = { path = "./crates/rustc_codegen_spirv", version = "=0.9.0", default-features = false }
 rustc_codegen_spirv-types = { path = "./crates/rustc_codegen_spirv-types", version = "=0.9.0" }
 
+# External dependencies that need to be mentioned more than once.
+num-traits = { version = "0.2.15", default-features = false }
+glam = { version = ">=0.22, <=0.24", default-features = false }
+
 # Enable incremental by default in release mode.
 [profile.release]
 incremental = true

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -42,7 +42,7 @@ syn = { version = "1", features = ["extra-traits", "full"] }
 # in order to avoid multiple separate instances of `rustc_codegen_spirv`.
 hashbrown = "0.11"
 libc = { version = "0.2", features = ["align", "extra_traits"] }
-num-traits = { version = "0.2", features = ["libm"] }
+num-traits = { workspace = true, default-features = true }
 once_cell = "1"
 regex = { version = "1", features = ["perf"] }
 

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -11,8 +11,14 @@ repository.workspace = true
 spirv-std-types.workspace = true
 spirv-std-macros.workspace = true
 bitflags = "1.2.1"
-num-traits = { version = "0.2.15", default-features = false, features = ["libm"] }
-glam = { version = ">=0.22, <=0.24", default-features = false, features = ["libm"] }
+
+[target.'cfg(target_arch = "spirv")'.dependencies]
+num-traits = { workspace = true, features = ["libm"] }
+glam = { workspace = true, features = ["libm"] }
+
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+num-traits = { workspace = true, default-features = true }
+glam = { workspace = true, default-features = true }
 
 [features]
 default = []


### PR DESCRIPTION
- fixes #1121

Draft because I'm not sure if we should do some kind of automated testing for this, I can't think of an obvious way to know "slower floating-point algorithms are being used" (also there's https://github.com/EmbarkStudios/rust-gpu/pull/1115 which may conflict).

Testing-wise the best we can do is probably likely this:
```console
$ cargo tree -e features -p spirv-std | rg libm
├── glam feature "libm"
│       └── libm v0.2.8
├── num-traits feature "libm"
│       └── libm feature "default"
│           └── libm v0.2.8
```
(the above is *before* this PR, and there are no `libm` results *after* this PR)