### PR TITLE
Update to Rust 1.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#1127](https://github.com/EmbarkStudios/rust-gpu/pull/1127) updated `spirv-tools` to `0.10.0`, which follows `vulkan-sdk-1.3.275`
 - [PR#1101](https://github.com/EmbarkStudios/rust-gpu/pull/1101) added `ignore` and `no_run` to documentation to make `cargo test` pass
 - [PR#1112](https://github.com/EmbarkStudios/rust-gpu/pull/1112) updated wgpu and winit in example runners
-- [PR#1102](https://github.com/EmbarkStudios/rust-gpu/pull/1102) updated toolchain to `nightly-2023-11-26`
+- [PR#1134](https://github.com/EmbarkStudios/rust-gpu/pull/1134) updated toolchain to `nightly-2023-12-21`
 - [PR#1100](https://github.com/EmbarkStudios/rust-gpu/pull/1100) updated toolchain to `nightly-2023-09-30`
 - [PR#1091](https://github.com/EmbarkStudios/rust-gpu/pull/1091) updated toolchain to `nightly-2023-08-29`
 - [PR#1085](https://github.com/EmbarkStudios/rust-gpu/pull/1085) updated toolchain to `nightly-2023-07-08`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#1127](https://github.com/EmbarkStudios/rust-gpu/pull/1127) updated `spirv-tools` to `0.10.0`, which follows `vulkan-sdk-1.3.275`
 - [PR#1101](https://github.com/EmbarkStudios/rust-gpu/pull/1101) added `ignore` and `no_run` to documentation to make `cargo test` pass
 - [PR#1112](https://github.com/EmbarkStudios/rust-gpu/pull/1112) updated wgpu and winit in example runners
+- [PR#1102](https://github.com/EmbarkStudios/rust-gpu/pull/1102) updated toolchain to `nightly-2023-11-26`
 - [PR#1100](https://github.com/EmbarkStudios/rust-gpu/pull/1100) updated toolchain to `nightly-2023-09-30`
 - [PR#1091](https://github.com/EmbarkStudios/rust-gpu/pull/1091) updated toolchain to `nightly-2023-08-29`
 - [PR#1085](https://github.com/EmbarkStudios/rust-gpu/pull/1085) updated toolchain to `nightly-2023-07-08`

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -10,9 +10,9 @@ use std::process::{Command, ExitCode};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain.toml");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2023-09-30"
+channel = "nightly-2023-11-26"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = 8ce4540bd6fe7d58d4bc05f1b137d61937d3cf72"#;
+# commit_hash = f5dc2653fdd8b5d177b2ccbd84057954340a89fc"#;
 
 fn get_rustc_commit_hash() -> Result<String, Box<dyn Error>> {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -10,9 +10,9 @@ use std::process::{Command, ExitCode};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain.toml");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2023-11-26"
+channel = "nightly-2023-12-21"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = f5dc2653fdd8b5d177b2ccbd84057954340a89fc"#;
+# commit_hash = 5ac4c8a63ee305742071ac6dd11817f7c24adce2"#;
 
 fn get_rustc_commit_hash() -> Result<String, Box<dyn Error>> {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -148,13 +148,13 @@ impl AggregatedSpirvAttributes {
     pub fn parse<'tcx>(cx: &CodegenCx<'tcx>, attrs: &'tcx [Attribute]) -> Self {
         let mut aggregated_attrs = Self::default();
 
-        // NOTE(eddyb) `delay_span_bug` ensures that if attribute checking fails
+        // NOTE(eddyb) `span_delayed_bug` ensures that if attribute checking fails
         // to see an attribute error, it will cause an ICE instead.
         for parse_attr_result in crate::symbols::parse_attrs_for_checking(&cx.sym, attrs) {
             let (span, parsed_attr) = match parse_attr_result {
                 Ok(span_and_parsed_attr) => span_and_parsed_attr,
                 Err((span, msg)) => {
-                    cx.tcx.sess.delay_span_bug(span, msg);
+                    cx.tcx.sess.span_delayed_bug(span, msg);
                     continue;
                 }
             };
@@ -166,7 +166,7 @@ impl AggregatedSpirvAttributes {
                 }) => {
                     cx.tcx
                         .sess
-                        .delay_span_bug(span, format!("multiple {category} attributes"));
+                        .span_delayed_bug(span, format!("multiple {category} attributes"));
                 }
             }
         }

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -3037,7 +3037,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         self.intcast(val, dest_ty, false)
     }
 
-    fn do_not_inline(&mut self, _llret: Self::Value) {
+    fn apply_attrs_to_cleanup_callsite(&mut self, _llret: Self::Value) {
         // Ignore
     }
 }

--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -12,8 +12,8 @@ use rustc_codegen_ssa::traits::{BuilderMethods, IntrinsicCallMethods};
 use rustc_middle::bug;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{FnDef, Instance, ParamEnv, Ty, TyKind};
-use rustc_span::source_map::Span;
 use rustc_span::sym;
+use rustc_span::Span;
 use rustc_target::abi::call::{FnAbi, PassMode};
 use std::assert_matches::assert_matches;
 

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -29,7 +29,7 @@ use rustc_middle::ty::layout::{
 };
 use rustc_middle::ty::{Instance, ParamEnv, Ty, TyCtxt};
 use rustc_span::def_id::DefId;
-use rustc_span::source_map::Span;
+use rustc_span::Span;
 use rustc_target::abi::call::{ArgAbi, FnAbi, PassMode};
 use rustc_target::abi::{HasDataLayout, Size, TargetDataLayout};
 use rustc_target::spec::{HasTargetSpec, Target};

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -767,7 +767,7 @@ impl<'tcx> BuilderSpirv<'tcx> {
                     FileName::Real(name) => {
                         name.to_string_lossy(FileNameDisplayPreference::Remapped)
                     }
-                    _ => sf.name.prefer_remapped().to_string().into(),
+                    _ => sf.name.prefer_remapped_unconditionaly().to_string().into(),
                 };
                 let file_name = {
                     // FIXME(eddyb) it should be possible to arena-allocate a

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -290,7 +290,8 @@ impl<'tcx> ConstMethods<'tcx> for CodegenCx<'tcx> {
                 }
             }
             Scalar::Ptr(ptr, _) => {
-                let (alloc_id, offset) = ptr.into_parts();
+                let (prov, offset) = ptr.into_parts();
+                let alloc_id = prov.alloc_id();
                 let (base_addr, _base_addr_space) = match self.tcx.global_alloc(alloc_id) {
                     GlobalAlloc::Memory(alloc) => {
                         let pointee = match self.lookup_type(ty) {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -9,7 +9,8 @@ use rustc_middle::ty::layout::{
 };
 use rustc_middle::ty::Ty;
 use rustc_middle::{bug, span_bug};
-use rustc_span::source_map::{Span, Spanned, DUMMY_SP};
+use rustc_span::source_map::Spanned;
+use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::call::{CastTarget, FnAbi, Reg};
 use rustc_target::abi::{Abi, AddressSpace, FieldsShape};
 

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -99,7 +99,7 @@ use rustc_codegen_ssa::traits::{
 };
 use rustc_codegen_ssa::{CodegenResults, CompiledModule, ModuleCodegen, ModuleKind};
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_errors::{ErrorGuaranteed, FatalError, Handler};
+use rustc_errors::{DiagCtxt, ErrorGuaranteed, FatalError};
 use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::mir::mono::{MonoItem, MonoItemData};
@@ -294,7 +294,7 @@ impl WriteBackendMethods for SpirvCodegenBackend {
 
     fn run_link(
         _cgcx: &CodegenContext<Self>,
-        _diag_handler: &Handler,
+        _diag_handler: &DiagCtxt,
         _modules: Vec<ModuleCodegen<Self::Module>>,
     ) -> Result<ModuleCodegen<Self::Module>, FatalError> {
         todo!()
@@ -326,7 +326,7 @@ impl WriteBackendMethods for SpirvCodegenBackend {
 
     unsafe fn optimize(
         _: &CodegenContext<Self>,
-        _: &Handler,
+        _: &DiagCtxt,
         _: &ModuleCodegen<Self::Module>,
         _: &ModuleConfig,
     ) -> Result<(), FatalError> {
@@ -357,7 +357,7 @@ impl WriteBackendMethods for SpirvCodegenBackend {
 
     unsafe fn codegen(
         cgcx: &CodegenContext<Self>,
-        _diag_handler: &Handler,
+        _diag_handler: &DiagCtxt,
         module: ModuleCodegen<Self::Module>,
         _config: &ModuleConfig,
     ) -> Result<CompiledModule, FatalError> {
@@ -500,7 +500,7 @@ pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
     rustc_driver::install_ice_hook(
         "https://github.com/EmbarkStudios/rust-gpu/issues/new",
         |handler| {
-            handler.note_without_error(concat!(
+            handler.note(concat!(
                 "`rust-gpu` version `",
                 env!("CARGO_PKG_VERSION"),
                 "`"

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -350,7 +350,7 @@ fn do_spirv_opt(
                 }
                 Level::Error => sess.struct_err(msg.message).forget_guarantee(),
                 Level::Warning => sess.struct_warn(msg.message),
-                Level::Info | Level::Debug => sess.struct_note_without_error(msg.message),
+                Level::Info | Level::Debug => sess.struct_note(msg.message),
             };
 
             err.note(format!("module `{}`", filename.display()));

--- a/crates/rustc_codegen_spirv/src/linker/dce.rs
+++ b/crates/rustc_codegen_spirv/src/linker/dce.rs
@@ -281,7 +281,7 @@ fn instruction_is_pure(inst: &Instruction) -> bool {
         | PtrEqual
         | PtrNotEqual
         | PtrDiff => true,
-        Variable => inst.operands.get(0) == Some(&Operand::StorageClass(StorageClass::Function)),
+        Variable => inst.operands.first() == Some(&Operand::StorageClass(StorageClass::Function)),
         _ => false,
     }
 }

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -534,7 +534,7 @@ pub fn link(
         }
 
         if any_spirt_bugs {
-            let mut note = sess.struct_note_without_error("SPIR-T bugs were reported");
+            let mut note = sess.struct_note("SPIR-T bugs were reported");
             note.help(format!(
                 "pretty-printed SPIR-T was saved to {}.html",
                 dump_spirt_file_path.as_ref().unwrap().display()

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -155,6 +155,7 @@ fn link_with_linker_opts(
                 rustc_interface::util::rustc_version_str().unwrap_or("unknown"),
                 Default::default(),
                 Default::default(),
+                Default::default(),
             );
 
             // HACK(eddyb) inject `write_diags` into `sess`, to work around

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -122,9 +122,9 @@ fn link_with_linker_opts(
     // is really a silent unwinding device, that should be treated the same as
     // `Err(ErrorGuaranteed)` returns from `link`).
     rustc_driver::catch_fatal_errors(|| {
-        let mut early_error_handler = rustc_session::EarlyErrorHandler::new(
-            rustc_session::config::ErrorOutputType::default(),
-        );
+        let mut early_error_handler =
+            rustc_session::EarlyDiagCtxt::new(rustc_session::config::ErrorOutputType::default());
+        early_error_handler.initialize_checked_jobserver();
         let matches = rustc_driver::handle_options(
             &early_error_handler,
             &["".to_string(), "x.rs".to_string()],
@@ -135,7 +135,7 @@ fn link_with_linker_opts(
 
         rustc_span::create_session_globals_then(sopts.edition, || {
             let mut sess = rustc_session::build_session(
-                &early_error_handler,
+                early_error_handler,
                 sopts,
                 CompilerIO {
                     input: Input::Str {
@@ -160,7 +160,7 @@ fn link_with_linker_opts(
 
             // HACK(eddyb) inject `write_diags` into `sess`, to work around
             // the removals in https://github.com/rust-lang/rust/pull/102992.
-            sess.parse_sess.span_diagnostic = {
+            sess.parse_sess.dcx = {
                 let fallback_bundle = {
                     extern crate rustc_error_messages;
                     rustc_error_messages::fallback_fluent_bundle(
@@ -172,8 +172,8 @@ fn link_with_linker_opts(
                     rustc_errors::emitter::EmitterWriter::new(Box::new(buf), fallback_bundle)
                         .sm(Some(sess.parse_sess.clone_source_map()));
 
-                rustc_errors::Handler::with_emitter(Box::new(emitter))
-                    .with_flags(sess.opts.unstable_opts.diagnostic_handler_flags(true))
+                rustc_errors::DiagCtxt::with_emitter(Box::new(emitter))
+                    .with_flags(sess.opts.unstable_opts.dcx_flags(true))
             };
 
             let res = link(

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -569,7 +569,7 @@ fn parse_local_size_attr(arg: &NestedMetaItem) -> Result<[u32; 3], ParseAttrErro
             }
             Ok(local_size)
         }
-        Some(tuple) if tuple.is_empty() => Err((
+        Some([]) => Err((
             arg.span,
             "#[spirv(compute(threads(x, y, z)))] must have the x dimension specified, trailing ones may be elided".to_string(),
         )),

--- a/crates/spirv-builder/README.md
+++ b/crates/spirv-builder/README.md
@@ -2,7 +2,7 @@
 <!-- markdownlint-disable-file MD033 -->
 # `spirv-builder`
 
-![Rust version](https://img.shields.io/badge/rust-nightly--2023--05--27-purple.svg)
+![Rust version](https://img.shields.io/badge/rust-nightly--2023--12--21-purple.svg)
 
 This crate gives you `SpirvBuilder`, a tool to build shaders using [rust-gpu][rustgpu].
 
@@ -31,12 +31,13 @@ const SHADER: &[u8] = include_bytes!(env!("my_shaders.spv"));
 
 As `spirv-builder` relies on `rustc_codegen_spirv` being built for it (by Cargo, as a direct dependency), and due to the special nature of the latter (as a `rustc` codegen backend "plugin"), both end up sharing the requirement for a very specific nightly toolchain version of Rust.
 
-**The current Rust toolchain version is: `nightly-2023-05-27`.**
+**The current Rust toolchain version is: `nightly-2023-12-21`.**
 
 Rust toolchain version history across [rust-gpu releases](https://github.com/EmbarkStudios/rust-gpu/releases) (since `0.4`):
 
 |`spirv-builder`<br>version|Rust toolchain<br>version|
 |:-:|:-:|
+|`0.10`|`nightly-2023-12-21`|
 |`0.9`|`nightly-2023-05-27`|
 |`0.8`|`nightly-2023-04-15`|
 |`0.7`|`nightly-2023-03-04`|

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2023-09-30"
+channel = "nightly-2023-11-26"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = 8ce4540bd6fe7d58d4bc05f1b137d61937d3cf72
+# commit_hash = f5dc2653fdd8b5d177b2ccbd84057954340a89fc
 
 # Whenever changing the nightly channel, update the commit hash above, and make
 # sure to change `REQUIRED_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` also.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2023-11-26"
+channel = "nightly-2023-12-21"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = f5dc2653fdd8b5d177b2ccbd84057954340a89fc
+# commit_hash = 5ac4c8a63ee305742071ac6dd11817f7c24adce2
 
 # Whenever changing the nightly channel, update the commit hash above, and make
 # sure to change `REQUIRED_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` also.

--- a/tests/ui/dis/issue-1062.stderr
+++ b/tests/ui/dis/issue-1062.stderr
@@ -4,7 +4,7 @@ OpLine %5 11 12
 %6 = OpLoad  %7  %8
 OpLine %5 11 35
 %9 = OpLoad  %7  %10
-OpLine %11 1142 4
+OpLine %11 1145 4
 %12 = OpBitwiseAnd  %7  %9 %13
 %14 = OpISub  %7  %15 %12
 %16 = OpShiftLeftLogical  %7  %6 %12

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,13 +1,13 @@
 error: cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2778:9
+    --> $CORE_SRC/intrinsics.rs:2776:9
      |
-2778 |         copy(src, dst, count)
+2776 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
      |
 note: used from within `core::intrinsics::copy::<f32>`
-    --> $CORE_SRC/intrinsics.rs:2764:21
+    --> $CORE_SRC/intrinsics.rs:2762:21
      |
-2764 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+2762 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
      |                     ^^^^
 note: called by `ptr_copy::copy_via_raw_ptr`
     --> $DIR/ptr_copy.rs:28:18
@@ -25,5 +25,5 @@ note: called by `main`
 32   | pub fn main(i: f32, o: &mut f32) {
      |        ^^^^
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 

--- a/tests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/ui/dis/ptr_copy.normal.stderr
@@ -1,13 +1,13 @@
 error: cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics.rs:2776:9
+    --> $CORE_SRC/intrinsics.rs:2794:9
      |
-2776 |         copy(src, dst, count)
+2794 |         copy(src, dst, count)
      |         ^^^^^^^^^^^^^^^^^^^^^
      |
 note: used from within `core::intrinsics::copy::<f32>`
-    --> $CORE_SRC/intrinsics.rs:2762:21
+    --> $CORE_SRC/intrinsics.rs:2780:21
      |
-2762 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+2780 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
      |                     ^^^^
 note: called by `ptr_copy::copy_via_raw_ptr`
     --> $DIR/ptr_copy.rs:28:18

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1183 8
+OpLine %8 1200 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read.stderr
+++ b/tests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1200 8
+OpLine %8 1215 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1183 8
+OpLine %8 1200 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_read_method.stderr
+++ b/tests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1200 8
+OpLine %8 1215 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1382 8
+OpLine %11 1400 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/dis/ptr_write.stderr
+++ b/tests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1400 8
+OpLine %11 1415 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1382 8
+OpLine %11 1400 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/dis/ptr_write_method.stderr
+++ b/tests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1400 8
+OpLine %11 1415 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -18,6 +18,6 @@ note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAM
 881 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -18,6 +18,6 @@ note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAM
 907 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -23,6 +23,6 @@ note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAM
 938 |         Self: HasQuerySize,
     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -18,6 +18,6 @@ note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_st
 982 |         Self: HasQuerySizeLod,
     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/lang/control_flow/issue_764.stderr
+++ b/tests/ui/lang/control_flow/issue_764.stderr
@@ -1,4 +1,4 @@
 error: module has recursion, which is not allowed: `<(i32, issue_764::Transform2D) as issue_764::GivesFinalTransform>::get_final_transform` calls `<(i32, issue_764::Transform2D) as issue_764::GivesFinalTransform>::get_final_transform`
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -1,3 +1,12 @@
+warning: the feature `ptr_internals` is internal to the compiler or standard library
+ --> $DIR/allocate_const_scalar.rs:6:12
+  |
+6 | #![feature(ptr_internals)]
+  |            ^^^^^^^^^^^^^
+  |
+  = note: using it is strongly discouraged
+  = note: `#[warn(internal_features)]` on by default
+
 error: pointer has non-null integer address
    |
 note: used from within `allocate_const_scalar::main`
@@ -11,5 +20,5 @@ note: called by `main`
 15 | pub fn main(output: &mut Unique<[u8; 4]>) {
    |        ^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
+++ b/tests/ui/lang/core/ptr/allocate_const_scalar.stderr
@@ -11,5 +11,5 @@ note: called by `main`
 15 | pub fn main(output: &mut Unique<[u8; 4]>) {
    |        ^^^^
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 

--- a/tests/ui/lang/core/ptr/allocate_vec_like.stderr
+++ b/tests/ui/lang/core/ptr/allocate_vec_like.stderr
@@ -1,0 +1,11 @@
+warning: the feature `ptr_internals` is internal to the compiler or standard library
+ --> $DIR/allocate_vec_like.rs:4:12
+  |
+4 | #![feature(ptr_internals)]
+  |            ^^^^^^^^^^^^^
+  |
+  = note: using it is strongly discouraged
+  = note: `#[warn(internal_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/lang/core/ref/member_ref_arg-broken.stderr
+++ b/tests/ui/lang/core/ref/member_ref_arg-broken.stderr
@@ -8,5 +8,5 @@ error: error:0:0 - OpLoad Pointer <id> '$ID[%$ID]' is not a logical pointer.
   = note: spirv-val failed
   = note: module `$TEST_BUILD_DIR/lang/core/ref/member_ref_arg-broken.default`
 
-error: aborting due to previous error; 2 warnings emitted
+error: aborting due to 1 previous error; 2 warnings emitted
 

--- a/tests/ui/lang/core/unwrap_or.stderr
+++ b/tests/ui/lang/core/unwrap_or.stderr
@@ -3,9 +3,9 @@
 OpLine %5 13 11
 %6 = OpCompositeInsert  %7  %8 %9 0
 %10 = OpCompositeExtract  %11  %6 1
-OpLine %12 956 14
+OpLine %12 952 14
 %13 = OpBitcast  %14  %8
-OpLine %12 956 8
+OpLine %12 952 8
 %15 = OpIEqual  %16  %13 %17
 OpNoLine
 OpSelectionMerge %18 None

--- a/tests/ui/spirv-attr/invalid-matrix-type-empty.stderr
+++ b/tests/ui/spirv-attr/invalid-matrix-type-empty.stderr
@@ -4,5 +4,5 @@ error: #[spirv(matrix)] type must have at least two fields
 7 | pub struct EmptyStruct {}
   | ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 

--- a/tests/ui/spirv-attr/invalid-target.rs
+++ b/tests/ui/spirv-attr/invalid-target.rs
@@ -288,7 +288,8 @@ fn _fn(
             vertex, // fn-only
             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
         )]
-        (1, 2, 3) // expression
+        (1, 2, 3)
+        // expression
     );
 
     match () {

--- a/tests/ui/spirv-attr/invalid-target.stderr
+++ b/tests/ui/spirv-attr/invalid-target.stderr
@@ -1583,267 +1583,267 @@ error: attribute is only valid on a function parameter, not on a expression
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:296:13
+   --> $DIR/invalid-target.rs:297:13
     |
-296 |             sampler, block, sampled_image, generic_image_type, // struct-only
+297 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |             ^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:296:22
+   --> $DIR/invalid-target.rs:297:22
     |
-296 |             sampler, block, sampled_image, generic_image_type, // struct-only
+297 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                      ^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:296:29
+   --> $DIR/invalid-target.rs:297:29
     |
-296 |             sampler, block, sampled_image, generic_image_type, // struct-only
+297 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                             ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a match arm
-   --> $DIR/invalid-target.rs:296:44
+   --> $DIR/invalid-target.rs:297:44
     |
-296 |             sampler, block, sampled_image, generic_image_type, // struct-only
+297 |             sampler, block, sampled_image, generic_image_type, // struct-only
     |                                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a match arm
-   --> $DIR/invalid-target.rs:297:13
+   --> $DIR/invalid-target.rs:298:13
     |
-297 |             vertex, // fn-only
+298 |             vertex, // fn-only
     |             ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:298:13
+   --> $DIR/invalid-target.rs:299:13
     |
-298 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+299 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |             ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:298:22
+   --> $DIR/invalid-target.rs:299:22
     |
-298 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+299 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                      ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:298:32
+   --> $DIR/invalid-target.rs:299:32
     |
-298 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+299 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:298:52
+   --> $DIR/invalid-target.rs:299:52
     |
-298 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+299 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                    ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:298:65
+   --> $DIR/invalid-target.rs:299:65
     |
-298 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+299 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                 ^^^^
 
 error: attribute is only valid on a function parameter, not on a match arm
-   --> $DIR/invalid-target.rs:298:71
+   --> $DIR/invalid-target.rs:299:71
     |
-298 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+299 |             uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                       ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:306:9
+   --> $DIR/invalid-target.rs:307:9
     |
-306 |         sampler, block, sampled_image, generic_image_type, // struct-only
+307 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:306:18
+   --> $DIR/invalid-target.rs:307:18
     |
-306 |         sampler, block, sampled_image, generic_image_type, // struct-only
+307 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:306:25
+   --> $DIR/invalid-target.rs:307:25
     |
-306 |         sampler, block, sampled_image, generic_image_type, // struct-only
+307 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:306:40
+   --> $DIR/invalid-target.rs:307:40
     |
-306 |         sampler, block, sampled_image, generic_image_type, // struct-only
+307 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:307:9
+   --> $DIR/invalid-target.rs:308:9
     |
-307 |         vertex, // fn-only
+308 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:308:9
+   --> $DIR/invalid-target.rs:309:9
     |
-308 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+309 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:308:18
+   --> $DIR/invalid-target.rs:309:18
     |
-308 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+309 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:308:28
+   --> $DIR/invalid-target.rs:309:28
     |
-308 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+309 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:308:48
+   --> $DIR/invalid-target.rs:309:48
     |
-308 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+309 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:308:61
+   --> $DIR/invalid-target.rs:309:61
     |
-308 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+309 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a lifetime parameter
-   --> $DIR/invalid-target.rs:308:67
+   --> $DIR/invalid-target.rs:309:67
     |
-308 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+309 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:311:9
+   --> $DIR/invalid-target.rs:312:9
     |
-311 |         sampler, block, sampled_image, generic_image_type, // struct-only
+312 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:311:18
+   --> $DIR/invalid-target.rs:312:18
     |
-311 |         sampler, block, sampled_image, generic_image_type, // struct-only
+312 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:311:25
+   --> $DIR/invalid-target.rs:312:25
     |
-311 |         sampler, block, sampled_image, generic_image_type, // struct-only
+312 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a type parameter
-   --> $DIR/invalid-target.rs:311:40
+   --> $DIR/invalid-target.rs:312:40
     |
-311 |         sampler, block, sampled_image, generic_image_type, // struct-only
+312 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a type parameter
-   --> $DIR/invalid-target.rs:312:9
+   --> $DIR/invalid-target.rs:313:9
     |
-312 |         vertex, // fn-only
+313 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:313:9
+   --> $DIR/invalid-target.rs:314:9
     |
-313 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:313:18
+   --> $DIR/invalid-target.rs:314:18
     |
-313 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:313:28
+   --> $DIR/invalid-target.rs:314:28
     |
-313 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:313:48
+   --> $DIR/invalid-target.rs:314:48
     |
-313 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:313:61
+   --> $DIR/invalid-target.rs:314:61
     |
-313 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a type parameter
-   --> $DIR/invalid-target.rs:313:67
+   --> $DIR/invalid-target.rs:314:67
     |
-313 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+314 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:316:9
+   --> $DIR/invalid-target.rs:317:9
     |
-316 |         sampler, block, sampled_image, generic_image_type, // struct-only
+317 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |         ^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:316:18
+   --> $DIR/invalid-target.rs:317:18
     |
-316 |         sampler, block, sampled_image, generic_image_type, // struct-only
+317 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                  ^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:316:25
+   --> $DIR/invalid-target.rs:317:25
     |
-316 |         sampler, block, sampled_image, generic_image_type, // struct-only
+317 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                         ^^^^^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a const parameter
-   --> $DIR/invalid-target.rs:316:40
+   --> $DIR/invalid-target.rs:317:40
     |
-316 |         sampler, block, sampled_image, generic_image_type, // struct-only
+317 |         sampler, block, sampled_image, generic_image_type, // struct-only
     |                                        ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function, not on a const parameter
-   --> $DIR/invalid-target.rs:317:9
+   --> $DIR/invalid-target.rs:318:9
     |
-317 |         vertex, // fn-only
+318 |         vertex, // fn-only
     |         ^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:318:9
+   --> $DIR/invalid-target.rs:319:9
     |
-318 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+319 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |         ^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:318:18
+   --> $DIR/invalid-target.rs:319:18
     |
-318 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+319 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                  ^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:318:28
+   --> $DIR/invalid-target.rs:319:28
     |
-318 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+319 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                            ^^^^^^^^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:318:48
+   --> $DIR/invalid-target.rs:319:48
     |
-318 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+319 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                ^^^^^^^^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:318:61
+   --> $DIR/invalid-target.rs:319:61
     |
-318 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+319 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                             ^^^^
 
 error: attribute is only valid on a function parameter, not on a const parameter
-   --> $DIR/invalid-target.rs:318:67
+   --> $DIR/invalid-target.rs:319:67
     |
-318 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
+319 |         uniform, position, descriptor_set = 0, binding = 0, flat, invariant, // param-only
     |                                                                   ^^^^^^^^^
 
 error: attribute is only valid on a struct, not on a associated type

--- a/tests/ui/spirv-attr/invariant-invalid.stderr
+++ b/tests/ui/spirv-attr/invariant-invalid.stderr
@@ -4,5 +4,5 @@ error: `#[spirv(invariant)]` is only valid on Output variables
 7 | pub fn main(#[spirv(invariant)] input: f32) {}
   |                     ^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 

--- a/tests/ui/storage_class/runtime_descriptor_array_error.stderr
+++ b/tests/ui/storage_class/runtime_descriptor_array_error.stderr
@@ -10,5 +10,5 @@ warning: use &[T] instead of &RuntimeArray<T>
 8 |     #[spirv(uniform, descriptor_set = 0, binding = 0)] two: &RuntimeArray<u32>,
   |                                                             ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/target_features_err.stderr
+++ b/tests/ui/target_features_err.stderr
@@ -1,4 +1,4 @@
 error: Invalid Capability: `rayTracingKHR`
 
-error: aborting due to previous error
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
This updates to the last nightly tagged as rust 1.76, which was released to stable.

This is a version of https://github.com/EmbarkStudios/rust-gpu/pull/1109 that stops on the last nightly of the current stable release rather than trying to track the most recent nightly.