### PR TITLE
feat: allow shader crate cargo features to be passed through spirv-builder

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -255,11 +255,19 @@ pub enum ShaderPanicStrategy {
     UNSOUND_DO_NOT_USE_UndefinedBehaviorViaUnreachable,
 }
 
+/// Cargo features specification for building the shader crate.
+#[derive(Default)]
+struct ShaderCrateFeatures {
+    default_features: Option<bool>,
+    features: Vec<String>,
+}
+
 pub struct SpirvBuilder {
     path_to_crate: PathBuf,
     print_metadata: MetadataPrintout,
     release: bool,
     target: String,
+    shader_crate_features: ShaderCrateFeatures,
     deny_warnings: bool,
     multimodule: bool,
     spirv_metadata: SpirvMetadata,
@@ -306,6 +314,7 @@ impl SpirvBuilder {
             skip_block_layout: false,
 
             preserve_bindings: false,
+            shader_crate_features: ShaderCrateFeatures::default(),
         }
     }
 
@@ -429,6 +438,20 @@ impl SpirvBuilder {
     #[must_use]
     pub fn extra_arg(mut self, arg: impl Into<String>) -> Self {
         self.extra_args.push(arg.into());
+        self
+    }
+
+    /// Set --default-features for the target shader crate.
+    #[must_use]
+    pub fn shader_crate_default_features(mut self, default_features: bool) -> Self {
+        self.shader_crate_features.default_features = Some(default_features);
+        self
+    }
+
+    /// Set --features for the target shader crate.
+    #[must_use]
+    pub fn shader_crate_features(mut self, features: impl IntoIterator<Item = String>) -> Self {
+        self.shader_crate_features.features = features.into_iter().collect();
         self
     }
 
@@ -689,6 +712,18 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         "--target",
         &*builder.target,
     ]);
+
+    if let Some(default_features) = builder.shader_crate_features.default_features {
+        if !default_features {
+            cargo.arg("--no-default-features");
+        }
+    }
+
+    if !builder.shader_crate_features.features.is_empty() {
+        cargo
+            .arg("--features")
+            .arg(builder.shader_crate_features.features.join(","));
+    }
 
     // NOTE(eddyb) see above how this is computed and why it might be missing.
     if let Some(target_dir) = target_dir {


### PR DESCRIPTION
* Adds fields for default-features and features to SpirvBuilder
* Pipes those fields through to the cargo command that builds the shader crate

