### PR TITLE
Fix bit rotates by using `== 0` instead of `!= 0` for `mask_is_zero`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed 🛠
-- [PR#1127](https://github.com/EmbarkStudios/rust-gpu/pull/1127) updated `spirv-tools` to `0.10.0`, which follows `vulkan-sdk-1.3.275`.
-- [PR#1101](https://github.com/EmbarkStudios/rust-gpu/pull/1101) Add `ignore` and `no_run` to documentation to make `cargo test` pass.
+- [PR#1127](https://github.com/EmbarkStudios/rust-gpu/pull/1127) updated `spirv-tools` to `0.10.0`, which follows `vulkan-sdk-1.3.275`
+- [PR#1101](https://github.com/EmbarkStudios/rust-gpu/pull/1101) added `ignore` and `no_run` to documentation to make `cargo test` pass
 - [PR#1112](https://github.com/EmbarkStudios/rust-gpu/pull/1112) updated wgpu and winit in example runners
 - [PR#1100](https://github.com/EmbarkStudios/rust-gpu/pull/1100) updated toolchain to `nightly-2023-09-30`
 - [PR#1091](https://github.com/EmbarkStudios/rust-gpu/pull/1091) updated toolchain to `nightly-2023-08-29`
 - [PR#1085](https://github.com/EmbarkStudios/rust-gpu/pull/1085) updated toolchain to `nightly-2023-07-08`
+
+### Fixed 🩹
+- [PR#1129](https://github.com/EmbarkStudios/rust-gpu/pull/1129) fixed [#1062](https://github.com/EmbarkStudios/rust-gpu/issues/1062) by not flipping the comparison of the rotate amount with zero
 
 ## [0.9.0]
 

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -242,7 +242,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // So we need to check for zero shift, and don't use the shift result if it is.
         let mask_is_zero = self
             .emit()
-            .i_not_equal(bool, None, mask_shift.def(self), zero.def(self))
+            .i_equal(bool, None, mask_shift.def(self), zero.def(self))
             .unwrap()
             .with_type(bool);
         self.select(mask_is_zero, value, or)

--- a/tests/ui/dis/issue-1062.rs
+++ b/tests/ui/dis/issue-1062.rs
@@ -1,0 +1,13 @@
+#![crate_name = "issue_1062"]
+
+// Test that rotates take the correct path for non-zero bit amounts.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-entry=main
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(#[spirv(flat)] x: u32, #[spirv(flat)] s: u32, out: &mut (u32, u32)) {
+    *out = (x.rotate_left(s), x.rotate_right(s));
+}

--- a/tests/ui/dis/issue-1062.stderr
+++ b/tests/ui/dis/issue-1062.stderr
@@ -10,14 +10,14 @@ OpLine %11 1142 4
 %16 = OpShiftLeftLogical  %7  %6 %12
 %17 = OpShiftRightLogical  %7  %6 %14
 %18 = OpBitwiseOr  %7  %16 %17
-%19 = OpINotEqual  %20  %12 %21
+%19 = OpIEqual  %20  %12 %21
 %22 = OpSelect  %7  %19 %6 %18
 %23 = OpBitwiseAnd  %7  %9 %13
 %24 = OpISub  %7  %15 %23
 %25 = OpShiftRightLogical  %7  %6 %23
 %26 = OpShiftLeftLogical  %7  %6 %24
 %27 = OpBitwiseOr  %7  %25 %26
-%28 = OpINotEqual  %20  %23 %21
+%28 = OpIEqual  %20  %23 %21
 %29 = OpSelect  %7  %28 %6 %27
 OpLine %5 12 4
 %30 = OpAccessChain  %31  %32 %21

--- a/tests/ui/dis/issue-1062.stderr
+++ b/tests/ui/dis/issue-1062.stderr
@@ -1,0 +1,29 @@
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 11 12
+%6 = OpLoad  %7  %8
+OpLine %5 11 35
+%9 = OpLoad  %7  %10
+OpLine %11 1142 4
+%12 = OpBitwiseAnd  %7  %9 %13
+%14 = OpISub  %7  %15 %12
+%16 = OpShiftLeftLogical  %7  %6 %12
+%17 = OpShiftRightLogical  %7  %6 %14
+%18 = OpBitwiseOr  %7  %16 %17
+%19 = OpINotEqual  %20  %12 %21
+%22 = OpSelect  %7  %19 %6 %18
+%23 = OpBitwiseAnd  %7  %9 %13
+%24 = OpISub  %7  %15 %23
+%25 = OpShiftRightLogical  %7  %6 %23
+%26 = OpShiftLeftLogical  %7  %6 %24
+%27 = OpBitwiseOr  %7  %25 %26
+%28 = OpINotEqual  %20  %23 %21
+%29 = OpSelect  %7  %28 %6 %27
+OpLine %5 12 4
+%30 = OpAccessChain  %31  %32 %21
+OpStore %30 %22
+%33 = OpAccessChain  %31  %32 %34
+OpStore %33 %29
+OpNoLine
+OpReturn
+OpFunctionEnd


### PR DESCRIPTION
- fixes #1062 

(no idea what happened here, the variable name alone should've made this easy to spot, but it took @chrisliebaer seeing the broken expression in SPIRV-Cross output, to narrow it down)